### PR TITLE
Solve separable first-order ODEs posed as initial-value problems

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 # Unreleased
 
+- `DSolve` solves separable first-order equations posed as initial-value
+    problems. `y'[x] == g[x] h[y[x]]` is nonlinear in `y` whenever `h` is, so
+    the term classifier — which only understands equations linear in `y` —
+    turned it down and the whole equation came back unevaluated. Separating
+    the variables and integrating each side gives the implicit relation, the
+    initial condition pins the constant, and the result is solved for `y`,
+    keeping only the branch that condition selects:
+    `DSolve[{y'[t] == -t y[t]^2, y[0] == 1}, y, t]` is
+    `{{y -> Function[{t}, 2/(2 + t^2)]}}`. Without an initial condition the
+    equation still stays unevaluated.
+
 - An Orderless argument is re-read when a rule's guard turns down the first
     reading. `Times` and `Plus` arguments can satisfy a structural pattern
     more than one way, and the guard may accept only some of them:

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -187,7 +187,28 @@ fn dsolve_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let ode_normalized = normalize_equation(&ode_expr)?;
 
   // Collect terms: classify each additive term by derivative order
-  let terms = collect_ode_terms(&ode_normalized, &y_name, &x_name)?;
+  let terms = match collect_ode_terms(&ode_normalized, &y_name, &x_name) {
+    Ok(terms) => terms,
+    // The term classifier only understands equations that are linear in y.
+    // An equation it rejects may still be separable (`y' == g(x) h(y)`), so
+    // try quadrature before giving up.
+    Err(err) => match solve_separable_first_order(
+      &ode_expr,
+      &y_name,
+      &x_name,
+      &initial_conditions,
+    ) {
+      Some(solution) => {
+        return Ok(build_dsolve_result(
+          solution,
+          y_name,
+          x_name,
+          function_form,
+        ));
+      }
+      None => return Err(err),
+    },
+  };
 
   // Determine max order
   let max_order = terms.iter().map(|t| t.order).max().unwrap_or(0);
@@ -238,7 +259,18 @@ fn dsolve_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let solution =
     crate::evaluator::evaluate_expr_to_expr(&solution).unwrap_or(solution);
 
