### PR TITLE
Suppress spurious NIntegrate message from a discarded endpoint sample

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -15397,7 +15397,20 @@ pub fn nintegrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::functions::math_ast::try_eval_to_f64(&evaluated)
         .filter(|v| v.is_finite())
     };
-    if let Some(v) = raw(x) {
+    // Evaluate the literal point quietly: a removable singularity there (e.g.
+    // Sin[x]/x at x = 0, or this same quotient once an adaptive-quadrature
+    // fallback lands one of its subdivision endpoints exactly on it) yields
+    // Indeterminate/ComplexInfinity, which would otherwise emit a spurious
+    // `Power::infy`-style message for a sample that is about to be discarded
+    // and replaced by the perturbed value below. Snapshot/restore the message
+    // buffers around the probe (push_quiet only silences printing, not
+    // capture).
+    let snapshot = crate::snapshot_warnings();
+    crate::push_quiet();
+    let direct = raw(x);
+    crate::pop_quiet();
+    crate::restore_warnings(snapshot);
+    if let Some(v) = direct {
       return Some(v);
     }
     let d = x.abs().max(1.0) * 1e-10;

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -4787,9 +4787,17 @@ mod nintegrate {
     clear_state();
     let result = interpret("NIntegrate[Sin[x]^2/x^2, {x, 0, 15000}]").unwrap();
     let val: f64 = result.parse().unwrap();
+    // ∫₀^∞ Sin[x]^2/x^2 dx = Pi/2; truncating at 15000 drops a tail bounded
+    // by 1/15000 (Sin^2 <= 1), on the order of 1e-4. The adaptive-Simpson
+    // fallback used for this wide, highly oscillatory interval is not itself
+    // fully accurate — that inaccuracy is a separate, pre-existing limitation
+    // — so this checks against the true value with a tolerance loose enough
+    // to not pin the fallback's current error as correct, while still
+    // catching a grossly wrong (e.g. zero or divergent) result.
+    let true_value = std::f64::consts::FRAC_PI_2 - 1.0 / 30000.0;
     assert!(
-      (val - 1.5716742354706954).abs() < 1e-6,
-      "got {val}, expected ~1.5716742354706954"
+      (val - true_value).abs() < 2e-3,
+      "got {val}, expected ~{true_value}"
     );
     let msgs = woxi::get_captured_messages_raw();
     assert!(

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -4774,6 +4774,30 @@ mod nintegrate {
     );
   }
 
+  // Over an interval wide enough that tanh-sinh's endpoint-crowded nodes
+  // never resolve the interesting region near a removable singularity, it
+  // gives up and falls back to adaptive Simpson — which, unlike tanh-sinh,
+  // samples the literal endpoint. That endpoint evaluation (Sin[0.]^2 /
+  // 0.^2) is discarded and replaced by a nearby perturbed value, exactly
+  // like the small-interval case above, but it used to also print a
+  // spurious `Power::infy` for the discarded sample before being thrown
+  // away — a message wolframscript never shows for this integral.
+  #[test]
+  fn wide_interval_removable_singularity_prints_no_spurious_message() {
+    clear_state();
+    let result = interpret("NIntegrate[Sin[x]^2/x^2, {x, 0, 15000}]").unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 1.5716742354706954).abs() < 1e-6,
+      "got {val}, expected ~1.5716742354706954"
+    );
+    let msgs = woxi::get_captured_messages_raw();
+    assert!(
+      msgs.iter().all(|m| !m.contains("Power::infy")),
+      "spurious message for a discarded endpoint sample: {msgs:?}"
+    );
+  }
+
   // Smooth integrands keep their accuracy, including the oscillatory ones that
   // fall back to the adaptive rule because tanh-sinh does not settle on them.
   #[test]


### PR DESCRIPTION
## Summary

- Checked Woxi Studio's support for a randomly downloaded Wolfram Demonstrations Project notebook ("Heat Capacity of Solids in the Debye Approximation"). The `Manipulate` rendered correctly — the live plot matched the notebook's embedded reference snapshot (controls, curve shapes, colors, frame/plot labels all correct).
- Running it did surface one divergence from `wolframscript`: `NIntegrate` spuriously printed a `Power::infy`-style message. Its adaptive-Simpson fallback (used when tanh-sinh quadrature doesn't converge — e.g. over an interval much wider than the region where the integrand is non-negligible) samples the literal interval endpoints. When one lands exactly on a removable singularity of the integrand, the sample is correctly detected as non-finite, discarded, and replaced by a perturbed nearby value — but the message raised while evaluating that discarded sample still printed, which `wolframscript` never does for these integrals.
- Fixed in `src/functions/calculus_ast.rs`'s `nintegrate_ast`: the literal-point probe inside the `eval_at` closure is now evaluated under `push_quiet`/`snapshot_warnings`/`restore_warnings`, discarding any message it raised — the same pattern already used a few hundred lines earlier in the same file for `Series`' removable-singularity probe.
- Added a regression test (`wide_interval_removable_singularity_prints_no_spurious_message` in `tests/interpreter_tests/calculus.rs`) using a generic `Sin[x]^2/x^2` example over a wide interval, not copied from the notebook.

## Test plan

- [x] `make test` — all 27588 tests pass
- [x] `make format`
- [x] Manually verified `./target/release/woxi eval 'NIntegrate[Sin[x]^2/x^2, {x, 0, 15000}]'` prints no message and returns the same numeric value before/after the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPhFBZdXY1wCzghZcxQhh7)_