### PR TITLE
Implement TopologicalSort for directed graphs

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -3175,7 +3175,7 @@ FilteredEntityClass,,🚫,,12.0,3224
 LanguageIdentify,,🚫,,10.1,3224
 ObservabilityMatrix,Observability matrix of a state-space model,✅,pure,8.0,3224
 PowerDistribution,Continuous distribution with PDF a k^a x^(a-1) on support (0 1/k],✅,pure,8.0,3224
-TopologicalSort,Tie-breaking order among independent vertices follows WL-internal traversal (three candidate models contradicted by probes),🚫,pure,8.0,3224
+TopologicalSort,Topological ordering of a directed acyclic graph's vertices (tie-break among independent vertices differs from WL; see conformance_gaps.md),✅,pure,8.0,3224
 DynamicUpdating,,🚫,,6.0,3233
 EvaluatorNames,,🚫,,4.0,3233
 FindThreshold,,,,8.0,3233

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -701,6 +701,7 @@ fn evaluate_function_call_ast_inner(
     "MultigraphQ",
     "PageRankCentrality",
     "RadialityCentrality",
+    "TopologicalSort",
     "TreeGraphQ",
     "TuttePolynomial",
     "UndirectedGraphQ",
@@ -7830,6 +7831,63 @@ fn evaluate_function_call_ast_inner(
           .map(|v| Expr::List(v.into()))
           .collect(),
       ));
+    }
+    return Ok(unevaluated(name, args));
+  }
+
+  // TopologicalSort[graph] — a topological ordering of a directed acyclic
+  // graph's vertices: every directed edge u -> v has u appear before v.
+  // WL's tie-break among simultaneously-ready vertices is not reproducible
+  // (see conformance_gaps.md — Kahn-min, Kahn-max and DFS reverse-postorder
+  // each fit some probes and contradict others), so Woxi picks the
+  // lexicographically smallest order via Kahn's algorithm on VertexList
+  // order. A cyclic graph has no topological order, so the call stays
+  // unevaluated, same as any other unmatched pattern.
+  if name == "TopologicalSort" && args.len() == 1 {
+    if let Expr::FunctionCall {
+      name: gname,
+      args: gargs,
+    } = &args[0]
+      && gname == "Graph"
+      && gargs.len() >= 2
+      && let (Expr::List(vertices), Expr::List(edges)) = (&gargs[0], &gargs[1])
+    {
+      let n = vertices.len();
+      let (pg_digraph, _) =
+        crate::functions::graph::build_digraph(vertices, edges);
+      let mut indeg = vec![0usize; n];
+      let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+      for edge in pg_digraph.raw_edges() {
+        if edge.weight {
+          let u = edge.source().index();
+          let v = edge.target().index();
+          adj[u].push(v);
+          indeg[v] += 1;
+        }
+      }
+      use std::cmp::Reverse;
+      use std::collections::BinaryHeap;
+      let mut ready: BinaryHeap<Reverse<usize>> = indeg
+        .iter()
+        .enumerate()
+        .filter(|&(_, &d)| d == 0)
+        .map(|(i, _)| Reverse(i))
+        .collect();
+      let mut order = Vec::with_capacity(n);
+      while let Some(Reverse(u)) = ready.pop() {
+        order.push(u);
+        for &v in &adj[u] {
+          indeg[v] -= 1;
+          if indeg[v] == 0 {
+            ready.push(Reverse(v));
+          }
+        }
+      }
+      if order.len() == n {
+        return Ok(Expr::List(
+          order.into_iter().map(|i| vertices[i].clone()).collect(),
+        ));
+      }
     }
     return Ok(unevaluated(name, args));
   }

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -7855,15 +7855,20 @@ fn evaluate_function_call_ast_inner(
       let n = vertices.len();
       let (pg_digraph, _) =
         crate::functions::graph::build_digraph(vertices, edges);
+      // TopologicalSort is only defined for a DAG. An undirected edge
+      // (weight == false) can't be oriented, so a graph carrying one has
+      // no topological order — stay unevaluated rather than silently
+      // dropping the constraint and reporting a bogus order.
+      if pg_digraph.raw_edges().iter().any(|edge| !edge.weight) {
+        return Ok(unevaluated(name, args));
+      }
       let mut indeg = vec![0usize; n];
       let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
       for edge in pg_digraph.raw_edges() {
-        if edge.weight {
-          let u = edge.source().index();
-          let v = edge.target().index();
-          adj[u].push(v);
-          indeg[v] += 1;
-        }
+        let u = edge.source().index();
+        let v = edge.target().index();
+        adj[u].push(v);
+        indeg[v] += 1;
       }
       use std::cmp::Reverse;
       use std::collections::BinaryHeap;

--- a/tests/cli/comparison/mathematica/conformance_gaps.md
+++ b/tests/cli/comparison/mathematica/conformance_gaps.md
@@ -2518,12 +2518,14 @@ order, DFS pre/post, BFS from the target, degree-based start) is contradicted.
 `WeaklyConnectedGraphComponents` is unimplemented for this reason.
 **Not reproducible.**
 
-### `TopologicalSort` is unimplemented
+### `TopologicalSort` vertex order
 
 WL's vertex ordering is not reproducible by DFS reverse-postorder or by Kahn
 with a min/max heap: `{1->3, 2->3}` → `{1,2,3}` needs Kahn-min, but
 `{1->2, 1->3, 2->4, 3->4}` → `{1,3,2,4}` needs DFS, and the two contradict.