-  // Build result: {{y[x] -> solution}} or {{y -> Function[{x}, solution]}}
+  Ok(build_dsolve_result(solution, y_name, x_name, function_form))
+}
+
+/// Wrap a solved right-hand side as `{{y[x] -> sol}}`, or
+/// `{{y -> Function[{x}, sol]}}` when the caller asked for `y` rather than
+/// `y[x]`.
+fn build_dsolve_result(
+  solution: Expr,
+  y_name: String,
+  x_name: String,
+  function_form: bool,
+) -> Expr {
   let rule = if function_form {
     Expr::Rule {
       pattern: Box::new(Expr::Identifier(y_name)),
@@ -258,7 +290,7 @@ fn dsolve_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
 
-  Ok(Expr::List(vec![Expr::List(vec![rule].into())].into()))
+  Expr::List(vec![Expr::List(vec![rule].into())].into())
 }
 
 // ─── NDSolve ───────────────────────────────────────────────────────────
@@ -3384,6 +3416,240 @@ fn solve_first_order_linear(
   let homogeneous =
     crate::functions::calculus_ast::simplify(times2(inv_mu, make_c(1)));
   Ok(plus2(particular, homogeneous))
+}
+
+// ─── Separable First-Order ODEs ────────────────────────────────────────
+
+/// Solve a separable first-order ODE `y'[x] == g(x) h(y[x])` by quadrature.
+///
+/// Only the initial-value problem is answered: the general solution needs an
+/// arbitrary constant, and where wolframscript places it inside the solved
+/// form is not something Woxi reproduces yet, so `DSolve` keeps returning the
+/// equation unevaluated when no initial condition pins the constant.
+fn solve_separable_first_order(
+  ode: &Expr,
+  y_name: &str,
+  x_name: &str,
+  initial_conditions: &[Expr],
+) -> Option<Expr> {
+  let rhs = separable_derivative_rhs(ode, y_name, x_name)?;
+  let (x0, y0) = separable_initial_value(initial_conditions, y_name)?;
+
+  let u_name = fresh_symbol_name(ode, "u")?;
+  let rhs_u =
+    replace_y_call(&rhs, y_name, x_name, &Expr::Identifier(u_name.clone()));
+  if !is_free_of_y(&rhs_u, y_name) {
+    return None;
+  }
+  let (g, h) = split_separable_factors(&rhs_u, &u_name, x_name)?;
+
+  // Separating gives ∫ du/h(u) == ∫ g(x) dx + C.
+  let y_integral = closed_form_integral(&div2(Expr::Integer(1), h), &u_name)?;
+  let x_integral = closed_form_integral(&g, x_name)?;
+
+  let constant = simplify(minus2(
+    crate::syntax::substitute_variable(&y_integral, &u_name, &y0),
+    crate::syntax::substitute_variable(&x_integral, x_name, &x0),
+  ));
+  let relation = Expr::Comparison {
+    operands: vec![y_integral, plus2(x_integral, constant)],
+    operators: vec![ComparisonOp::Equal],
+  };
+
+  let solved =
+    crate::functions::solve_ast(&[relation, Expr::Identifier(u_name.clone())])
+      .ok()?;
+
+  // Separating loses branch information, so more than one root can come back
+  // (`y^2` on the right gives a ± pair). Keep the one the initial condition
+  // actually selects.
+  let Expr::List(solution_sets) = &solved else {
+    return None;
+  };
+  for set in solution_sets {
+    let Expr::List(rules) = set else { continue };
+    let Some(Expr::Rule {
+      pattern,
+      replacement,
+    }) = rules.get(0)
+    else {
+      continue;
+    };
+    if !matches!(pattern.as_ref(), Expr::Identifier(n) if n == &u_name) {
+      continue;
+    }
+    let candidate = simplify(replacement.as_ref().clone());
+    let at_x0 = crate::evaluator::evaluate_expr_to_expr(
+      &crate::syntax::substitute_variable(&candidate, x_name, &x0),
+    )
+    .ok()?;
+    if values_agree(&at_x0, &y0) {
+      return Some(candidate);
+    }
+  }
+  None
+}
+
+/// Read `y'[x] == rhs` (in either orientation) and return the right-hand side.
+fn separable_derivative_rhs(
+  ode: &Expr,
+  y_name: &str,
+  x_name: &str,
+) -> Option<Expr> {
+  let (lhs, rhs) = as_equal_pair(ode)?;
+  for (derivative, other) in [(lhs, rhs), (rhs, lhs)] {
+    if let Some((1, point)) =
+      extract_derivative_order_and_point(derivative, y_name)
+      && matches!(&point, Expr::Identifier(n) if n == x_name)
+      && !contains_derivative(other)
+    {
+      return Some(other.clone());
+    }
+  }
+  None
+}
+
+/// Find an initial condition `y[x0] == y0`, returning the pair `(x0, y0)`.
+fn separable_initial_value(
+  initial_conditions: &[Expr],
+  y_name: &str,
+) -> Option<(Expr, Expr)> {
+  for condition in initial_conditions {
+    let Some((lhs, rhs)) = as_equal_pair(condition) else {
+      continue;
+    };
+    if let Expr::FunctionCall { name, args } = lhs
+      && name == y_name
+      && args.len() == 1
+    {
+      return Some((args[0].clone(), rhs.clone()));
+    }
+  }
+  None
+}
+
+/// Pick a symbol name that does not occur in `expr`, so the dependent
+/// variable can be stood in for by a plain symbol while integrating.
+fn fresh_symbol_name(expr: &Expr, base: &str) -> Option<String> {
+  (0..64).find_map(|n| {
+    let candidate = if n == 0 {
+      base.to_string()
+    } else {
+      format!("{base}{n}")
+    };
+    crate::functions::calculus_ast::is_constant_wrt(expr, &candidate)
+      .then_some(candidate)
+  })
+}
+
+/// Replace every `y[x]` in `expr` with `value`.
+fn replace_y_call(
+  expr: &Expr,
+  y_name: &str,
+  x_name: &str,
+  value: &Expr,
+) -> Expr {
+  if let Expr::FunctionCall { name, args } = expr
+    && name == y_name
+    && args.len() == 1
+    && matches!(&args[0], Expr::Identifier(n) if n == x_name)
+  {
+    return value.clone();
+  }
+  map_children(expr, &|child| replace_y_call(child, y_name, x_name, value))
+}
+
+/// Split a product into its `x`-only and `u`-only halves. `None` when some
+/// factor mixes the two, which means the equation is not separable this way.
+fn split_separable_factors(
+  rhs: &Expr,
+  u_name: &str,
+  x_name: &str,
+) -> Option<(Expr, Expr)> {
+  let mut factors = Vec::new();
+  collect_multiplicative_factors(rhs, &mut factors);
+
+  let mut x_part = Vec::new();
+  let mut u_part = Vec::new();
+  for factor in factors {
+    if crate::functions::calculus_ast::is_constant_wrt(&factor, u_name) {
+      x_part.push(factor);
+    } else if crate::functions::calculus_ast::is_constant_wrt(&factor, x_name) {
+      u_part.push(factor);
+    } else {
+      return None;
+    }
+  }
+  Some((product_of(x_part), product_of(u_part)))
+}
+
+fn collect_multiplicative_factors(expr: &Expr, out: &mut Vec<Expr>) {
+  match expr {
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      right,
+    } => {
+      collect_multiplicative_factors(left, out);
+      collect_multiplicative_factors(right, out);
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => {
+      collect_multiplicative_factors(left, out);
+      out.push(pow2(right.as_ref().clone(), Expr::Integer(-1)));
+    }
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => {
+      out.push(Expr::Integer(-1));
+      collect_multiplicative_factors(operand, out);
+    }
+    Expr::FunctionCall { name, args } if name == "Times" => {
+      for arg in args {
+        collect_multiplicative_factors(arg, out);
+      }
+    }
+    _ => out.push(expr.clone()),
+  }
+}
+
+fn product_of(factors: Vec<Expr>) -> Expr {
+  factors
+    .into_iter()
+    .reduce(times2)
+    .unwrap_or(Expr::Integer(1))
+}
+
+/// Integrate, accepting only a result that actually closed — a residual
+/// `Integrate[…]` head means the antiderivative is not available and the
+/// separable route cannot finish.
+fn closed_form_integral(integrand: &Expr, var: &str) -> Option<Expr> {
+  let result = crate::functions::calculus_ast::integrate_ast(&[
+    simplify(integrand.clone()),
+    Expr::Identifier(var.to_string()),
+  ])
+  .ok()?;
+  (!mentions_head(&result, "Integrate")).then_some(result)
+}
+
+fn mentions_head(expr: &Expr, head: &str) -> bool {
+  if matches!(expr, Expr::FunctionCall { name, .. } if name == head) {
+    return true;
+  }
+  expr_children(expr).iter().any(|c| mentions_head(c, head))
+}
+
+/// Compare two solution values, numerically where both sides evaluate to a
+/// number and structurally otherwise.
+fn values_agree(a: &Expr, b: &Expr) -> bool {
+  match (expr_to_f64(a), expr_to_f64(b)) {
+    (Ok(x), Ok(y)) => (x - y).abs() <= 1e-9 * y.abs().max(1.0),
+    _ => exprs_match(a, b),
+  }
 }
 
 /// Create E^(expr*x) for symbolic expressions

--- a/tests/cli/symbolic/DSolve.md
+++ b/tests/cli/symbolic/DSolve.md
@@ -6,3 +6,11 @@ Solves ordinary differential equations symbolically.
 $ wo "DSolve[y'[x] == y[x], y[x], x]"
 {{y[x] -> E^x*C[1]}}
 ```
+
+A separable equation is nonlinear in `y`, so it needs an initial condition to
+pin the constant of integration:
+
+```scrut
+$ wo "DSolve[{y'[t] == -t y[t]^2, y[0] == 1}, y, t]"
+{{y -> Function[{t}, 2/(2 + t^2)]}}
+```

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7010,7 +7010,8 @@ mod dsolve {
   // of an x-factor and a nonlinear y-factor (e.g. x*y[x]^2) used to be
   // misclassified — the x*y^2 term was treated as a y-free forcing term and
   // "integrated", yielding the bogus circular C[1] + Integrate[x*y[x]^2, x].
-  // It must instead stay unevaluated, like the bare y[x]^2 case.
+  // Without an initial condition to pin the constant it must stay
+  // unevaluated, like the bare y[x]^2 case.
   #[test]
   fn separable_nonlinear_product_stays_unevaluated() {
     assert_eq!(
@@ -7020,6 +7021,58 @@ mod dsolve {
     assert_eq!(
       interpret("DSolve[y'[x] == x^2 y[x]^2, y[x], x]").unwrap(),
       "DSolve[Derivative[1][y][x] == x^2*y[x]^2, y[x], x]"
+    );
+  }
+
+  // An initial condition pins the constant of a separable equation, so the
+  // implicit relation ∫dy/h(y) == ∫g(x)dx + C can be solved outright — the
+  // nonlinear right-hand sides above are the ones the linear term classifier
+  // rejects.
+  #[test]
+  fn separable_nonlinear_initial_value_problem() {
+    assert_eq!(
+      interpret("DSolve[{y'[x] == x y[x]^2, y[0] == 2}, y[x], x]").unwrap(),
+      "{{y[x] -> -2/(-1 + x^2)}}"
+    );
+    assert_eq!(
+      interpret("DSolve[{y'[x] == y[x]^2, y[0] == 1}, y[x], x]").unwrap(),
+      "{{y[x] -> (1 - x)^(-1)}}"
+    );
+    assert_eq!(
+      interpret("DSolve[{y'[x] == y[x]^3, y[0] == 1}, y[x], x]").unwrap(),
+      "{{y[x] -> 1/Sqrt[1 - 2*x]}}"
+    );
+    // The x-factor may be any closed-form function of x, not just a monomial.
+    assert_eq!(
+      interpret("DSolve[{y'[x] == Cos[x] y[x]^2, y[0] == 1}, y[x], x]")
+        .unwrap(),
+      "{{y[x] -> (1 - Sin[x])^(-1)}}"
+    );
+    // A quotient separates too: y' == x/y.
+    assert_eq!(
+      interpret("DSolve[{y'[x] == x/y[x], y[0] == 1}, y[x], x]").unwrap(),
+      "{{y[x] -> Sqrt[1 + x^2]}}"
+    );
+    // `DSolve[…, y, x]` asks for the Function form.
+    assert_eq!(
+      interpret("DSolve[{y'[t] == -t y[t]^2, y[0] == 1}, y, t]").unwrap(),
+      "{{y -> Function[{t}, 2/(2 + t^2)]}}"
+    );
+    assert_eq!(
+      interpret("DSolve[{y'[t] == (t - t^3) y[t]^2, y[0] == 1}, y, t]")
+        .unwrap(),
+      "{{y -> Function[{t}, 4/(4 - 2*t^2 + t^4)]}}"
+    );
+  }
+
+  // Squaring away the square root when solving for y loses the branch, so the
+  // root that does not meet the initial condition has to be dropped: with
+  // y[0] == -1 the answer is the negative branch, not the positive one.
+  #[test]
+  fn separable_solution_picks_the_branch_the_condition_selects() {
+    assert_eq!(
+      interpret("DSolve[{y'[x] == x/y[x], y[0] == -1}, y[x], x]").unwrap(),
+      "{{y[x] -> -Sqrt[1 + x^2]}}"
     );
   }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21387,4 +21387,111 @@ SaveDefinitions -> True]";
       "the construction must still render with the new radii"
     );
   }
+
+  /// Regression for the shape a numerical-methods Demonstration uses: a
+  /// popup picks the right-hand side of `y' == f[t, y]`, `DSolve` draws the
+  /// exact solution, and a stepped polyline is overlaid on top of it. The
+  /// nonlinear choice (`-t y^2`) is separable but not linear in `y`, so
+  /// `DSolve` used to come back unevaluated and `y[t] /. DSolve[…]` failed
+  /// with `ReplaceAll::reps` — the widget still rendered, just silently
+  /// missing the exact curve it exists to compare against.
+  #[test]
+  fn demonstration_ode_comparison_manipulate_draws_the_exact_solution() {
+    let code = "Manipulate[\
+      Show[{\
+        Plot[Evaluate[y[t] /. exact[rhs, start, t]], {t, 0, 2}, \
+          PlotRange -> All], \
+        ListLinePlot[trail[rhs, start, steps], PlotRange -> All]\
+      }, ImageSize -> {300, 300}], \
+      {{rhs, decay, \"y'\"}, {decay -> \"-y\", quad -> \"-t y^2\"}, \
+        ControlType -> PopupMenu}, \
+      {{start, 1, \"y(0)\"}, 0.5, 2, 0.5}, \
+      {{steps, 4, \"steps\"}, 2, 8, 1}, \
+      Initialization :> (\
+        decay[t_, u_] := -u; \
+        quad[t_, u_] := -t u^2; \
+        exact[f_, u0_, t_] := DSolve[{y'[t] == f[t, y[t]], y[0] == u0}, y, t]; \
+        trail[f_, u0_, n_] := Module[{h, pts}, \
+          h = 2/n; pts = {{0, u0}}; \
+          Do[pts = Append[pts, \
+            {h i, Last[Last[pts]] + h f[h (i - 1), Last[Last[pts]]]}], \
+            {i, 1, n}]; \
+          pts]; \
+      )]";
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a popup plus two sliders should build a ManipulateState");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "both curves must render");
+
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, ["rhs", "start", "steps"]);
+
+    // The exact solution is a smooth `Plot`, so it renders as one polyline
+    // with hundreds of vertices; every other polyline in the picture is an
+    // axis tick (2 vertices) or the 5-point stepped trail. Counting the
+    // vertices of the longest one therefore says whether the exact curve is
+    // there at all — a plain polyline *count* would only move by one and
+    // could be matched by an extra tick.
+    let longest_curve = |s: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = s
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      let svg = woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&s.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the comparison plot must render");
+      svg
+        .match_indices("<polyline")
+        .filter_map(|(at, _)| {
+          let tag = &svg[at..svg[at..].find("/>")? + at];
+          let key = " points=\"";
+          let start = tag.find(key)? + key.len();
+          Some(tag[start..][..tag[start..].find('"')?].split(' ').count())
+        })
+        .max()
+        .unwrap_or(0)
+    };
+    let linear = longest_curve(&state);
+    assert!(
+      linear > 50,
+      "the linear choice's exact curve should be a smooth polyline, got \
+       {linear} vertices"
+    );
+
+    for control in &mut state.controls {
+      if let manipulate::ControlState::Discrete {
+        name,
+        current_index,
+        ..
+      } = control
+        && name == "rhs"
+      {
+        *current_index = 1;
+      }
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "the nonlinear choice must evaluate: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+    let nonlinear = longest_curve(&state);
+    assert!(
+      nonlinear > 50,
+      "the separable nonlinear choice must draw its exact curve too, got \
+       {nonlinear} vertices"
+    );
+  }
 }


