### PR TITLE
Accept trailing option rules in Compile

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -216,7 +216,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "ColorNegate" => Some((1, 1)),
     "ColorQ" => Some((1, 1)),
     "Commonest" => Some((1, 2)),
-    "Compile" => Some((2, 2)),
+    "Compile" => Some((2, usize::MAX)),
     "Complex" => Some((2, 2)),
     "ComplexExpand" => Some((1, 2)),
     "ComplexListPlot" => Some((1, usize::MAX)),

--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -42,7 +42,7 @@ pub fn dispatch_structural(
         return Some(Ok(unevaluated("Function", args)));
       }
     },
-    "Compile" if args.len() == 2 => {
+    "Compile" if args.len() >= 2 => {
       let vars = match &args[0] {
         Expr::List(items) => {
           let mut var_names = Vec::new();

--- a/tests/cli/expressions/Compile.md
+++ b/tests/cli/expressions/Compile.md
@@ -29,3 +29,11 @@ A rank-`n` `_Real` argument is converted element by element:
 $ wo 'Compile[{{g, _Real, 2}}, g][{{1, 1/2}, {3, 4}}]'
 {{1., 0.5}, {3., 4.}}
 ```
+
+Trailing option rules such as `RuntimeAttributes` and `RuntimeOptions` are
+accepted and don't change the result:
+
+```scrut
+$ wo 'Compile[{{x, _Real}}, x^2, RuntimeAttributes -> {Listable}, RuntimeOptions -> "Speed"][3.]'
+9.
+```

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -763,6 +763,26 @@ mod compile {
     let result = interpret("Compile[{x, y}, x + y]").unwrap();
     assert!(result.starts_with("CompiledFunction["));
   }
+
+  // Regression: `Compile` only accepted exactly 2 arguments, so the trailing
+  // option rules real Wolfram code commonly appends (`RuntimeAttributes`,
+  // `RuntimeOptions`, ...) raised a spurious `Compile::argrx` message and
+  // left the function unevaluated.
+  #[test]
+  fn compile_accepts_trailing_option_rules() {
+    clear_state();
+    let r = woxi::interpret_with_stdout(
+      "cf = Compile[{{x, _Real}}, x^2, RuntimeAttributes -> {Listable}, RuntimeOptions -> \"Speed\"]; cf[3.]",
+    )
+    .unwrap();
+    assert_eq!(r.result, "9.");
+    assert!(
+      r.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      r.warnings
+    );
+    assert_eq!(interpret("Head[cf]").unwrap(), "CompiledFunction");
+  }
 }
 
 mod dispatch {


### PR DESCRIPTION
## Summary

- `Compile` only accepted exactly 2 arguments, so real-world code that appends option rules (e.g. `RuntimeAttributes -> {Listable}`, `RuntimeOptions -> "Speed"`) after the body raised a spurious `Compile::argrx` message and left the call unevaluated.
- `Compile` now accepts 2 or more arguments; trailing rule arguments after the variable list and body are accepted and ignored (Woxi doesn't produce real bytecode, so these options don't change the symbolic result).
- Found while checking whether Woxi Studio fully supports a randomly-selected Wolfram Demonstrations Project notebook ("Coupler Curve Atlas for the Four-Bar Linkage"), which defines its core function with `Compile[..., RuntimeAttributes -> {Listable}, RuntimeOptions -> "Speed"]`. With this fix the notebook's input cells evaluate cleanly with no errors or warnings.

## Test plan
- [x] Added a regression unit test (`compile_accepts_trailing_option_rules`) exercising `Compile` with trailing `RuntimeAttributes`/`RuntimeOptions` rules
- [x] Added a corresponding `scrut` doc example in `tests/cli/expressions/Compile.md`
- [x] `make test` (27,560 tests passed)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TC7kpNj8dTYQA3kKPHNYgb


---
_Generated by [Claude Code](https://claude.ai/code/session_01TC7kpNj8dTYQA3kKPHNYgb)_