### PR TITLE
Skip Place[n]-based custom control-layout templates in Manipulate

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11224,6 +11224,26 @@ fn annotation_contains_dynamic(expr: &Expr) -> bool {
   }
 }
 
+/// Whether a `Row[…]`/`Column[…]` argument is Wolfram's custom
+/// control-layout template rather than a static annotation row: it places
+/// each already-declared control by number with `Place[n]` (e.g.
+/// `Column[{Row[{Place[1], Spacer[20], Place[2]}], …}]`), the documented
+/// alternative to per-control `ControlPlacement -> n` for arranging a
+/// Manipulate's panel by hand. Woxi renders one flat control panel rather
+/// than reproducing such a custom arrangement (see the per-control
+/// `ControlPlacement` handling above), so this template must be recognized
+/// and dropped silently — not misread as a `Row[{Style[…], …}]`-style text
+/// heading, which would add a spurious blank-labeled control row.
+fn annotation_contains_place(expr: &Expr) -> bool {
+  match expr {
+    Expr::FunctionCall { name, args } => {
+      name == "Place" || args.iter().any(annotation_contains_place)
+    }
+    Expr::List(items) => items.iter().any(annotation_contains_place),
+    _ => false,
+  }
+}
+
 /// Peel a display-only `Invisible[expr]` wrapper, returning the content it
 /// hides. `Invisible` keeps exactly the space `expr` would take but paints
 /// nothing — Demonstrations use it to hold a layout's shape steady while an
@@ -17395,6 +17415,12 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         });
         continue;
       }
+      // A custom control-layout template (`Row`/`Column`/`Grid` placing
+      // declared controls by number via `Place[n]`) contributes no control
+      // or display of its own — see `annotation_contains_place`.
+      Expr::FunctionCall { .. } if annotation_contains_place(spec) => {
+        continue;
+      }
       Expr::FunctionCall { name, .. }
         if is_manipulate_annotation_head(name)
           && !annotation_contains_dynamic(spec) =>
@@ -23414,5 +23440,35 @@ mod manipulate_control_placement_tests {
       vec!["a"]
     );
     assert_eq!(spec.control_placement, ControlPlacement::Top);