### PR DESCRIPTION
Checking Woxi Studio against a random Wolfram Demonstrations Project notebook
(a comparison of leapfrog and other numerical methods for differential
equations) turned up one gap.

The demonstration lets you pick one of seven right-hand sides for
`y' == f[t, y]`, draws the exact solution with `DSolve`, and overlays the
polyline a chosen numerical method produces. Two of the seven equations have a
right-hand side that is nonlinear in `y` (`-x y^2` and `y^2 (x - x^3)`).
`DSolve`'s term classifier only understands equations linear in `y`, so it
turned those down and the whole equation came back unevaluated. The
demonstration's `y[t] /. DSolve[…]` then failed with `ReplaceAll::reps`, and
the exact-solution curve the widget exists to compare against was silently
missing from the plot — the widget still rendered, just without the reference
it is for.

Both equations are separable, so `DSolve` now falls back to quadrature when the
linear classifier rejects a first-order equation:

- the right-hand side is split into its `x`-only and `y`-only factors (bailing
  out when any factor mixes the two, which means it is not separable this way);
- each side is integrated, accepting only an antiderivative that actually
  closed — a residual `Integrate[…]` head ends the attempt;
- the initial condition pins the constant of integration;
- the resulting implicit relation is solved for `y`.

Solving loses branch information — squaring away a square root turns one root
into a `±` pair — so each candidate is checked back against the initial
condition and only the branch that condition selects is kept.

