### PR TITLE
Render doubly-nested inline-math cells instead of leaking box syntax

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1472,6 +1472,26 @@ fn render_boxes_text(s: &str) -> String {
       .collect::<String>();
   }
 
+  // A `TextData[...]` run inside a box tree (e.g. one inline-math cell's
+  // argument accidentally wraps another whole cell — an artifact of
+  // copy/pasting one formula into another in the FrontEnd). Its content
+  // follows the same prose conventions as a top-level `TextData[...]`, so
+  // reuse that extractor rather than treating it as an opaque box.
+  if let Some(inner) = s
+    .strip_prefix("TextData[")
+    .and_then(|r| r.strip_suffix(']'))
+  {
+    return extract_textdata(inner);
+  }
+
+  // A `Cell[...]` nested inside a box tree — the same accidental-nesting
+  // artifact from the other side (a `FormBox` argument that is itself a
+  // whole inline-math `Cell[...]`). `render_text_element` already knows
+  // how to unwrap an inline-math/inline-formula cell's content.
+  if s.starts_with("Cell[") {
+    return render_text_element(s);
+  }
+
   // Superscripts of digits (and a leading minus) read best as Unicode
   // superscript characters: `V²`, `∇²`, `10⁻³`.
   fn superscript_unicode(s: &str) -> Option<String> {
@@ -4523,6 +4543,37 @@ Cell[TextData[Cell[BoxData[
     match &parsed.cells[0] {
       CellEntry::Single(cell) => {
         assert_eq!(cell.content, "{U \u{2192} P\nV \u{2192} Q");
+      }
+      CellEntry::Group(_) => panic!("Expected single cell"),
+    }
+  }
+
+  #[test]
+  fn test_doubly_nested_inline_math_cell_renders_its_formula() {
+    // The FrontEnd occasionally saves an inline-math cell whose `FormBox`
+    // argument is itself a whole `Cell[TextData[Cell[BoxData[...]]]]` —
+    // an artifact of pasting one inline formula's cell into another's box
+    // slot. The nested cell must still resolve to its formula text
+    // instead of leaking the raw box source into the surrounding prose.
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "the potential is ",
+ Cell[BoxData[
+  FormBox[Cell[TextData[Cell[BoxData[
+    FormBox[
+     RowBox[{
+      RowBox[{"V", "(", "x", ")"}], "=", "0"}], TraditionalForm]],
+    "InlineMath",ExpressionUUID->"11111111-1111-1111-1111-111111111111"]],
+    "InlineMath",ExpressionUUID->"22222222-2222-2222-2222-222222222222"],
+   TraditionalForm]], "InlineMath",ExpressionUUID->
+  "33333333-3333-3333-3333-333333333333"],
+ " elsewhere."
+}], "Text"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.content, "the potential is V(x)=0 elsewhere.");
       }
       CellEntry::Group(_) => panic!("Expected single cell"),
     }


### PR DESCRIPTION
## Summary

- Fetched a random Wolfram Demonstration notebook ("Exact Solution for Rectangular Double-Well Potential") via the resource system's random-page API and checked whether Woxi Studio fully supports it.
- The notebook's core `Manipulate` (4 controls: `a`, `v`, `s`, `n`) evaluated cleanly with correct control types, and all embedded snapshot graphics decoded and rendered — but one prose cell leaked raw Wolfram box syntax instead of readable text.
- Root cause: the notebook contains an inline-math cell whose `FormBox` argument is itself a whole `Cell[TextData[Cell[BoxData[...]]]]` (an artifact of pasting one formula's cell into another's box slot). `render_boxes_text` in `src/notebook.rs` had no case for a `Cell[...]` or `TextData[...]` node appearing inside a box tree, so it fell through to the raw-source fallback.
- Fix: `render_boxes_text` now recognizes a nested `TextData[...]` (delegating to the existing `extract_textdata` prose extractor) and a nested `Cell[...]` (delegating to `render_text_element`, which already knows how to unwrap inline-math/inline-formula cells).
- Added a regression test (`test_doubly_nested_inline_math_cell_renders_its_formula`) covering the general doubly-nested-cell pattern, independently written rather than copied from the (copyrighted) source notebook.

## Test plan

- [x] `make test` — all 27,588 tests pass
- [x] `make format`
- [x] Verified against the actual downloaded Demonstration notebook: the previously garbled caption text now reads "...V(x)=∞ for x<0 and x>π, V(x)=V_0 for π/2-a/2⩽x⩽π/2+a/2, and V(x)=0 elsewhere." with no leaked box syntax anywhere in the notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW56VWQh5H46hL6AiTcKw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW56VWQh5H46hL6AiTcKw6)_