### PR TITLE
Render VerticalSlider controls vertically and typeset TraditionalForm PopupMenu labels

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16818,6 +16818,9 @@ pub enum ManipulateControl {
     /// integer unchanged. A control whose whole spec is exact integers
     /// (`{{n, 5, "n"}, 1, 10, 1}`) keeps binding exact integers throughout.
     is_real: bool,
+    /// `ControlType -> VerticalSlider`: draw the slider running bottom-to-top
+    /// instead of Wolfram's default left-to-right rail.
+    orientation: ControlOrientation,
   },
   Discrete {
     name: String,
@@ -17094,6 +17097,15 @@ impl ControlPlacement {
       _ => None,
     }
   }
+}
+
+/// A continuous control's rail direction, from `ControlType -> Slider` (the
+/// default) vs `ControlType -> VerticalSlider`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ControlOrientation {
+  #[default]
+  Horizontal,
+  Vertical,
 }
 
 /// Result of parsing a single list-shaped Manipulate argument.
@@ -19003,6 +19015,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       ..Default::default()
     }],
     is_real: false,
+    orientation: ControlOrientation::Horizontal,
   };
   Some(ManipulateSpec {
     body_code,
@@ -19086,6 +19099,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
       ..Default::default()
     }],
     is_real,
+    orientation: ControlOrientation::Horizontal,
   };
   Some(ManipulateSpec {
     body_code: var,
@@ -21091,6 +21105,11 @@ fn parse_manipulate_control(
     Some("Animator") => Some(true),
     _ => None,
   };
+  let orientation = if control_type.as_deref() == Some("VerticalSlider") {
+    ControlOrientation::Vertical
+  } else {
+    ControlOrientation::Horizontal
+  };
 
   // `{u, umin, umax}` with umin > umax is a documented reversed-direction
   // slider (e.g. an angle control counting down from a positive start to a
@@ -21112,6 +21131,7 @@ fn parse_manipulate_control(
       label,
       label_runs,
       is_real,
+      orientation,
     },
     enabled,
     min_code,
@@ -21231,9 +21251,9 @@ fn is_text_layout_head(name: &str) -> bool {
 }
 
 /// Rendered SVG for a discrete-choice label that is a graphic (e.g.
-/// `"+" -> myIcon[2]` in a Demonstrations crosshair picker). A held
-/// `Graphics[…]` call or a call producing one is evaluated; anything
-/// text-like yields `None`.
+/// `"+" -> myIcon[2]` in a Demonstrations crosshair picker) or a
+/// `TraditionalForm[…]`-typeset expression. A held `Graphics[…]` call or a
+/// call producing one is evaluated; anything else text-like yields `None`.
 fn discrete_choice_label_svg(label: &Expr) -> Option<String> {
   match label {
     Expr::Graphics { svg, .. } => Some(svg.clone()),
@@ -21254,6 +21274,14 @@ fn discrete_choice_label_svg(label: &Expr) -> Option<String> {
     // (e.g. `Show[ColorData[name, "Image"], ImageSize -> 100]`) recurses
     // into the raster arm above.
     //
+    // `TraditionalForm[expr]` typesets conventional math notation (stacked
+    // fractions, radicals, …) through the same box pipeline `ExportString`
+    // and cell output use, rather than falling back to flattened text.
+    Expr::FunctionCall { name, args }
+      if name == "TraditionalForm" && args.len() == 1 =>
+    {
+      form_box_svg(&args[0])
+    }
     // Text layout heads never become icons: `Column[{"…", "…"}]` has no
     // graphical meaning, and evaluating it only yields the typeset echo of
     // its own source — which would put the label's InputForm on the button.
@@ -23511,5 +23539,151 @@ mod manipulate_control_placement_tests {
       "the layout template must not become a third, blank-labeled control: {:?}",
       spec.controls
     );
+  }
+}
+
+#[cfg(test)]
+mod manipulate_control_orientation_tests {
+  use super::*;
+
+  fn orientation(code: &str) -> ControlOrientation {
+    let expr = crate::parse_to_expr(code).expect("parse");
+    let spec = extract_manipulate_spec(&expr).expect("extract spec");
+    match spec.controls.first() {
+      Some(ManipulateControl::Continuous { orientation, .. }) => *orientation,
+      other => panic!("expected a continuous control, got {other:?}"),
+    }
+  }
+
+  /// Wolfram's default is a left-to-right rail, so a slider that says
+  /// nothing about its `ControlType` keeps the horizontal orientation.
+  #[test]
+  fn plain_slider_defaults_to_horizontal() {
+    assert_eq!(
+      orientation("Manipulate[a, {a, 0, 1}]"),
+      ControlOrientation::Horizontal
+    );
+  }
+
+  /// `ControlType -> VerticalSlider` given as an option rule is recorded on
+  /// the control, not just accepted as a parseable-but-ignored keyword.
+  #[test]
+  fn vertical_slider_option_rule_is_recorded() {
+    assert_eq!(
+      orientation("Manipulate[a, {a, 0, 1, ControlType -> VerticalSlider}]"),
+      ControlOrientation::Vertical
+    );
+  }
+
+  /// The bare-marker spelling (`{u, min, max, VerticalSlider}`, no
+  /// `ControlType ->`) is Wolfram's shorthand for the same option.
+  #[test]
+  fn vertical_slider_bare_marker_is_recorded() {
+    assert_eq!(
+      orientation("Manipulate[a, {a, 0, 1, VerticalSlider}]"),
+      ControlOrientation::Vertical
+    );
+  }
+
+  /// A fully labelled, stepped spec (`{{u, uinit, ulbl}, min, max, du,
+  /// ControlType -> VerticalSlider}` — the shape a "morph" control in a
+  /// side control panel typically takes) still carries the orientation
+  /// through to the built control, not just the terse 2-item form above.
+  #[test]
+  fn labelled_stepped_vertical_slider_is_recorded() {
+    assert_eq!(
+      orientation(
+        "Manipulate[a, {{a, 0.5, \"morph\"}, 0, 1, 0.01, \
+         ControlType -> VerticalSlider}]"
+      ),
+      ControlOrientation::Vertical
+    );
+  }
+}
+
+#[cfg(test)]
+mod manipulate_traditional_form_choice_svg_tests {
+  use super::*;
+
+  fn discrete_control(code: &str) -> ManipulateControl {
+    let expr = crate::parse_to_expr(code).expect("parse");
+    let spec = extract_manipulate_spec(&expr).expect("extract spec");
+    spec.controls.into_iter().next().expect("one control")
+  }
+
+  /// A PopupMenu rule label wrapped in `TraditionalForm[…]` (the "choose a
+  /// formula, see it typeset" idiom several Demonstrations use — original
+  /// expressions here, not copied from any specific one) must render as a
+  /// typeset icon rather than falling back to flattened InputForm-ish text,
+  /// exactly like a `Graphics[…]` rule label already does.
+  #[test]
+  fn traditional_form_labels_render_as_distinct_svg_icons() {
+    let control = discrete_control(
+      "Manipulate[shape, \
+       {{shape, quad, \"shape\"}, \
+        {quad -> TraditionalForm[t^2], \
+         recip -> TraditionalForm[1/t], \
+         root -> TraditionalForm[Sqrt[4 - t^2]]}, \
+        ControlType -> PopupMenu}]",
+    );
+    match &control {
+      ManipulateControl::Discrete {
+        values,
+        value_labels,
+        value_label_svgs,
+        popup,
+        ..
+      } => {
+        assert!(*popup, "ControlType -> PopupMenu must render a dropdown");
+        assert_eq!(values, &["quad", "recip", "root"]);
+        // The icon takes over the label column; the fallback text (shown by
+        // a non-graphical frontend) is the bound value's own name, not the
+        // TraditionalForm math that leaked through pre-fix.
+        assert_eq!(value_labels, &["quad", "recip", "root"]);
+        let svgs: Vec<&str> = value_label_svgs
+          .iter()
+          .map(|s| {
+            s.as_deref().unwrap_or_else(|| {
+              panic!(
+                "TraditionalForm label must render an icon: {value_label_svgs:?}"
+              )
+            })
+          })
+          .collect();
+        for svg in &svgs {
+          assert!(svg.starts_with("<svg"), "not a rendered SVG: {svg}");
+          assert!(
+            svg.len() > 100,
+            "typeset math should be more than a trivial placeholder: {svg}"
+          );
+        }
+        assert_ne!(svgs[0], svgs[1], "t^2 and 1/t must typeset differently");
+        assert_ne!(
+          svgs[1], svgs[2],
+          "1/t and Sqrt[4 - t^2] must typeset differently"
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  /// A plain (non-`TraditionalForm`) rule label still flattens to text, not
+  /// an icon — the new branch must not swallow every discrete choice.
+  #[test]
+  fn plain_text_labels_still_have_no_icon() {
+    let control = discrete_control(
+      "Manipulate[shape, {{shape, a, \"shape\"}, {a -> \"alpha\", b -> \"beta\"}}]",
+    );
+    match &control {
+      ManipulateControl::Discrete {
+        value_label_svgs, ..
+      } => {
+        assert!(
+          value_label_svgs.iter().all(Option::is_none),
+          "plain string labels must not grow icons: {value_label_svgs:?}"
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
   }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -19346,6 +19346,7 @@ mod manipulate {
         label,
         label_runs,
         is_real,
+        orientation,
       } => {
         assert_eq!(name, "x");
         assert_eq!(*min, 0.0);
@@ -19353,6 +19354,10 @@ mod manipulate {
         assert!(step.is_none());
         assert_eq!(*initial, 0.0); // umin when no uinit
         assert_eq!(label, "x");
+        assert_eq!(
+          *orientation,
+          woxi::functions::graphics::ControlOrientation::Horizontal
+        );
         // Unlabelled control → a single upright run of the variable name.
         assert_eq!(label_runs.len(), 1);
         assert_eq!(label_runs[0].text, "x");

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3897,29 +3897,51 @@ fn render_manipulate_widget<'a>(
         max,
         step,
         current,
+        orientation,
         ..
       } => {
         let label_widget =
           manipulate_label_widget(label_runs, label, label_col_width, enabled);
-        let mut s = slider(*min..=*max, *current, move |v| {
-          if enabled {
-            Message::ManipulateContinuousChanged(cell_idx, ctrl_idx, v)
-          } else {
-            Message::Noop
-          }
-        })
-        .step(*step)
-        .width(Fill);
-        if !enabled {
-          s = s.style(disabled_slider_style);
-        }
         let value_widget = text(format_manipulate_number(*current))
           .size(11)
           .font(Font::MONOSPACE)
           .width(iced::Length::Fixed(64.0));
-        let control_row = row![label_widget, s, value_widget]
-          .align_y(Center)
-          .spacing(8);
+        let control_row =
+          if *orientation == manipulate::ControlOrientation::Vertical {
+            let mut s =
+              iced::widget::vertical_slider(*min..=*max, *current, move |v| {
+                if enabled {
+                  Message::ManipulateContinuousChanged(cell_idx, ctrl_idx, v)
+                } else {
+                  Message::Noop
+                }
+              })
+              .step(*step)
+              // Default `Fill` height collapses to 0 in this row's `Shrink` cross axis.
+              .height(120.0);
+            if !enabled {
+              s = s.style(disabled_slider_style);
+            }
+            row![label_widget, s, value_widget]
+              .align_y(Center)
+              .spacing(8)
+          } else {
+            let mut s = slider(*min..=*max, *current, move |v| {
+              if enabled {
+                Message::ManipulateContinuousChanged(cell_idx, ctrl_idx, v)
+              } else {
+                Message::Noop
+              }
+            })
+            .step(*step)
+            .width(Fill);
+            if !enabled {
+              s = s.style(disabled_slider_style);
+            }
+            row![label_widget, s, value_widget]
+              .align_y(Center)
+              .spacing(8)
+          };
         controls_col = controls_col.push(control_row);
       }
       manipulate::ControlState::Discrete {
@@ -9914,6 +9936,53 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn popup_menu_traditional_form_labels_render_as_typeset_svg() {
+    // Regression: a PopupMenu choice label wrapped in `TraditionalForm[…]`
+    // (the "pick a formula" idiom several Demonstrations use, independently
+    // written here rather than copied from any specific one) used to fall
+    // back to flattened InputForm-ish text (`is_text_layout_head` bailed the
+    // SVG path for TraditionalForm) instead of a typeset fraction/radical
+    // icon the way a `Graphics[…]` rule label already got one.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[shape, \
+       {{shape, quad, \"choose a shape\"}, \
+        {quad -> TraditionalForm[t^2], \
+         recip -> TraditionalForm[1/t], \
+         root -> TraditionalForm[Sqrt[4 - t^2]]}, \
+        ControlType -> PopupMenu}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the TraditionalForm-labelled PopupMenu must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete {
+        values,
+        value_labels,
+        value_label_svgs,
+        popup,
+        ..
+      } => {
+        assert!(*popup, "ControlType -> PopupMenu must render a dropdown");
+        assert_eq!(values, &["quad", "recip", "root"]);
+        // The icon replaces the label column; the fallback text shown by a
+        // non-graphical frontend is the bound value's own name, not the
+        // TraditionalForm math (which is what leaked through pre-fix).
+        assert_eq!(value_labels, &["quad", "recip", "root"]);
+        assert!(
+          value_label_svgs.iter().all(Option::is_some),
+          "every TraditionalForm choice must carry a rendered icon: {value_label_svgs:?}"
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  #[test]
   fn parametric_curves_manipulate_lays_out_its_plots() {
     // End-to-end regression for "Parametric Curves in 2D": four plots are
     // `Inset` into one picture, and the `t` slider is bounded by symbols
@@ -12093,6 +12162,7 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
       step: 0.1,
       current: 0.0,
       is_real: false,
+      orientation: manipulate::ControlOrientation::Horizontal,
     };
     let empty = manipulate::ControlState::Continuous {
       name: "theta".to_string(),
@@ -12103,6 +12173,7 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
       step: 0.1,
       current: 0.0,
       is_real: false,
+      orientation: manipulate::ControlOrientation::Horizontal,
     };
     assert_eq!(manipulate_label_char_count(&m1), 2);
     assert_eq!(manipulate_label_char_count(&empty), 0);

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -8,7 +8,7 @@
 //! that free control variables are substituted.
 
 use iced::widget::svg;
-pub use woxi::functions::graphics::ControlPlacement;
+pub use woxi::functions::graphics::{ControlOrientation, ControlPlacement};
 use woxi::functions::graphics::{
   DisplayNode, LabelRun, ManipulateControl, ManipulateSpec,
   apply_manipulate_mutations, build_manipulate_display, extract_animator_spec,
@@ -37,6 +37,9 @@ pub enum ControlState {
     /// rather than the exact integer, matching Wolfram — which matters for
     /// a caption that formats it with `NumberForm[…, {n, f}]`.
     is_real: bool,
+    /// `ControlType -> VerticalSlider`: rendered with `vertical_slider`
+    /// instead of the default horizontal `slider`.
+    orientation: ControlOrientation,
   },
   Discrete {
     name: String,
@@ -1048,6 +1051,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         step,
         initial,
         is_real,
+        orientation,
       } => {
         let step = step.unwrap_or_else(|| {
           let span = (*max - *min).abs();
@@ -1062,6 +1066,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           step,
           current: *initial,
           is_real: *is_real,
+          orientation: *orientation,
         }
       }
       ManipulateControl::Discrete {


### PR DESCRIPTION
## Summary

While checking Woxi Studio against a randomly downloaded Wolfram Demonstration notebook ("Morphing the Graph of a Function to Its Domain", a `Manipulate` with a `PopupMenu` control over `symbol -> TraditionalForm[expr]` rules and a `VerticalSlider` control), two gaps surfaced:

- `ControlType -> VerticalSlider` parsed correctly but always rendered as an ordinary horizontal slider — the orientation was recognized as a keyword token but never carried through the pipeline into the Studio widget.
- A `PopupMenu` choice label wrapped in `TraditionalForm[...]` fell back to flattened plain text (e.g. `"x/(6*Sqrt[1 - x^2])"`) instead of typeset math, because `TraditionalForm` was treated as a text-layout head and bailed out of the SVG-icon path.

## Changes

- Added a `ControlOrientation` enum (`Horizontal`/`Vertical`) to `ManipulateControl::Continuous` in `src/functions/graphics.rs`, set from `ControlType -> VerticalSlider` (both the `ControlType -> ...` option-rule spelling and the bare-marker spelling), and threaded it through `woxi-studio/src/manipulate.rs`'s `ControlState::Continuous`.
- `woxi-studio/src/main.rs` now renders a vertical control with `iced::widget::vertical_slider` instead of `iced::widget::slider`.
- `discrete_choice_label_svg` in `src/functions/graphics.rs` now delegates `TraditionalForm[...]` labels to the existing `form_box_svg` helper — the same box-layout-to-SVG pipeline used by `ExportString[..., "SVG"]` and cell output — rather than duplicating typesetting logic, per this repo's rule against implementing a construct twice.

## Tests

- `src/functions/graphics.rs`: new `manipulate_control_orientation_tests` (default horizontal, `ControlType -> VerticalSlider` option rule, bare marker, labelled/stepped spec) and `manipulate_traditional_form_choice_svg_tests` (distinct typeset SVG icons for different `TraditionalForm` expressions; plain string labels still get no icon).
- `tests/interpreter_tests/graphics.rs`: updated an exhaustive `ManipulateControl::Continuous` destructure for the new field.
- `woxi-studio/src/main.rs`: end-to-end `popup_menu_traditional_form_labels_render_as_typeset_svg` test via `ManipulateState::from_expr`.

All test cases are original, not copied from the source notebook (which is copyrighted).

## Test plan

- [x] `cargo build -p woxi` and `cargo build -p woxi-studio` succeed
- [x] New unit tests pass (`cargo test -p woxi --lib manipulate_control_orientation_tests`, `manipulate_traditional_form_choice_svg_tests`)
- [x] Full `cargo test -p woxi-studio` (185 tests) passes
- [x] Full `cargo test` for the `woxi` crate (lib, cli_tests, interpreter_tests, miscellaneous_tests, script_snapshot_tests) passes with 0 failures
- [x] `make format` run, only touching the 4 files already in this diff

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2c7mNwoguxfXrjUi665hc)_