The general solution needs an arbitrary constant whose placement inside the
solved form Woxi does not reproduce yet, so an equation with **no** initial
condition still returns unevaluated exactly as before. The existing tests
asserting that are unchanged.

```wolfram
DSolve[{y'[t] == -t y[t]^2, y[0] == 1}, y, t]
(* {{y -> Function[{t}, 2/(2 + t^2)]}} *)

DSolve[{y'[t] == (t - t^3) y[t]^2, y[0] == 1}, y, t]
(* {{y -> Function[{t}, 4/(4 - 2*t^2 + t^4)]}} *)
```

## Tests

- Unit tests for the separable initial-value problems, covering a monomial
  `x`-factor, a transcendental one (`Cos[x] y^2`), a quotient (`x/y`), higher
  powers (`y^3`), and both the `y[x]` and `y` (Function form) result shapes.
- A unit test for branch selection: with `y[0] == -1`, `y' == x/y` must give
  `-Sqrt[1 + x^2]`, not the positive root.
- A CLI documentation test in `tests/cli/symbolic/DSolve.md`.
- A Woxi Studio regression test reproducing the demonstration's *shape* — a
  popup switching the right-hand side, an exact `DSolve` curve, a stepped
  polyline overlaid — asserting that the nonlinear choice draws a smooth
  many-vertex curve rather than only the numeric trail. (Written from scratch;
  no code from the notebook is reproduced.)

`cargo test --workspace` is green (25,482 interpreter tests plus the studio,
notebook, and CLI suites), and `cargo clippy --workspace --all-targets` is
clean.

## Noted, not fixed

`Solve[c*Sqrt[u] == rhs, u]` with a symbolic `rhs` and a coefficient on the
radical (`2 Sqrt[u] == 3 + x`) returns unevaluated: the radical solver clears
the root correctly but cannot verify the candidate back through
`Sqrt[(3 + x)^2/4]` without a sign assumption, so it drops it. That makes
`DSolve[{y'[x] == Sqrt[y[x]], y[1] == 4}, y[x], x]` stay unevaluated. It is a
pre-existing `Solve` limitation in a different subsystem, unrelated to the
notebook, and fixing it means teaching the radical check about signs — left
out of this change rather than half-done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgjs8tjaxLgeYrQrWhWB1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wgjs8tjaxLgeYrQrWhWB1q)_