+  }
+
+  /// A custom layout template (`Column[{Row[{Place[1], …}], Grid[{…}]}]`)
+  /// is Wolfram's other way of arranging a Manipulate's controls by hand —
+  /// each `Place[n]` stands for the nth declared control. Woxi keeps one
+  /// flat control panel rather than reproducing the custom arrangement
+  /// (see `per_control_placement_leaves_the_widget_default` above), so the
+  /// template itself must disappear rather than being misread as a
+  /// `Row[{Style[…], …}]`-style static text heading — which would add a
+  /// spurious blank-labeled control row after the two real sliders.
+  #[test]
+  fn place_layout_template_contributes_no_control() {
+    let expr = crate::parse_to_expr(
+      "Manipulate[Plot[Sin[a x] + b, {x, 0, 6}], \
+       {{a, 1, \"a\"}, 0, 5, ControlPlacement -> 1}, \
+       {{b, 0, \"b\"}, -1, 1, ControlPlacement -> 2}, \
+       Column[{Row[{Place[1], Spacer[20], Place[2]}]}]]",
+    )
+    .expect("parse");
+    let spec = extract_manipulate_spec(&expr).expect("extract spec");
+    assert_eq!(
+      spec
+        .controls
+        .iter()
+        .map(ManipulateControl::name)
+        .collect::<Vec<_>>(),
+      vec!["a", "b"],
+      "the layout template must not become a third, blank-labeled control: {:?}",
+      spec.controls
+    );
   }
 }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21038,4 +21038,147 @@ SaveDefinitions -> True]";
       "the GraphPlot must still render after switching network/measure/bidirectional"
     );
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook
+  /// exploring the geometry of three mutually tangent circles: a `Setter`
+  /// toggles between a `Graphics3D` view (three `Sphere`s) and a 2D
+  /// `Graphics` construction (the same three disks plus their tangent
+  /// points), while sliders drive the three radii and a zoom factor.
+  /// Independently written, not copied from any specific Demonstration:
+  /// this version places the third circle via a plain right-triangle
+  /// decomposition (`dist13x`/`dist13y`) rather than the original's
+  /// particular soap-bubble angle construction, and uses different helper
+  /// names throughout.
+  ///
+  /// The construct worth pinning down is the combination of (1) a
+  /// `Setter` control whose domain is given as `value -> "label"` rules
+  /// feeding an `If` that switches the rendered dimensionality, (2) an
+  /// `Initialization` block defining several pattern-matched helper
+  /// functions (`f[Pattern[x, Blank[]], …] := …`) that call each other and
+  /// use a `Rational[1, 2]` power (not `Sqrt`) — mirroring the original's
+  /// style — evaluated fresh on every re-render against the *current*
+  /// slider values (not memoized once at Initialization time), and (3) a
+  /// custom layout argument (`Column[{Row[{Place[1], …}], Grid[{…}]}]`)
+  /// with per-control `ControlPlacement -> n` — Woxi keeps one control
+  /// panel rather than reproducing Wolfram's multi-region custom layout,
+  /// so this must parse harmlessly rather than breaking extraction.
+  #[test]
+  fn demonstration_tangent_circles_setter_toggles_3d_and_construction() {
+    let code = "Manipulate[\
+      If[view3d, \
+        Graphics3D[{\
+          Sphere[{0, 0, 0}, r1], \
+          Sphere[{dist12[r1, r2], 0, 0}, r2], \
+          Sphere[{dist13x[r1, r2, r3], dist13y[r1, r2, r3], 0}, r3]\
+        }, PlotRange -> spread {{-1, 2}, {-1, 1}, {-1, 1}}, Boxed -> False], \
+        Graphics[{\
+          Circle[{0, 0}, r1], \
+          Circle[{dist12[r1, r2], 0}, r2], \
+          Circle[{dist13x[r1, r2, r3], dist13y[r1, r2, r3]}, r3], \
+          Black, PointSize[0.02], \
+          Point[{0, 0}], \
+          Point[{dist12[r1, r2], 0}], \
+          Point[{dist13x[r1, r2, r3], dist13y[r1, r2, r3]}]\
+        }, PlotRange -> spread {{-1, 2}, {-1, 1}}]\
+      ], \
+      {{view3d, True, \"\"}, {True -> \"3D view\", False -> \"construction\"}, \
+        ControlType -> Setter, ControlPlacement -> 1}, \
+      {{spread, 5, \"zoom\"}, 5, 12, 0.001, Appearance -> \"Labeled\", \
+        ImageSize -> Small, ControlPlacement -> 2}, \
+      {{r1, 3, Style[\"r1\", Italic]}, 2, 4, 0.001, Appearance -> \"Labeled\", \
+        ImageSize -> Small, ControlPlacement -> 3}, \
+      {{r2, 2, Style[\"r2\", Italic]}, 1, 3, 0.001, Appearance -> \"Labeled\", \
+        ImageSize -> Small, ControlPlacement -> 4}, \
+      {{r3, 1, Style[\"r3\", Italic]}, 0.5, 2, 0.001, Appearance -> \"Labeled\", \
+        ImageSize -> Small, ControlPlacement -> 5}, \
+      Column[{\
+        Row[{Place[1], Spacer[20], Place[2]}], \
+        Grid[{{\"radii\", Spacer[20], Place[3], Place[4], Place[5]}}]\
+      }], \
+      TrackedSymbols :> {view3d, r1, r2, r3, spread}, \
+      ControlPlacement -> Top, \
+      Initialization :> (\
+        dist12[Pattern[x, Blank[]], Pattern[y, Blank[]]] := x + y; \
+        dist13x[Pattern[x, Blank[]], Pattern[y, Blank[]], Pattern[z, Blank[]]] := \
+          ((x + y)^2 + x^2 - z^2)/(2 (x + y)); \
+        dist13y[Pattern[x, Blank[]], Pattern[y, Blank[]], Pattern[z, Blank[]]] := \
+          (x^2 - dist13x[x, y, z]^2)^Rational[1, 2];\
+      )\
+    ]";
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "a Setter plus four labeled sliders (with a custom Place layout) \
+       should build a ManipulateState",
+    );
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the 3D Sphere view must render by default"
+    );
+
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, ["view3d", "spread", "r1", "r2", "r3"]);
+
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete {
+        values,
+        value_labels,
+        current_index,
+        ..
+      } => {
+        assert_eq!(values, &["True", "False"]);
+        assert_eq!(value_labels, &["3D view", "construction"]);
+        assert_eq!(*current_index, 0, "view3d should start True (3D view)");
+      }
+      other => panic!("view3d should be a discrete Setter: {other:?}"),
+    }
+
+    // Switch to the 2D construction view: the same helper functions must
+    // still evaluate against the (unchanged) radii and produce a Graphics
+    // (not Graphics3D) render.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[0]
+    {
+      *current_index = 1;
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "2D construction re-render failed: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the 2D construction Graphics must render"
+    );
+
+    // Now change the radii and re-render: the Initialization-defined
+    // helpers must be called fresh with the *new* r1/r2/r3, not whatever
+    // they memoized during the one-time Initialization run.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[2]
+    {
+      *current = 4.0; // r1: 3 -> 4
+    }
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[3]
+    {
+      *current = 3.0; // r2: 2 -> 3
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "re-render after changing radii failed: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the construction must still render with the new radii"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Sampled a random Wolfram Demonstrations Project notebook (three mutually tangent circles/spheres, with a `Setter` switching between a `Graphics3D` view and a 2D `Graphics` construction). It passes a trailing `Column[{Row[{Place[1], ...}], Grid[{...}]}]` argument — Wolfram's documented way to arrange a Manipulate's controls by hand, using `Place[n]` placeholders instead of per-control `ControlPlacement`.
- Woxi already deliberately renders one flat control panel rather than reproducing such custom arrangements (see the existing `per_control_placement_leaves_the_widget_default` test), but the template argument itself was falling through to the `Row`/`Column` static-text-heading path, producing a spurious blank-labeled control row.
- Fixed by recognizing any Manipulate spec argument containing `Place[...]` and dropping it silently instead of misreading it as a text heading.

## Test plan

- [x] Added `place_layout_template_contributes_no_control` in `src/functions/graphics.rs`, targeting the parsing fix directly.
- [x] Added `demonstration_tangent_circles_setter_toggles_3d_and_construction` in `woxi-studio/src/main.rs`, an independently-written test (not copied from the sampled notebook) covering the notebook's broader feature set: a `Setter` with a rule-labeled domain switching `Graphics3D`/`Graphics`, and `Initialization`-defined pattern-matched helper functions (using a `Rational[1, 2]` power) that are re-evaluated fresh against the current slider values on every render.
- [x] `cargo test --workspace` — all 25457 + 1258 + 576 + 183 tests pass.
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGsMw6EkzuwGN6Yu5dRXhT)_