### PR TITLE
Paint nothing for Invisible[...]-wrapped Text labels

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -288,6 +288,14 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
   if let Some(inner) = text_wrapper_content(expr) {
     return parse_styled_label(inner);
   }
+  // `Invisible[…]` paints nothing — a Demonstration wraps a `Text[…]`
+  // label in it to hide one item (e.g. a hidden edge's name) while keeping
+  // the surrounding code uniform across all items. Falling through to the
+  // catch-all below would instead typeset the wrapper itself as literal
+  // text ("Invisible[e]"), so peel and drop it here.
+  if crate::functions::graphics::peel_invisible(expr).is_some() {
+    return None;
+  }
   // A `Grid`/`Column` title stacks: each row becomes its own line. This is
   // how a Demonstration writes a two-line plot title (the function above,
   // the transformed one below).

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -3210,11 +3210,24 @@ fn apply_agreed_row_part_styles(content: &Expr, style: &mut StyleState) {
 
 fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
   // Text[str, {x, y}] or Text[Style[str, ...], {x, y}]
+  //
+  // `Invisible[…]` paints nothing — a Demonstration wraps one item's label
+  // in it to hide it while keeping a shared `Table[Text[label[[i]], …], …]`
+  // loop uniform across items. It can nest either way
+  // (`Invisible[Style[…]]` or `Style[Invisible[…], …]`), so peel it off
+  // both before and after the `Style` peel below and, either way, skip the
+  // primitive entirely rather than falling through to the catch-all in
+  // `graphics_text_content`, which would typeset the wrapper's own
+  // textual form (`Invisible[e]`) as a literal on-screen label.
+  let (first_arg, mut hidden) = match peel_invisible(&args[0]) {
+    Some(inner) => (inner, true),
+    None => (&args[0], false),
+  };
   let mut local_style = style.clone();
   // `Framed[content, opts…]` boxes the label: a border around it and, with
   // `Background -> colour`, a panel behind it. Peel it off first so the
   // `Style` directives it usually wraps still reach the primitive.
-  let (framed_body, frame_opts) = match &args[0] {
+  let (framed_body, frame_opts) = match first_arg {
     Expr::FunctionCall { name, args: fargs }
       if name == "Framed" && !fargs.is_empty() =>
     {
@@ -3237,6 +3250,17 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     }
     other => other,
   };
+  // `Style[Invisible[…], dirs…]` — the wrapper inside the styling.
+  let content = match peel_invisible(content) {
+    Some(inner) => {
+      hidden = true;
+      inner
+    }
+    None => content,
+  };
+  if hidden {
+    return;
+  }
   // A label written as a `Row` of styled parts — the `f(x)` a
   // Demonstration writes beside a point — carries its font directives on
   // the parts rather than on the label itself. The label is drawn as one

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1653,6 +1653,41 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_invisible_text_label_paints_nothing() {
+    // `Text[Invisible[Style["e", …]], pos]` — a Demonstration hides one
+    // item's label (e.g. an edge whose name shouldn't show) by wrapping it
+    // in `Invisible[…]` rather than special-casing it out of a shared
+    // `Table[Text[label[[i]], …], {i, …}]` loop. Regression: `Invisible[…]`
+    // was not recognized by the label parser shared across 2D and 3D
+    // `Text[…]`/chart labels, so it fell through to the catch-all branch
+    // and typeset the wrapper's own textual form, `Invisible[e]`, as a
+    // literal on-screen label instead of painting nothing.
+    clear_state();
+    let svg2d = interpret(
+      "ExportString[Graphics[{Text[\"A\", {0, 0}], Text[Invisible[Style[\"e\", 16]], {1, 1}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(svg2d.contains(">A<"), "visible label lost: {svg2d}");
+    assert!(
+      !svg2d.contains("Invisible"),
+      "Invisible[…] label leaked as literal text: {svg2d}"
+    );
+    assert!(!svg2d.contains(">e<"), "hidden label was painted: {svg2d}");
+
+    clear_state();
+    let svg3d = interpret(
+      "ExportString[Graphics3D[{Text[\"A\", {0, 0, 0}], Text[Invisible[Style[\"e\", 16]], {1, 1, 1}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(svg3d.contains(">A<"), "visible label lost: {svg3d}");
+    assert!(
+      !svg3d.contains("Invisible"),
+      "Invisible[…] label leaked as literal text: {svg3d}"
+    );
+    assert!(!svg3d.contains(">e<"), "hidden label was painted: {svg3d}");
+  }
+
+  #[test]
   fn test_inset_labeled_graphic_embeds_picture() {
     // `Inset[Labeled[Graphics[…], caption], pos, opos, size]` — a
     // Demonstration's usual way to caption a small diagram composited into


### PR DESCRIPTION
## Summary

This run's random Wolfram Demonstration was ["Altitude of a Tetrahedron Given Its Edges"](https://demonstrations.wolfram.com/AltitudeOfATetrahedronGivenItsEdges/). Its `Manipulate` labels each of the tetrahedron's six edges by indexing into a shared list:

```
edlabels = {Style["a", ...], Style["b", ...], ..., Invisible[Style["e", ...]], Style["f", ...]}
...
Table[Text[edlabels[[i]], mids[[i]], {-1, -1}], {i, 1, 3}]
```

One edge's label is wrapped in `Invisible[...]` to hide it while keeping the `Table`/`Text` loop uniform across all six edges — a common Demonstration idiom. Neither the shared 2D/3D chart-label parser (`parse_styled_label` in `chart.rs`, used by `Graphics3D`'s `Text[...]` primitive) nor `Graphics`'s own 2D `Text[...]` primitive parser recognized the `Invisible` wrapper, so both fell through to the catch-all branch and typeset the wrapper's own textual form, `Invisible[e]`, as a literal on-screen label instead of painting nothing.

- `src/functions/chart.rs`: `parse_styled_label` now peels a top-level `Invisible[...]` and returns `None` (no label), matching the existing `peel_invisible` handling already used for `Grid`/`Column` cells.
- `src/functions/graphics.rs`: `parse_text` (2D `Graphics`) now peels `Invisible[...]` in both nesting orders (`Invisible[Style[...]]` and `Style[Invisible[...], ...]`) and skips pushing the text primitive entirely when found.
- `tests/interpreter_tests.rs`: added `test_invisible_text_label_paints_nothing`, covering both the 2D and 3D `Text[Invisible[...], ...]` cases.

Verified visually by rendering the downloaded notebook's `Manipulate` through Woxi Studio's `dump_manipulate` diagnostic — before the fix the tetrahedron picture showed a literal "Invisible[e]" label; after the fix it's gone while the other five edge labels (a, b, c, d, f) still render.

## Test plan
- [x] `make test` — all 27,588 tests pass
- [x] `make format`
- [x] New regression test `test_invisible_text_label_paints_nothing` passes
- [x] Rendered the downloaded Demonstration notebook through `cargo run --example dump_manipulate -p woxi-studio` before/after and visually confirmed the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01SkaiY2nHojjXRac35FwAQB)_