### PR TITLE
Accept bare edge lists in graph functions; fix @@ over Rule/Association

### DIFF
--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -540,6 +540,100 @@ fn evaluate_function_call_ast_inner(
     other => other,
   };
 
+  // Every graph query/analysis function below documents its first argument
+  // as "a graph or a list of edges" (VertexList, EdgeList, the centrality
+  // measures, connectivity predicates, …) — Wolfram accepts a bare edge
+  // list anywhere a `Graph[...]` object is expected. Rather than teaching
+  // each of these functions to parse a bare edge list itself, normalize it
+  // once here through the same `Graph[edges] -> Graph[vertices, edges]`
+  // canonicalization `Graph` itself already performs.
+  const GRAPH_ARG_FUNCTIONS: &[&str] = &[
+    "AcyclicGraphQ",
+    "AdjacencyMatrix",
+    "BetweennessCentrality",
+    "ChromaticPolynomial",
+    "ClosenessCentrality",
+    "ConnectedComponents",
+    "ConnectedGraphComponents",
+    "ConnectedGraphQ",
+    "DegreeCentrality",
+    "DirectedGraphQ",
+    "EdgeAdd",
+    "EdgeBetweennessCentrality",
+    "EdgeContract",
+    "EdgeCount",
+    "EdgeDelete",
+    "EdgeList",
+    "EdgeQ",
+    "EdgeRules",
+    "EdgeTags",
+    "EigenvectorCentrality",
+    "EulerianGraphQ",
+    "FindMaximumFlow",
+    "FindSpanningTree",
+    "GraphComplement",
+    "GraphDisjointUnion",
+    "GraphDistance",
+    "GraphDistanceMatrix",
+    "GraphEmbedding",
+    "GraphPower",
+    "GraphReciprocity",
+    "IncidenceMatrix",
+    "IndexGraph",
+    "KatzCentrality",
+    "KirchhoffMatrix",
+    "LocalClusteringCoefficient",
+    "MixedGraphQ",
+    "MultigraphQ",
+    "PageRankCentrality",
+    "RadialityCentrality",
+    "TreeGraphQ",
+    "TuttePolynomial",
+    "UndirectedGraphQ",
+    "VertexAdd",
+    "VertexContract",
+    "VertexCount",
+    "VertexDegree",
+    "VertexDelete",
+    "VertexInDegree",
+    "VertexIndex",
+    "VertexList",
+    "VertexOutDegree",
+    "VertexQ",
+    "WeaklyConnectedComponents",
+    "WeaklyConnectedGraphQ",
+    "WeightedAdjacencyMatrix",
+    "WeightedGraphQ",
+  ];
+  if GRAPH_ARG_FUNCTIONS.contains(&name)
+    && let Some(Expr::List(items)) = args.first()
+    && !items.is_empty()
+    && let Ok(canonical) =
+      evaluate_function_call_ast("Graph", std::slice::from_ref(&args[0]))
+    && let Expr::FunctionCall {
+      name: gname,
+      args: gargs,
+    } = &canonical
+    && gname == "Graph"
+    && gargs.len() >= 2
+  {
+    let mut new_args = args.to_vec();
+    new_args[0] = canonical;
+    let result = evaluate_function_call_ast(name, &new_args)?;
+    // A result still headed by the same function name means it fell
+    // through to its own "can't handle this" case rather than computing an
+    // answer (e.g. `VertexInDegree[g, v]` for a `v` not in `g`). Echo back
+    // the caller's original bare edge list there instead of leaking this
+    // normalization's internal `Graph[...]` into the held result — Wolfram
+    // never surfaces it either.
+    if let Expr::FunctionCall { name: rname, .. } = &result
+      && rname == name
+    {
+      return Ok(unevaluated(name, args));
+    }
+    return Ok(result);
+  }
+
   // Thread Listable functions over list arguments
   let is_listable =
     is_builtin_listable(name) || crate::func_attrs_contains(name, "Listable");

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -381,47 +381,18 @@ pub fn apply_apply_ast(
   func: &Expr,
   list: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  let items = match list {
-    Expr::List(items) => items.clone(),
-    // Apply replaces the head of any expression: f @@ Plus[a, b, c] → f[a, b, c]
-    Expr::FunctionCall { args, .. } => args.clone(),
-    // Some heads stay as (possibly nested) BinaryOp nodes rather than
-    // FunctionCall nodes — notably Alternatives (`a | b | c`). Flatten
-    // same-operator chains so `List @@ (a | b | c)` → {a, b, c}, matching WS.
-    Expr::BinaryOp { op, left, right } => {
-      fn flatten(op: BinaryOperator, e: &Expr, out: &mut Vec<Expr>) {
-        if let Expr::BinaryOp {
-          op: inner,
-          left,
-          right,
-        } = e
-          && *inner == op
-          && !matches!(op, BinaryOperator::Power)
-        {
-          flatten(op, left, out);
-          flatten(op, right, out);
-          return;
-        }
-        out.push(e.clone());
-      }
-      let mut parts = Vec::new();
-      flatten(*op, left, &mut parts);
-      flatten(*op, right, &mut parts);
-      parts.into()
-    }
-    // Comparison chains: `a == b == c` is Equal[a, b, c]; `a < b <= c` is
-    // Inequality[a, Less, b, LessEqual, c]. Matches wolframscript.
-    Expr::Comparison {
-      operands,
-      operators,
-    } => {
-      let (_, args) =
-        crate::syntax::comparison_head_and_args(operands, operators);
-      args.into()
-    }
-    _ => {
+  // Delegate the "what are this expression's parts" question to the same
+  // helper the bracket form `Apply[f, list]` uses (`apply_ast` below), so a
+  // head this operator doesn't special-case itself — notably `Rule`/
+  // `RuleDelayed` (`f @@ (a -> b)` -> `f[a, b]`) and `Association` — still
+  // gets the same parts both forms agree are its children.
+  let items: crate::ExprList = if let Expr::Association(pairs) = list {
+    pairs.iter().map(|(_, v)| v.clone()).collect()
+  } else {
+    match crate::functions::list_helpers_ast::expr_children(list) {
+      Some(items) => items.into(),
       // Atoms have no children; Apply on an atom returns the atom unchanged
-      return Ok(list.clone());
+      None => return Ok(list.clone()),
     }
   };
 

--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -875,7 +875,7 @@ fn nest_while_history(
 
 /// Extract the children of any expression in Wolfram canonical form.
 /// Returns None for atomic expressions (Integer, Real, String, Symbol).
-fn expr_children(expr: &Expr) -> Option<Vec<Expr>> {
+pub(crate) fn expr_children(expr: &Expr) -> Option<Vec<Expr>> {
   // Rational and Complex are atoms: Apply on them returns them unchanged.
   if crate::functions::predicate_ast::is_atomic_number(expr) {
     return None;

--- a/tests/interpreter_tests/function_application.rs
+++ b/tests/interpreter_tests/function_application.rs
@@ -343,6 +343,36 @@ mod function_head {
   }
 
   #[test]
+  fn infix_apply_over_rule_matches_bracket_form() {
+    // `f @@ list` (Expr::Apply) and `Apply[f, list]` (a plain function call)
+    // are two different code paths that must agree on every head. A `Rule`/
+    // `RuleDelayed` is its own Expr variant rather than a FunctionCall, so
+    // the infix form was missing this case entirely and returned the Rule
+    // unchanged instead of applying to its two parts.
+    assert_eq!(interpret("List @@ (1 -> 2)").unwrap(), "{1, 2}");
+    assert_eq!(interpret("Apply[List, 1 -> 2]").unwrap(), "{1, 2}");
+    assert_eq!(interpret("List @@ (1 :> 2)").unwrap(), "{1, 2}");
+    assert_eq!(
+      interpret("List @@@ {1 -> 2, 2 -> 3}").unwrap(),
+      "{{1, 2}, {2, 3}}"
+    );
+  }
+
+  #[test]
+  fn infix_apply_over_association_matches_bracket_form() {
+    // Same underlying bug as the Rule case above: Association is its own
+    // Expr variant, and Apply on it maps over the values (not the rules).
+    assert_eq!(
+      interpret("List @@ <|\"a\" -> 1, \"b\" -> 2|>").unwrap(),
+      "{1, 2}"
+    );
+    assert_eq!(
+      interpret("Apply[List, <|\"a\" -> 1, \"b\" -> 2|>]").unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  #[test]
   fn apply_negative_levelspec() {
     // Negative level -k selects subexpressions of Depth k (here -3 means
     // Depth 3 subexpressions). For {{{{{a}}}}} (Depth 6), {2, -3} = {2, 3}.

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -7094,3 +7094,76 @@ mod graph_annotations {
     );
   }
 }
+
+// Wolfram's own documentation states that every graph query/analysis
+// function below accepts either a `Graph[...]` object or a bare list of
+// edges for its first argument ("g can be a graph or a list of edges").
+// Woxi already normalized `Graph[{a -> b, ...}]` (a single-argument Graph
+// constructor) into the canonical `Graph[vertices, edges]` form; these
+// functions just weren't reusing that normalization when the `Graph[...]`
+// wrapper was missing entirely, so a bare edge list fell through to
+// "unevaluated" instead.
+mod bare_edge_list_argument {
+  use super::*;
+
+  #[test]
+  fn vertex_and_edge_list_accept_bare_edges() {
+    assert_eq!(
+      interpret("VertexList[{1 -> 2, 2 -> 3, 3 -> 1}]").unwrap(),
+      "{1, 2, 3}"
+    );
+    assert_eq!(
+      interpret("VertexCount[{1 -> 2, 2 -> 3, 3 -> 1}]").unwrap(),
+      "3"
+    );
+    assert_eq!(
+      interpret("EdgeCount[{1 -> 2, 2 -> 3, 3 -> 1}]").unwrap(),
+      "3"
+    );
+  }
+
+  #[test]
+  fn centrality_measures_accept_bare_edges() {
+    // Matches the Graph[...]-wrapped result exactly (this is a shorthand
+    // for the same graph, not a different computation).
+    let wrapped =
+      interpret("ClosenessCentrality[Graph[{1 -> 2, 2 -> 3, 3 -> 1}]]")
+        .unwrap();
+    let bare =
+      interpret("ClosenessCentrality[{1 -> 2, 2 -> 3, 3 -> 1}]").unwrap();
+    assert_eq!(bare, wrapped);
+    assert_eq!(
+      interpret("Round[ClosenessCentrality[{1 -> 2, 2 -> 3, 3 -> 1}], 10^-6]")
+        .unwrap(),
+      "{666667/1000000, 666667/1000000, 666667/1000000}"
+    );
+
+    assert_eq!(
+      interpret("Round[PageRankCentrality[{1 -> 2, 2 -> 3, 3 -> 1}], 10^-6]")
+        .unwrap(),
+      "{333333/1000000, 333333/1000000, 333333/1000000}"
+    );
+    assert_eq!(
+      interpret("DegreeCentrality[{1 -> 2, 2 -> 3, 3 -> 1}]").unwrap(),
+      "{2, 2, 2}"
+    );
+  }
+
+  #[test]
+  fn undirected_bare_edges_also_normalize() {
+    assert_eq!(
+      interpret("VertexList[{1 <-> 2, 2 <-> 3}]").unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+
+  #[test]
+  fn non_edge_bare_list_still_falls_through_unevaluated() {
+    // {1, 2, 3} isn't a list of edges, so it must not be silently coerced
+    // into a graph on 3 vertices with no edges.
+    assert_eq!(
+      interpret("VertexCount[{1, 2, 3}]").unwrap(),
+      "VertexCount[{1, 2, 3}]"
+    );
+  }
+}

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -20924,4 +20924,118 @@ SaveDefinitions -> True]";
       "the steps bound must shrink with block size 3 and clamp the value down from 4"
     );
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook
+  /// visualizing node-prominence measures on a network: a `GraphPlot` whose
+  /// `VertexRenderingFunction` sizes each point by a chosen centrality
+  /// measure, with a `SetterBar` picking which of several small hardcoded
+  /// networks to show and a checkbox unioning in the reversed edges to make
+  /// it bidirectional. Independently written, not copied from any specific
+  /// Demonstration: this version uses two small 4/5-vertex networks of its
+  /// own, computes degree by hand with `Count`/`Flatten` rather than the
+  /// original's particular helper functions, and picks among Woxi's built-in
+  /// `PageRankCentrality`/`ClosenessCentrality` rather than the legacy
+  /// `GraphUtilities` package the original notebook loads.
+  ///
+  /// The construct worth pinning down is a bare edge list (`{1 -> 2, ...}`,
+  /// not wrapped in `Graph[...]`) threaded through `VertexList`,
+  /// `PageRankCentrality`, `ClosenessCentrality`, and `GraphPlot` all at
+  /// once, plus a `SetterBar` (`network number`) and a boolean checkbox
+  /// (`bidirectional`) both feeding which edge list is even built, ahead of
+  /// a `PopupMenu` (`centrality measure`) selecting which rescaled measure
+  /// sizes the vertices.
+  #[test]
+  fn demonstration_node_prominence_manipulate_renders_and_switches_network() {
+    let code = "Manipulate[\
+      Module[{edges, g, vlist, deg, pr, cc}, \
+        edges = If[net == 1, \
+          {1 -> 2, 2 -> 3, 3 -> 1, 3 -> 4}, \
+          {1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4, 4 -> 1}]; \
+        g = If[bidir, Union[edges, Reverse /@ edges], edges]; \
+        vlist = VertexList[g]; \
+        deg = Rescale[N[Table[Count[Flatten[List @@@ g], v], {v, vlist}]]]; \
+        pr = Rescale[PageRankCentrality[g]]; \
+        cc = Rescale[ClosenessCentrality[g]]; \
+        GraphPlot[g, \
+          DirectedEdges -> Not[bidir], \
+          VertexRenderingFunction -> ({PointSize[scale (#2 /. Thread[vlist -> Which[\
+              measure == \"Degree\", deg, \
+              measure == \"PageRank\", pr, \
+              True, cc]])], Point[#1]} &)]\
+      ], \
+      {{scale, 0.05, \"vertex scale\"}, 0, 0.2, 0.01}, \
+      {{measure, \"PageRank\", \"centrality measure\"}, {\"Degree\", \"PageRank\", \"Closeness\"}}, \
+      {{net, 1, \"network number\"}, {1, 2}, ControlType -> SetterBar}, \
+      {{bidir, False, \"bidirectional\"}, {True, False}}\
+    ]";
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "a slider, a PopupMenu, a SetterBar and a checkbox should build a ManipulateState",
+    );
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the GraphPlot must render");
+
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, ["scale", "measure", "net", "bidir"]);
+
+    match &state.controls[1] {
+      manipulate::ControlState::Discrete {
+        values,
+        current_index,
+        popup,
+        ..
+      } => {
+        assert_eq!(values, &["\"Degree\"", "\"PageRank\"", "\"Closeness\""]);
+        assert_eq!(*current_index, 1, "measure should start at PageRank");
+        assert!(!*popup, "ControlType -> PopupMenu was never requested");
+      }
+      other => panic!("measure should be a discrete control: {other:?}"),
+    }
+
+    match &state.controls[2] {
+      manipulate::ControlState::Discrete {
+        values,
+        current_index,
+        setter_bar,
+        ..
+      } => {
+        assert_eq!(values, &["1", "2"]);
+        assert_eq!(*current_index, 0, "network number should start at 1");
+        assert!(*setter_bar, "ControlType -> SetterBar was requested");
+      }
+      other => panic!("net should be a discrete SetterBar: {other:?}"),
+    }
+
+    // Switch to the second network, make it bidirectional, and pick a
+    // different centrality measure, then re-render: none of that should
+    // error, and a bare edge list must still flow cleanly through
+    // VertexList/PageRankCentrality/ClosenessCentrality/GraphPlot for the
+    // new 5-vertex network.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[1]
+    {
+      *current_index = 0; // "Degree"
+    }
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[2]
+    {
+      *current_index = 1; // network 2
+    }
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[3]
+    {
+      *current_index = 0; // bidir -> True
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(
+      state.graphics_handle.is_some(),
+      "the GraphPlot must still render after switching network/measure/bidirectional"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Sampled a random Wolfram Demonstrations Project notebook ("Measures of Node Prominence on a Network" — a `GraphPlot` with a `VertexRenderingFunction` sizing vertices by a chosen centrality measure). Checking whether Woxi Studio could support it surfaced two real interpreter bugs:

- **~50 graph functions required an explicit `Graph[...]` wrapper.** `VertexList`, `EdgeList`, the centrality measures (`ClosenessCentrality`, `PageRankCentrality`, `DegreeCentrality`, ...), and most other graph query/analysis functions returned unevaluated when given a bare edge list (e.g. `VertexList[{1 -> 2, 2 -> 3}]`), even though Wolfram documents all of them as accepting "a graph or a list of edges" directly. Fixed by normalizing a bare edge list through the same `Graph[edges] -> Graph[vertices, edges]` canonicalization `Graph[...]` itself already performs — done once, centrally, rather than teaching each function to parse edges itself. A result still headed by the same function name (i.e. the function couldn't resolve it) echoes back the caller's original argument instead of leaking the internal `Graph[...]` into the held form.

- **`f @@ list` (infix `Apply`) disagreed with `Apply[f, list]`.** The infix operator is a separate code path with its own, incomplete copy of "what are this expression's children," missing `Rule`/`RuleDelayed`/`Association` entirely — so `List @@ (a -> b)` returned the `Rule` unchanged instead of `{a, b}`. Fixed by delegating to the same `expr_children` helper the bracket form already uses.

Also added a regression test in Woxi Studio for the demonstration's construct (independently written — different helper names, different example networks, uses Woxi's built-in centrality functions instead of the legacy `GraphUtilities` package the original notebook loads — no verbatim code from the notebook).

## Test plan

- [x] `make test` — all 27,549 tests pass
- [x] `make format`
- [x] New unit tests for the bare-edge-list coercion (`tests/interpreter_tests/graph_theory.rs`)
- [x] New unit tests for `@@`/`Apply` over `Rule`/`Association` (`tests/interpreter_tests/function_application.rs`)
- [x] New Woxi Studio regression test rendering and interacting with the node-prominence `Manipulate` (`woxi-studio/src/main.rs`)


---
_Generated by [Claude Code](https://claude.ai/code/session_0177X9XWeqVB4XrVNxUbsEt4)_