-Also `{1->2, 3->4}` → `{3,4,1,2}`. **Not reproducible.**
+Also `{1->2, 3->4}` → `{3,4,1,2}`. Woxi always returns the lexicographically
+smallest topological order (Kahn's algorithm, ties broken by `VertexList`
+index) — a valid ordering, just not always WL's. **Not reproducible.**
 
 ### `FindHamiltonianPath` choice
 

--- a/tests/cli/comparison/mathematica/missing_features.md
+++ b/tests/cli/comparison/mathematica/missing_features.md
@@ -530,7 +530,7 @@ Woxi does **not** support.
 - Statistical visualization: `SmoothHistogram`, `DensityHistogram`,
     `DistributionChart`, `ProbabilityPlot`, `QuantilePlot`,
     `PairedHistogram`
-- Graph analysis extras: `CayleyGraph`, `TopologicalSort`,
+- Graph analysis extras: `CayleyGraph`,
     `FindVertexCover`, `FindEdgeCover`, `HITSCentrality`,
     `BreadthFirstScan`, `DepthFirstScan`, and styling options
     (`VertexStyle`, `EdgeLabels`, `GraphLayout`)

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -7167,3 +7167,61 @@ mod bare_edge_list_argument {
     );
   }
 }
+
+mod topological_sort {
+  use super::*;
+
+  #[test]
+  fn linear_chain() {
+    let result =
+      interpret("TopologicalSort[Graph[{1 -> 2, 2 -> 3, 3 -> 4}]]").unwrap();
+    assert_eq!(result, "{1, 2, 3, 4}");
+  }
+
+  #[test]
+  fn diamond_shape() {
+    // Every directed edge u -> v must have u appear before v.
+    let result =
+      interpret("TopologicalSort[Graph[{1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4}]]")
+        .unwrap();
+    assert_eq!(result, "{1, 2, 3, 4}");
+  }
+
+  #[test]
+  fn independent_vertices_break_ties_lexicographically() {
+    // 1 and 2 both have no incoming edges; Woxi always picks the lower
+    // index first (Kahn's algorithm), giving the lexicographically
+    // smallest valid order.
+    let result = interpret("TopologicalSort[Graph[{1 -> 3, 2 -> 3}]]").unwrap();
+    assert_eq!(result, "{1, 2, 3}");
+  }
+
+  #[test]
+  fn isolated_vertex_included() {
+    let result =
+      interpret("TopologicalSort[Graph[{1, 2, 3}, {1 -> 3}]]").unwrap();
+    assert_eq!(result, "{1, 2, 3}");
+  }
+
+  #[test]
+  fn cyclic_graph_stays_unevaluated() {
+    // A cycle has no topological order, matching WL's failure behavior.
+    let result =
+      interpret("TopologicalSort[Graph[{1 -> 2, 2 -> 3, 3 -> 1}]]").unwrap();
+    assert_eq!(result, "TopologicalSort[Graph[<3>, <3>]]");
+  }
+
+  #[test]
+  fn self_loop_stays_unevaluated() {
+    let result = interpret("TopologicalSort[Graph[{1 -> 1, 1 -> 2}]]").unwrap();
+    assert!(result.starts_with("TopologicalSort["));
+  }
+
+  #[test]
+  fn accepts_bare_edge_list() {
+    assert_eq!(
+      interpret("TopologicalSort[{1 -> 2, 2 -> 3}]").unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+}

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -7224,4 +7224,21 @@ mod topological_sort {
       "{1, 2, 3}"
     );
   }
+
+  #[test]
+  fn undirected_graph_stays_unevaluated() {
+    // TopologicalSort is only defined for a DAG; an undirected edge can't
+    // be oriented, so it must not be silently dropped and treated as no
+    // constraint at all.
+    let result =
+      interpret("TopologicalSort[Graph[{1 <-> 2, 2 <-> 3}]]").unwrap();
+    assert!(result.starts_with("TopologicalSort["));
+  }
+
+  #[test]
+  fn mixed_directed_and_undirected_stays_unevaluated() {
+    let result =
+      interpret("TopologicalSort[Graph[{1 -> 2, 2 <-> 3}]]").unwrap();
+    assert!(result.starts_with("TopologicalSort["));
+  }
 }


### PR DESCRIPTION
## Summary

- A random Wolfram Demonstration ("Topological Sort in DAGs") failed to fully evaluate in Woxi Studio because `TopologicalSort` was entirely unimplemented (previously marked 🚫 in `functions.csv`).
- Implements `TopologicalSort[graph]` using Kahn's algorithm, always picking the lowest-index ready vertex, giving a deterministic, lexicographically-smallest topological order. A cyclic graph has no topological order, so the call now stays unevaluated, matching the existing pattern for other unmatched graph function calls.
- `TopologicalSort` also now accepts a bare edge list, consistent with the other graph analysis functions (`EdgeList`, `ConnectedComponents`, etc.).
- WL's own tie-break among simultaneously-ready vertices isn't reproducible (already documented in `conformance_gaps.md` after testing three candidate algorithms against known probes), so this only guarantees *a* valid topological ordering, not always the exact one WL would pick — consistent with how `ConnectedComponents`, `FindHamiltonianPath` and other graph functions already handle documented ordering divergence.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/graph_theory.rs` covering a linear chain, a diamond DAG, tie-breaking among independent vertices, isolated vertices, cyclic/self-loop graphs (stays unevaluated), and the bare-edge-list form.
- [x] `cargo test` — full suite passes (25,464 interpreter tests + 1,258 misc + 576 script snapshots), no regressions.
- [x] Verified against the actual downloaded Demonstration notebook via `woxi-studio`'s `examples/test_notebook` — both input cells (the DAG generator and the `Manipulate` widget using `TopologicalSort`) now evaluate without error.
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_012ooTDf5HLjYocYR6vFU8L2)_