### PR TITLE
Implement Attributes bitmask, part 2

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -927,20 +927,20 @@ fn reorder_orderless_pattern_args(pattern: Expr) -> Expr {
 }
 
 #[allow(clippy::if_not_else)]
-pub fn get_attributes(expr: &Expr) -> Option<Vec<String>> {
+pub fn get_attributes(expr: &Expr) -> Option<u32> {
   // Extract attribute names from the value
   let attr_exprs = match expr {
     Expr::List(items) => items.clone(),
     _ => vec![expr.clone()].into(),
   };
 
-  let mut valid_attrs = Vec::new();
+  let mut valid_attrs = 0u32;
   let mut has_error = false;
   for attr_expr in &attr_exprs {
     if let Expr::Identifier(attr_name) = attr_expr {
       let mask_val = Attributes::mask(attr_name);
       if mask_val != Attributes::None {
-        valid_attrs.push(attr_name.clone());
+        valid_attrs |= mask_val;
       } else {
         // Unknown attribute — emit warning
         crate::emit_message(&format!(
@@ -971,7 +971,7 @@ fn set_attributes_from_value(
   rhs_value: &Expr,
 ) -> crate::syntax::Expr {
   // Check if symbol is locked
-  let is_locked = crate::func_attrs_contains(sym_name, "Locked");
+  let is_locked = crate::func_attrs_contains(sym_name, Attributes::Locked);
   if is_locked {
     crate::emit_message(&format!(
       "Attributes::locked: Symbol {sym_name} is locked."
@@ -984,8 +984,9 @@ fn set_attributes_from_value(
   };
 
   // Replace all user-defined attributes for this symbol
+  let attr = Attributes::new(valid_attrs);
   crate::FUNC_ATTRS.with(|m| {
-    m.borrow_mut().insert(sym_name.to_string(), valid_attrs);
+    m.borrow_mut().insert(sym_name.to_string(), attr);
   });
 
   rhs_value.clone()
@@ -1443,12 +1444,13 @@ fn is_downvalue_head_protected(name: &str) -> bool {
   if is_value_redirect_head(name) {
     return false;
   }
-  let was_unprotected = crate::func_attrs_removed_contains(name, "Protected");
+  let was_unprotected =
+    crate::func_attrs_removed_contains(name, Attributes::Protected);
   if was_unprotected {
     return false;
   }
   attributes::get_builtin_attributes_mask(name).contains(Attributes::Protected)
-    || crate::func_attrs_contains(name, "Protected")
+    || crate::func_attrs_contains(name, Attributes::Protected)
 }
 
 /// Flatten a left-associative chain of `BinaryOp { op: Times, .. }` into

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 // Wolfram attributes
+#[derive(Clone, Default)]
 pub struct Attributes(u32); // bitmask
 #[allow(non_upper_case_globals)]
 impl Attributes {
@@ -55,14 +56,30 @@ impl Attributes {
       Err(_) => Self::None,
     }
   }
+  pub fn masks(names: &Vec<String>) -> u32 {
+    let mut mask = 0u32;
+    for val in names {
+      mask |= Self::mask(val.as_str());
+    }
+    mask
+  }
   pub fn new(bits: u32) -> Self {
     Self(bits)
+  }
+  pub fn to_u32(&self) -> u32 {
+    self.0
   }
   pub fn is_empty(&self) -> bool {
     self.0 == 0
   }
-  pub fn contains(&self, flag: u32) -> bool {
-    (self.0 & flag) != 0
+  pub fn contains(&self, mask: u32) -> bool {
+    (self.0 & mask) != 0
+  }
+  pub fn add(&mut self, mask: u32) {
+    self.0 |= mask;
+  }
+  pub fn remove(&mut self, mask: u32) {
+    self.0 &= !mask;
   }
   pub fn to_vec(&self) -> Vec<&'static str> {
     let mut list: Vec<&'static str> = vec![];
@@ -421,10 +438,6 @@ fn is_unprotected_builtin(name: &str) -> bool {
 
 /// Returns the built-in attributes for a given symbol name.
 /// Attributes are returned in alphabetical order, matching wolframscript output.
-pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
-  get_builtin_attributes_mask(name).to_vec()
-}
-
 pub fn get_builtin_attributes_mask(name: &str) -> Attributes {
   use Attributes as A;
   let mask = match name {
@@ -943,7 +956,7 @@ pub fn dispatch_attributes(
           let mut attrs = m.borrow_mut();
           for func_name in &func_names {
             if let Some(existing) = attrs.get(func_name)
-              && existing.contains(&"Locked".to_string())
+              && existing.contains(Attributes::Locked)
             {
               crate::emit_message(&format!(
                 "Attributes::locked: Symbol {func_name} is locked."
@@ -951,22 +964,22 @@ pub fn dispatch_attributes(
               locked = true;
               continue;
             }
-            let entry = attrs.entry(func_name.clone()).or_insert_with(Vec::new);
-            for a in &attr {
-              if !entry.contains(a) {
-                entry.push(a.clone());
-              }
-            }
+            let mask = attr;
+            attrs
+              .entry(func_name.clone())
+              .and_modify(|a| (*a).add(mask))
+              .or_insert(Attributes::new(mask));
           }
         });
         // Re-adding a builtin attribute via SetAttributes prunes it from
         // the removed-tracking, so `Attributes[sym]` once again reports it.
         crate::FUNC_ATTRS_REMOVED.with(|m| {
           let mut removed = m.borrow_mut();
+          let mask = attr;
           for func_name in &func_names {
-            if let Some(entry) = removed.get_mut(func_name) {
-              entry.retain(|a| !attr.contains(a));
-            }
+            removed.entry(func_name.clone()).and_modify(|a| {
+              (*a).remove(mask);
+            });
           }
         });
         if locked {
@@ -997,34 +1010,35 @@ pub fn dispatch_attributes(
       if !func_names.is_empty() {
         crate::FUNC_ATTRS.with(|m| {
           let mut attrs = m.borrow_mut();
+          let mask = Attributes::masks(&to_remove);
           for func_name in &func_names {
             if let Some(existing) = attrs.get(func_name)
-              && existing.contains(&"Locked".to_string())
+              && existing.contains(Attributes::Locked)
             {
               crate::emit_message(&format!(
                 "Attributes::locked: Symbol {func_name} is locked."
               ));
               continue;
             }
-            if let Some(entry) = attrs.get_mut(func_name) {
-              entry.retain(|a| !to_remove.contains(a));
-            }
+
+            attrs.entry(func_name.clone()).and_modify(|a| {
+              (*a).remove(mask);
+            });
           }
         });
         // Remove from builtin attributes via the removed-tracking, mirroring
         // how Unprotect handles the Protected attribute.
         crate::FUNC_ATTRS_REMOVED.with(|m| {
           let mut removed = m.borrow_mut();
+          let mask = Attributes::masks(&to_remove);
           for func_name in &func_names {
-            let builtin = get_builtin_attributes(func_name);
-            for a in &to_remove {
-              if builtin.contains(&a.as_str()) {
-                let entry =
-                  removed.entry(func_name.clone()).or_insert_with(Vec::new);
-                if !entry.contains(a) {
-                  entry.push(a.clone());
-                }
-              }
+            let builtin = get_builtin_attributes_mask(func_name);
+            let mask = mask & builtin.to_u32(); // ignore attributes not on builtin.
+            if mask != 0 {
+              removed
+                .entry(func_name.clone())
+                .and_modify(|a| (*a).add(mask))
+                .or_insert(Attributes::new(mask));
             }
           }
         });
@@ -1044,17 +1058,18 @@ pub fn dispatch_attributes(
           if was_builtin {
             crate::FUNC_ATTRS_REMOVED.with(|m| {
               let mut removed = m.borrow_mut();
-              if let Some(entry) = removed.get_mut(sym) {
-                entry.retain(|a| a != "Protected");
-              }
+              removed.entry(sym.clone()).and_modify(|a| {
+                (*a).remove(Attributes::Protected);
+              });
             });
           } else {
             crate::FUNC_ATTRS.with(|m| {
               let mut attrs = m.borrow_mut();
-              let entry = attrs.entry(sym.clone()).or_insert_with(Vec::new);
-              if !entry.contains(&"Protected".to_string()) {
-                entry.push("Protected".to_string());
-              }
+              let mask = Attributes::Protected;
+              attrs
+                .entry(sym.clone())
+                .and_modify(|a| (*a).add(mask))
+                .or_insert(Attributes::new(mask));
             });
           }
           protected_syms.push(Expr::String(sym.clone()));
@@ -1072,7 +1087,7 @@ pub fn dispatch_attributes(
             if builtin.contains(Attributes::Locked) {
               true
             } else {
-              crate::func_attrs_contains(sym.as_str(), "Locked")
+              crate::func_attrs_contains(sym.as_str(), Attributes::Locked)
             }
           };
           if is_locked {
@@ -1086,9 +1101,14 @@ pub fn dispatch_attributes(
           let was_user_protected = crate::FUNC_ATTRS.with(|m| {
             let mut attrs = m.borrow_mut();
             if let Some(entry) = attrs.get_mut(sym) {
-              let before_len = entry.len();
-              entry.retain(|a| a != "Protected");
-              before_len != entry.len()
+              let before = entry.to_u32();
+              let after = before & !Attributes::Protected;
+              if before == after {
+                false
+              } else {
+                attrs.insert(sym.clone(), Attributes::new(after));
+                true
+              }
             } else {
               false
             }
@@ -1098,10 +1118,11 @@ pub fn dispatch_attributes(
           if was_builtin_protected {
             crate::FUNC_ATTRS_REMOVED.with(|m| {
               let mut removed = m.borrow_mut();
-              let entry = removed.entry(sym.clone()).or_insert_with(Vec::new);
-              if !entry.contains(&"Protected".to_string()) {
-                entry.push("Protected".to_string());
-              }
+              let mask = Attributes::Protected;
+              removed
+                .entry(sym.clone())
+                .and_modify(|a| (*a).add(mask))
+                .or_insert(Attributes::new(mask));
             });
           }
           if was_user_protected || was_builtin_protected {
@@ -1169,16 +1190,15 @@ pub fn dispatch_attributes(
           .with(|m| m.borrow_mut().remove(sym));
         // Mark every builtin attribute as removed so `Attributes[sym]`
         // returns `{}` after ClearAll, matching wolframscript.
-        let builtin = get_builtin_attributes(sym);
+        let builtin = get_builtin_attributes_mask(sym);
         if !builtin.is_empty() {
           crate::FUNC_ATTRS_REMOVED.with(|m| {
             let mut removed = m.borrow_mut();
-            let entry = removed.entry(sym.to_string()).or_insert_with(Vec::new);
-            for a in builtin {
-              if !entry.contains(&a.to_string()) {
-                entry.push(a.to_string());
-              }
-            }
+            let mask = builtin.to_u32();
+            removed
+              .entry(sym.to_string())
+              .and_modify(|a| (*a).add(mask))
+              .or_insert(Attributes::new(mask));
           });
         }
         let up_defs = crate::UPVALUES.with(|m| m.borrow_mut().remove(sym));

--- a/src/evaluator/contexts.rs
+++ b/src/evaluator/contexts.rs
@@ -225,7 +225,7 @@ fn is_user_symbol(name: &str) -> bool {
   }
   let bare = short_name(name);
   !crate::evaluator::is_builtin_symbol(bare)
-    && crate::evaluator::get_builtin_attributes(bare).is_empty()
+    && crate::evaluator::get_builtin_attributes_mask(bare).is_empty()
 }
 
 /// Whether a symbol with this full name exists — either created in a

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -210,8 +210,8 @@ pub fn expand_arith_shorthand(
 }
 
 /// Check if a function has a specific Hold attribute (built-in or user-defined).
-fn has_hold_attribute(name: &str, attr: &str) -> bool {
-  get_builtin_attributes(name).contains(&attr)
+fn has_hold_attribute(name: &str, attr: u32) -> bool {
+  get_builtin_attributes_mask(name).contains(attr)
     || crate::func_attrs_contains(name, attr)
 }
 
@@ -222,9 +222,9 @@ pub(crate) fn head_holds_arguments(expr: &Expr) -> bool {
   let Expr::FunctionCall { name, .. } = expr else {
     return false;
   };
-  ["HoldAll", "HoldAllComplete", "HoldFirst", "HoldRest"]
-    .iter()
-    .any(|attr| has_hold_attribute(name, attr))
+  use Attributes as A;
+  let attr = A::HoldAll | A::HoldAllComplete | A::HoldFirst | A::HoldRest;
+  has_hold_attribute(name, attr)
 }
 
 /// Whether `name` holds the argument at the 0-based position `index`.
@@ -232,15 +232,16 @@ pub(crate) fn head_holds_arguments(expr: &Expr) -> bool {
 /// its `Association` exception, for callers that walk arguments themselves
 /// (the tracing functions).
 pub(crate) fn holds_argument_at(name: &str, index: usize) -> bool {
-  if has_hold_attribute(name, "HoldAll")
-    || (name != "Association" && has_hold_attribute(name, "HoldAllComplete"))
+  use Attributes as A;
+  if has_hold_attribute(name, A::HoldAll)
+    || (name != "Association" && has_hold_attribute(name, A::HoldAllComplete))
   {
     return true;
   }
   if index == 0 {
-    has_hold_attribute(name, "HoldFirst")
+    has_hold_attribute(name, A::HoldFirst)
   } else {
-    has_hold_attribute(name, "HoldRest")
+    has_hold_attribute(name, A::HoldRest)
   }
 }
 
@@ -257,11 +258,12 @@ fn evaluate_args_with_hold(
   // builds the association from evaluated parts (`<|a -> <|b -> 1|>|>` nests a
   // real association) — the attribute does not suppress evaluation there, so
   // neither does it here.
+  use Attributes as A;
   let hold_all_complete =
-    name != "Association" && has_hold_attribute(name, "HoldAllComplete");
-  let hold_all = has_hold_attribute(name, "HoldAll") || hold_all_complete;
-  let hold_first = has_hold_attribute(name, "HoldFirst");
-  let hold_rest = has_hold_attribute(name, "HoldRest");
+    name != "Association" && has_hold_attribute(name, A::HoldAllComplete);
+  let hold_all = has_hold_attribute(name, A::HoldAll) || hold_all_complete;
+  let hold_first = has_hold_attribute(name, A::HoldFirst);
+  let hold_rest = has_hold_attribute(name, A::HoldRest);
 
   let process_held = |arg: &Expr| -> Result<Expr, InterpreterError> {
     if hold_all_complete {
@@ -3713,8 +3715,8 @@ pub fn evaluate_expr_to_expr_inner(
       let func_holds_all = matches!(
         func.as_ref(),
         Expr::Identifier(name)
-          if has_hold_attribute(name, "HoldAll")
-            || has_hold_attribute(name, "HoldAllComplete")
+          if has_hold_attribute(name, Attributes::HoldAll)
+            || has_hold_attribute(name, Attributes::HoldAllComplete)
       );
       if func_holds_all && let Expr::Identifier(name) = func.as_ref() {
         // Convert any nested `Postfix(e, f)` to `FunctionCall { name: f,

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -524,15 +524,14 @@ pub fn dispatch_complex_and_special(
       if let Expr::Identifier(sym) = first_arg {
         // Check if this is a built-in function (in functions.csv)
         let builtin_info = crate::evaluator::get_builtin_function_info(sym);
-        let builtin_attrs =
-          crate::evaluator::attributes::get_builtin_attributes(sym);
+        let builtin_attrs = get_builtin_attributes_mask(sym);
 
         if builtin_info.is_some() || !builtin_attrs.is_empty() {
           // Built-in symbol
           return Some(Ok(format_builtin_information(
             sym,
             builtin_info,
-            &builtin_attrs,
+            builtin_attrs,
             is_full,
           )));
         }
@@ -1060,7 +1059,7 @@ pub fn dispatch_complex_and_special(
         {
           let has_flat =
             crate::evaluator::listable::is_builtin_flat(&expr_head)
-              || crate::func_attrs_contains(&expr_head, "Flat");
+              || crate::func_attrs_contains(&expr_head, Attributes::Flat);
           if has_flat {
             let all_bindings =
               crate::evaluator::pattern_matching::enumerate_flat_partition_matches(
@@ -2221,23 +2220,15 @@ fn parse_blank_fc(expr: &Expr) -> Option<(u8, Option<&str>)> {
 fn format_builtin_information(
   sym: &str,
   info: Option<&crate::evaluator::BuiltinFunctionInfo>,
-  builtin_attrs: &[&str],
+  builtin_attrs: Attributes,
   is_full: bool,
 ) -> Expr {
   // Collect user-set attributes (merged with built-in)
   let user_attrs = crate::FUNC_ATTRS.with(|m| m.borrow().get(sym).cloned());
-  let mut all_attrs: Vec<String> = builtin_attrs
-    .iter()
-    .map(std::string::ToString::to_string)
-    .collect();
+  let mut all_attrs = builtin_attrs;
   if let Some(ua) = user_attrs {
-    for a in ua {
-      if !all_attrs.contains(&a) {
-        all_attrs.push(a);
-      }
-    }
+    all_attrs.add(ua.to_u32());
   }
-  all_attrs.sort();
 
   let description = info.map_or("", |i| i.description);
 
@@ -2259,7 +2250,8 @@ fn format_builtin_information(
   let attrs_repr = if all_attrs.is_empty() {
     "{}".to_string()
   } else {
-    format!("{{{}}}", all_attrs.join(", "))
+    let vals = all_attrs.to_vec().join(", ");
+    format!("{{{vals}}}")
   };
   fields.push(format!("Attributes -> {attrs_repr}"));
   display_fields.push(InfoField::text("Attributes", &attrs_repr));
@@ -2397,7 +2389,7 @@ fn format_user_information(
       Expr,
     )>,
   >,
-  user_attrs: Option<Vec<String>>,
+  user_attrs: Option<Attributes>,
   is_full: bool,
 ) -> Expr {
   // Build OwnValues field
@@ -2468,7 +2460,8 @@ fn format_user_information(
     if attrs.is_empty() {
       "{}".to_string()
     } else {
-      format!("{{{}}}", attrs.join(", "))
+      let vals = attrs.to_vec().join(", ");
+      format!("{{{vals}}}")
     }
   } else {
     "{}".to_string()
@@ -15037,19 +15030,13 @@ pub fn definition_text(sym: &str) -> Option<String> {
   // `Attributes[In] = {Listable, NHoldFirst, Protected}` even with no
   // user-installed attrs, matching wolframscript.
   let user_attrs = crate::FUNC_ATTRS.with(|m| m.borrow().get(sym).cloned());
-  let attrs_to_show: Vec<String> = match &user_attrs {
+  let attrs_to_show: Attributes = match &user_attrs {
     Some(a) if !a.is_empty() => a.clone(),
-    _ => crate::evaluator::attributes::get_builtin_attributes(sym)
-      .into_iter()
-      .map(std::string::ToString::to_string)
-      .collect(),
+    _ => get_builtin_attributes_mask(sym),
   };
   if !attrs_to_show.is_empty() {
-    lines.push(format!(
-      "Attributes[{}] = {{{}}}",
-      printed,
-      attrs_to_show.join(", ")
-    ));
+    let vals = attrs_to_show.to_vec().join(", ");
+    lines.push(format!("Attributes[{printed}] = {{{vals}}}"));
   }
 
   // 2. Show OwnValues (variable assignments)
@@ -15080,7 +15067,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
   // (DownValues, UpValues, Format/MakeBoxes, NValues, SubValues),
   // surfacing only Attributes / Default / Options. Skip those
   // sections when the symbol is read-protected.
-  let read_protected = attrs_to_show.iter().any(|a| a == "ReadProtected");
+  let read_protected = attrs_to_show.contains(Attributes::ReadProtected);
   // 3. Show UpValues first (rules attached via Real /: F[x_Real] := x
   // etc.), matching wolframscript's ordering. UpValues precede
   // DownValues in Definition output.
@@ -15245,14 +15232,10 @@ pub fn definition_text(sym: &str) -> Option<String> {
 
   // For built-in symbols: show attributes
   if lines.is_empty() {
-    let builtin_attrs =
-      crate::evaluator::attributes::get_builtin_attributes(sym);
+    let builtin_attrs = get_builtin_attributes_mask(sym);
     if !builtin_attrs.is_empty() {
-      lines.push(format!(
-        "Attributes[{}] = {{{}}}",
-        printed,
-        builtin_attrs.join(", ")
-      ));
+      let vals = builtin_attrs.to_vec().join(", ");
+      lines.push(format!("Attributes[{printed}] = {{{vals}}}"));
     }
   }
 
@@ -15449,7 +15432,8 @@ pub fn full_definition_text(sym: &str) -> Option<String> {
     if let Some(attrs) = &user_attrs
       && !attrs.is_empty()
     {
-      lines.push(format!("Attributes[{}] = {{{}}}", sym, attrs.join(", ")));
+      let vals = attrs.to_vec().join(", ");
+      lines.push(format!("Attributes[{sym}] = {{{vals}}}"));
     }
 
     let own_value = crate::ENV.with(|e| {
@@ -15534,14 +15518,10 @@ pub fn full_definition_text(sym: &str) -> Option<String> {
     }
 
     if lines.is_empty() {
-      let builtin_attrs =
-        crate::evaluator::attributes::get_builtin_attributes(sym);
+      let builtin_attrs = get_builtin_attributes_mask(sym);
       if !builtin_attrs.is_empty() {
-        lines.push(format!(
-          "Attributes[{}] = {{{}}}",
-          sym,
-          builtin_attrs.join(", ")
-        ));
+        let vals = builtin_attrs.to_vec().join(", ");
+        lines.push(format!("Attributes[{sym}] = {{{vals}}}"));
       }
     }
 
@@ -15659,7 +15639,8 @@ fn information_property(sym: &str, property: &str) -> Expr {
     return match property {
       "Usage" => Expr::String(info.description.to_string()),
       "Attributes" => Expr::List(
-        crate::evaluator::attributes::get_builtin_attributes(sym)
+        get_builtin_attributes_mask(sym)
+          .to_vec()
           .into_iter()
           .map(|a| Expr::Identifier(a.to_string()))
           .collect(),

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -49,7 +49,7 @@ fn orderless_parts(expr: &Expr) -> Option<(String, Vec<Expr>)> {
     return None;
   }
   if !crate::evaluator::listable::is_builtin_orderless(&head)
-    && !crate::func_attrs_contains(&head, "Orderless")
+    && !crate::func_attrs_contains(&head, Attributes::Orderless)
   {
     return None;
   }
@@ -750,8 +750,8 @@ fn evaluate_function_call_ast_inner(
   }
 
   // Thread Listable functions over list arguments
-  let is_listable =
-    is_builtin_listable(name) || crate::func_attrs_contains(name, "Listable");
+  let is_listable = is_builtin_listable(name)
+    || crate::func_attrs_contains(name, Attributes::Listable);
   if is_listable && let Some(result) = thread_listable(name, args)? {
     return Ok(result);
   }
@@ -776,7 +776,7 @@ fn evaluate_function_call_ast_inner(
 
   // Apply Flat attribute: flatten nested calls of the same function
   let has_flat =
-    is_builtin_flat(name) || crate::func_attrs_contains(name, "Flat");
+    is_builtin_flat(name) || crate::func_attrs_contains(name, Attributes::Flat);
   let args_after_flat;
   let args = if has_flat {
     let mut flat_args: Vec<Expr> = Vec::new();
@@ -827,7 +827,7 @@ fn evaluate_function_call_ast_inner(
   let has_orderless = name != "Plus"
     && name != "Times"
     && (is_builtin_orderless(name)
-      || crate::func_attrs_contains(name, "Orderless"));
+      || crate::func_attrs_contains(name, Attributes::Orderless));
   let args_after_sort;
   let args = if has_orderless {
     let mut sorted_args = args.to_vec();
@@ -957,8 +957,9 @@ fn evaluate_function_call_ast_inner(
   // when the head carries HoldAllComplete we drop those entries before
   // dispatch — DownValues for the same head are still tried as usual.
   let head_has_hold_all_complete =
-    crate::func_attrs_contains(name, "HoldAllComplete")
-      || get_builtin_attributes(name).contains(&"HoldAllComplete");
+    crate::func_attrs_contains(name, Attributes::HoldAllComplete)
+      || get_builtin_attributes_mask(name)
+        .contains(Attributes::HoldAllComplete);
   let overloads = crate::FUNC_DEFS.with(|m| {
     let defs = m.borrow();
     let raw = defs.get(name).cloned();

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3271,11 +3271,8 @@ pub fn dispatch_io_functions(
         if let Some(attrs) = user_attrs
           && !attrs.is_empty()
         {
-          sym_lines.push(format!(
-            "Attributes[{}] = {{{}}}",
-            sym,
-            attrs.join(", ")
-          ));
+          let vals = attrs.to_vec().join(", ");
+          sym_lines.push(format!("Attributes[{sym}] = {{{vals}}}"));
         }
 
         // 2. DownValues (function definitions). Includes literal-argument

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1328,27 +1328,20 @@ pub fn dispatch_predicate_functions(
       // Check user-defined attributes first, then combine with built-in
       let user_attrs =
         crate::FUNC_ATTRS.with(|m| m.borrow().get(sym_name).cloned());
-      let builtin = get_builtin_attributes(sym_name);
+      let builtin = get_builtin_attributes_mask(sym_name);
       let removed = crate::FUNC_ATTRS_REMOVED
         .with(|m| m.borrow().get(sym_name).cloned())
         .unwrap_or_default();
-      let mut all_attr_strs: Vec<String> = builtin
-        .iter()
-        .map(std::string::ToString::to_string)
-        .filter(|a| !removed.contains(a))
-        .collect();
+      let mut all_attrs = builtin;
+      all_attrs.remove(removed.to_u32());
       if let Some(user) = user_attrs {
-        for a in user {
-          if !all_attr_strs.contains(&a) {
-            all_attr_strs.push(a);
-          }
-        }
-        all_attr_strs.sort();
+        all_attrs.add(user.to_u32());
       }
       return Some(Ok(Expr::List(
-        all_attr_strs
+        all_attrs
+          .to_vec()
           .iter()
-          .map(|a| Expr::Identifier(a.clone()))
+          .map(|a| Expr::Identifier(a.to_string()))
           .collect(),
       )));
     }
@@ -1379,7 +1372,7 @@ pub fn dispatch_predicate_functions(
         return Some(Ok(Expr::String(sym_name[..=last].to_string())));
       }
       // Built-in symbols are in System` context
-      let builtin = get_builtin_attributes(&sym_name);
+      let builtin = get_builtin_attributes_mask(&sym_name);
       if !builtin.is_empty() {
         return Some(Ok(Expr::String("System`".to_string())));
       }
@@ -1713,9 +1706,7 @@ pub fn dispatch_predicate_functions(
         // Check if the symbol has been defined (OwnValues, DownValues, or is built-in)
         let has_own = crate::ENV.with(|e| e.borrow().contains_key(name));
         let has_down = crate::FUNC_DEFS.with(|m| m.borrow().contains_key(name));
-        let has_builtin_attrs =
-          !crate::evaluator::attributes::get_builtin_attributes(name)
-            .is_empty();
+        let has_builtin_attrs = !get_builtin_attributes_mask(name).is_empty();
         if has_own || has_down || has_builtin_attrs {
           return Some(Ok(bool_expr(true)));
         }

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1554,8 +1554,8 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
 pub(crate) fn has_sequence_hold(name: &str) -> bool {
   let builtin = attributes::get_builtin_attributes_mask(name);
   builtin.contains(Attributes::SequenceHold)
-    || crate::func_attrs_contains(name, "SequenceHold")
-    || crate::func_attrs_contains(name, "HoldAllComplete")
+    || crate::func_attrs_contains(name, Attributes::SequenceHold)
+    || crate::func_attrs_contains(name, Attributes::HoldAllComplete)
     || builtin.contains(Attributes::HoldAllComplete)
 }
 

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -663,19 +663,19 @@ pub fn is_symbol_protected(name: &str) -> bool {
   let builtin_protected = builtin.contains(Attributes::Protected);
   // `Unprotect` records the removal in FUNC_ATTRS_REMOVED so the builtin's
   // baseline can be temporarily overridden without losing it.
-  let removed = crate::func_attrs_removed_contains(name, "Protected");
+  let removed = crate::func_attrs_removed_contains(name, Attributes::Protected);
   if builtin_protected && !removed {
     return true;
   }
-  crate::func_attrs_contains(name, "Protected")
+  crate::func_attrs_contains(name, Attributes::Protected)
 }
 
 fn has_one_identity(name: &str) -> bool {
-  let builtin = get_builtin_attributes(name);
-  if builtin.contains(&"OneIdentity") {
+  let builtin = get_builtin_attributes_mask(name);
+  if builtin.contains(Attributes::OneIdentity) {
     return true;
   }
-  crate::func_attrs_contains(name, "OneIdentity")
+  crate::func_attrs_contains(name, Attributes::OneIdentity)
 }
 
 /// Look up a user-defined `Default[f, position]` (or position-less
@@ -1327,7 +1327,7 @@ fn try_flat_partition_match(
 ) -> Option<Vec<(String, Expr)>> {
   let has_orderless =
     crate::evaluator::listable::is_builtin_orderless(pat_name)
-      || crate::func_attrs_contains(pat_name, "Orderless");
+      || crate::func_attrs_contains(pat_name, Attributes::Orderless);
   let n = expr_args.len();
   let k = pat_args.len();
   if has_orderless {
@@ -2183,8 +2183,8 @@ fn try_flat_replace_all(
 ) -> Result<Option<Expr>, InterpreterError> {
   match expr {
     Expr::FunctionCall { name, args } => {
-      let has_flat =
-        is_builtin_flat(name) || crate::func_attrs_contains(name, "Flat");
+      let has_flat = is_builtin_flat(name)
+        || crate::func_attrs_contains(name, Attributes::Flat);
       if has_flat
         && let Expr::FunctionCall {
           name: pat_name,
@@ -2194,7 +2194,7 @@ fn try_flat_replace_all(
         && pat_args.len() < args.len()
       {
         let has_orderless = is_builtin_orderless(name)
-          || crate::func_attrs_contains(name, "Orderless");
+          || crate::func_attrs_contains(name, Attributes::Orderless);
         if has_orderless {
           // For Flat+Orderless: try all combinations of sub_len args
           let sub_len = pat_args.len();
@@ -2229,7 +2229,7 @@ fn try_flat_replace_all(
           // fallback so plain literal patterns like `f[a, b, c] /.
           // f[a, b] -> d` still match.
           let has_one_identity =
-            crate::func_attrs_contains(name, "OneIdentity");
+            crate::func_attrs_contains(name, Attributes::OneIdentity);
           let sub_len = pat_args.len();
           for start in 0..=(args.len() - sub_len) {
             let try_match =
@@ -4274,7 +4274,7 @@ fn match_pattern_impl(
           // `Plus[n_Integer, s__Symbol, rest_]`.
           let is_orderless =
             crate::evaluator::listable::is_builtin_orderless(pat_name)
-              || crate::func_attrs_contains(pat_name, "Orderless");
+              || crate::func_attrs_contains(pat_name, Attributes::Orderless);
           if is_orderless && expr_args.len() >= 2 {
             for perm in permutations(expr_args) {
               if let Some(b) = match_args_with_sequences(&perm, pat_args) {
@@ -4328,7 +4328,7 @@ fn match_pattern_impl(
             if pat_args.len() < expr_args.len() && !pat_args.is_empty() {
               let has_flat =
                 crate::evaluator::listable::is_builtin_flat(pat_name)
-                  || crate::func_attrs_contains(pat_name, "Flat");
+                  || crate::func_attrs_contains(pat_name, Attributes::Flat);
               if has_flat
                 && let Some(b) =
                   try_flat_partition_match(pat_name, pat_args, expr_args)
@@ -4341,7 +4341,7 @@ fn match_pattern_impl(
           // For Orderless functions (Times, Plus), try all permutations
           let is_orderless =
             crate::evaluator::listable::is_builtin_orderless(pat_name)
-              || crate::func_attrs_contains(pat_name, "Orderless");
+              || crate::func_attrs_contains(pat_name, Attributes::Orderless);
           if is_orderless && pat_args.len() >= 2 {
             // Try all permutations of expression args against pattern args.
             // When Optional patterns are present, prefer matches where more

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::evaluator::Attributes;
 use crate::syntax::substitute_variable;
 
 pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -197,25 +198,17 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       // Honour NHoldAll / NHoldFirst / NHoldRest attributes (built-in or
       // user-set). When a slot is held, leave the argument literal and
       // skip the recursive N application.
-      let attrs: Vec<String> = {
-        let builtin: Vec<String> =
-          crate::evaluator::get_builtin_attributes(name)
-            .into_iter()
-            .map(String::from)
-            .collect();
+      let attrs = {
+        let builtin = crate::evaluator::get_builtin_attributes_mask(name);
         let user = crate::FUNC_ATTRS
           .with(|m| m.borrow().get(name).cloned().unwrap_or_default());
         let mut combined = builtin;
-        for a in user {
-          if !combined.contains(&a) {
-            combined.push(a);
-          }
-        }
+        combined.add(user.to_u32());
         combined
       };
-      let hold_all = attrs.iter().any(|a| a == "NHoldAll");
-      let hold_first = attrs.iter().any(|a| a == "NHoldFirst");
-      let hold_rest = attrs.iter().any(|a| a == "NHoldRest");
+      let hold_all = attrs.contains(Attributes::NHoldAll);
+      let hold_first = attrs.contains(Attributes::NHoldFirst);
+      let hold_rest = attrs.contains(Attributes::NHoldRest);
       let new_args: Vec<Expr> = if hold_all {
         args.to_vec()
       } else {
@@ -1238,25 +1231,17 @@ fn n_eval_arbitrary_partial(
       // Honour NHoldAll / NHoldFirst / NHoldRest so e.g. `N[Out[0], 50]`
       // doesn't recurse into Out's slot and rewrite the index as a
       // BigFloat. (Out has NHoldFirst; the `0` slot must stay literal.)
-      let attrs: Vec<String> = {
-        let builtin: Vec<String> =
-          crate::evaluator::get_builtin_attributes(name)
-            .into_iter()
-            .map(String::from)
-            .collect();
+      let attrs = {
+        let builtin = crate::evaluator::get_builtin_attributes_mask(name);
         let user = crate::FUNC_ATTRS
           .with(|m| m.borrow().get(name).cloned().unwrap_or_default());
         let mut combined = builtin;
-        for a in user {
-          if !combined.contains(&a) {
-            combined.push(a);
-          }
-        }
+        combined.add(user.to_u32());
         combined
       };
-      let hold_all = attrs.iter().any(|a| a == "NHoldAll");
-      let hold_first = attrs.iter().any(|a| a == "NHoldFirst");
-      let hold_rest = attrs.iter().any(|a| a == "NHoldRest");
+      let hold_all = attrs.contains(Attributes::NHoldAll);
+      let hold_first = attrs.contains(Attributes::NHoldFirst);
+      let hold_rest = attrs.contains(Attributes::NHoldRest);
       let new_args: Result<Vec<Expr>, _> = args
         .iter()
         .enumerate()

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -530,7 +530,8 @@ fn extract_reduce_vars(expr: &Expr) -> Vec<String> {
   match expr {
     Expr::Identifier(name) => {
       // Check it's not a constant
-      let is_constant = crate::func_attrs_contains(name, "Constant");
+      use crate::evaluator::Attributes as A;
+      let is_constant = crate::func_attrs_contains(name, A::Constant);
       if is_constant
         || matches!(
           name.as_str(),

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2411,7 +2411,8 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   // Check if variable has Constant attribute (user-defined constants)
-  let is_constant = crate::func_attrs_contains(var, "Constant");
+  use crate::evaluator::Attributes as A;
+  let is_constant = crate::func_attrs_contains(var, A::Constant);
   if is_constant {
     crate::emit_message(&format!(
       "Solve::ivar: {var} is not a valid variable."

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -4,6 +4,7 @@
 
 #[allow(unused_imports)]
 use super::*;
+use crate::evaluator::Attributes;
 use crate::functions::math_ast::rat_reduce;
 
 /// NumberQ[expr] - Tests if the expression is a number
@@ -639,7 +640,7 @@ pub fn is_numeric_q(expr: &Expr) -> bool {
 }
 
 /// Known numeric functions (have the NumericFunction attribute in Wolfram Language)
-fn is_numeric_function(name: &str) -> bool {
+fn is_builtin_numeric(name: &str) -> bool {
   matches!(
     name,
     "Plus"
@@ -695,7 +696,12 @@ fn is_numeric_function(name: &str) -> bool {
       | "BernoulliB"
       | "Zeta"
       | "N"
-  ) || crate::func_attrs_contains(name, "NumericFunction")
+  )
+}
+
+fn is_numeric_function(name: &str) -> bool {
+  is_builtin_numeric(name)
+    || crate::func_attrs_contains(name, Attributes::NumericFunction)
 }
 
 /// Numerically evaluate a NumericQ expression (e.g. Sin[11]) and apply

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,12 @@ thread_local! {
     // entries can be reconstructed as rules for DownValues introspection.
     pub static MEMO_VALUES: RefCell<HashMap<String, HashMap<String, (Vec<syntax::Expr>, syntax::Expr)>>> = RefCell::new(HashMap::new());
     // Function attributes (e.g., Listable, Flat, etc.)
-    static FUNC_ATTRS: RefCell<HashMap<String, Vec<String>>> = RefCell::new(HashMap::new());
+    static FUNC_ATTRS: RefCell<HashMap<String, evaluator::Attributes>> = RefCell::new(HashMap::new());
     // Builtin attributes that have been explicitly removed (via Unprotect,
     // ClearAttributes, or ClearAll). Subtracted from `Attributes[sym]` so
     // that e.g. `Unprotect[Pi]; Attributes[Pi]` no longer contains
     // `Protected`. Re-adding via SetAttributes/Protect prunes the entry.
-    pub static FUNC_ATTRS_REMOVED: RefCell<HashMap<String, Vec<String>>> = RefCell::new(HashMap::new());
+    pub static FUNC_ATTRS_REMOVED: RefCell<HashMap<String, evaluator::Attributes>> = RefCell::new(HashMap::new());
     // Function options (e.g., Options[f] = {a -> 1})
     pub static FUNC_OPTIONS: RefCell<HashMap<String, Vec<syntax::Expr>>> = RefCell::new(HashMap::new());
     // Track whether Options[f] was set with `:=` (SetDelayed) so Definition can
@@ -5380,25 +5380,26 @@ pub fn interpret_expr_with_stdout(
   })
 }
 
-pub fn func_attrs_contains(func_name: &str, attr_name: &str) -> bool {
+pub fn func_attrs_contains(func_name: &str, attr: u32) -> bool {
   FUNC_ATTRS.with(|m| {
     m.borrow()
       .get(func_name)
-      .is_some_and(|attrs| attrs.contains(&attr_name.to_string()))
+      .is_some_and(|attrs| attrs.contains(attr))
   })
 }
 
-pub fn func_attrs_removed_contains(func_name: &str, attr_name: &str) -> bool {
+pub fn func_attrs_removed_contains(func_name: &str, attr: u32) -> bool {
   FUNC_ATTRS_REMOVED.with(|m| {
     m.borrow()
       .get(func_name)
-      .is_some_and(|attrs| attrs.contains(&attr_name.to_string()))
+      .is_some_and(|attrs| attrs.contains(attr))
   })
 }
 
 fn store_function_definition(
   pair: Pair<Rule>,
 ) -> Result<Option<String>, InterpreterError> {
+  use evaluator::Attributes as A;
   // FunctionDefinition  :=  Identifier "[" (Pattern ("," Pattern)*)? "]" ":=" Expression
   // pest pairs are not Clone, so capture the source slices around ":=".
   let (raw_lhs, raw_rhs) = {
@@ -5444,12 +5445,12 @@ fn store_function_definition(
     "N" | "MessageName" | "Format" | "Default" | "Options"
   );
   let is_n_value_assignment = allows_redirected_rule;
-  let was_unprotected = func_attrs_removed_contains(&func_name, "Protected");
+  let was_unprotected = func_attrs_removed_contains(&func_name, A::Protected);
   let is_builtin_protected = !is_n_value_assignment
     && !was_unprotected
     && evaluator::get_builtin_attributes_mask(&func_name)
-      .contains(evaluator::Attributes::Protected);
-  let is_user_protected = func_attrs_contains(&func_name, "Protected");
+      .contains(A::Protected);
+  let is_user_protected = func_attrs_contains(&func_name, A::Protected);
   if is_builtin_protected || is_user_protected {
     let (tag, ret) = if is_builtin_protected && !is_user_protected {
       ("SetDelayed::write", Some("$Failed".to_string()))


### PR DESCRIPTION
This PR completes the process of replacing Vec<&str> for Wolfram attributes with an Attributes bitmask. It converts FUNC_ATTRS and FUNC_ATTRS_REMOVED to use the Attribute and then updates the code to as appropriate.  It also converts all remaining calls to get_builtin_attributes to get_builtin_attributes_mask, and deletes the fn.  Some of these cases were overlooked in part 1.

I also factored is_builtin_numeric out of is_numeric_function so I can add a test case to validate it is consistent with get_builtin_attributes, but will add that test in a followup PR so as not to further complicate this PR.