### PR TITLE
Fix notebook parsing and Integrate for Orthogonality of Sines and Cosines demo

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4411,6 +4411,78 @@ fn try_integrate_exp_trig_product(
   None
 }
 
+/// Try to integrate a product of exactly two trig factors (`Sin`/`Cos`,
+/// each to the first power) whose arguments are different functions of
+/// `var`, via the product-to-sum identities:
+///   Sin[A] Sin[B] = (Cos[A-B] - Cos[A+B]) / 2
+///   Cos[A] Cos[B] = (Cos[A-B] + Cos[A+B]) / 2
+///   Sin[A] Cos[B] = (Sin[A+B] + Sin[A-B]) / 2
+/// e.g. `Sin[m x] Sin[n x]` for `m ≠ n` — the orthogonality integrals a
+/// Fourier series relies on. `try_integrate_sin_cos_product` already
+/// covers the same-argument case (`Sin[f]^m * Cos[f]^n`), so this only
+/// needs to fire when the two arguments genuinely differ.
+fn try_integrate_trig_product_to_sum(
+  factors: &[&Expr],
+  var: &str,
+) -> Option<Expr> {
+  let [f0, f1] = factors else {
+    return None;
+  };
+  let trig_parts = |f: &Expr| -> Option<(&'static str, Expr)> {
+    if let Expr::FunctionCall { name, args } = f
+      && args.len() == 1
+    {
+      return match name.as_str() {
+        "Sin" => Some(("Sin", args[0].clone())),
+        "Cos" => Some(("Cos", args[0].clone())),
+        _ => None,
+      };
+    }
+    None
+  };
+  let (name0, arg0) = trig_parts(f0)?;
+  let (name1, arg1) = trig_parts(f1)?;
+  if expr_str_eq(&arg0, &arg1) {
+    // Same argument: `try_integrate_sin_cos_product` already handles this.
+    return None;
+  }
+
+  // Combine like terms (`Pi*t - 2*Pi*t` → `-Pi*t`) so the resulting
+  // Cos/Sin argument is a single linear term the recursive `integrate`
+  // call below can recognise — `simplify` alone leaves the bare
+  // subtraction/addition uncollected.
+  let sum_arg =
+    crate::evaluator::evaluate_expr_to_expr(&plus2(arg0.clone(), arg1.clone()))
+      .unwrap_or_else(|_| simplify(plus2(arg0.clone(), arg1.clone())));
+  let diff_arg = crate::evaluator::evaluate_expr_to_expr(&minus2(
+    arg0.clone(),
+    arg1.clone(),
+  ))
+  .unwrap_or_else(|_| simplify(minus2(arg0.clone(), arg1.clone())));
+  let half_of = |e: Expr| div2(e, Expr::Integer(2));
+  let rewritten = match (name0, name1) {
+    ("Sin", "Sin") => minus2(
+      half_of(call1("Cos", diff_arg)),
+      half_of(call1("Cos", sum_arg)),
+    ),
+    ("Cos", "Cos") => plus2(
+      half_of(call1("Cos", diff_arg)),
+      half_of(call1("Cos", sum_arg)),
+    ),
+    ("Sin", "Cos") => plus2(
+      half_of(call1("Sin", sum_arg)),
+      half_of(call1("Sin", diff_arg)),
+    ),
+    ("Cos", "Sin") => minus2(
+      half_of(call1("Sin", sum_arg)),
+      half_of(call1("Sin", diff_arg)),
+    ),
+    _ => return None,
+  };
+
+  integrate(&rewritten, var)
+}
+
 /// Try to integrate a product of Sin[f]^m * Cos[f]^n where f is linear in var.
 /// Handles:
 ///   - Sin[f] * Cos[f]^n → -Cos[f]^(n+1) / ((n+1)*a)
@@ -7648,6 +7720,12 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             {
               return Some(result);
             }
+            // Trig product-to-sum: Sin[m x] Sin[n x], m != n, etc.
+            if let Some(result) =
+              try_integrate_trig_product_to_sum(&[left, right], var)
+            {
+              return Some(result);
+            }
             // Trig quotients like Sin[x]*Tan[x] (= Sin^2/Cos)
             if let Some(result) =
               try_integrate_trig_quotient(&[left, right], &[], var)
@@ -8712,6 +8790,24 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 }
               };
               return Some(times2(const_expr, trig_result));
+            }
+            // Trig product-to-sum: Sin[m x] Sin[n x], m != n, etc.
+            if var_factors.len() == 2
+              && let Some(pts_result) =
+                try_integrate_trig_product_to_sum(&var_refs, var)
+            {
+              if const_factors.is_empty() {
+                return Some(pts_result);
+              }
+              let const_expr = if const_factors.len() == 1 {
+                const_factors[0].clone()
+              } else {
+                Expr::FunctionCall {
+                  name: "Times".to_string(),
+                  args: const_factors.into_iter().cloned().collect(),
+                }
+              };
+              return Some(times2(const_expr, pts_result));
             }
             // Try u-substitution for pairs of variable-dependent factors
             if var_factors.len() == 2

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1123,11 +1123,17 @@ fn integral_limits(s: &str) -> Option<Option<(String, String)>> {
 }
 
 /// The variable of a `RowBox[{"\[DifferentialD]", x}]` — the typeset `ⅆx`
-/// that closes an integral body and names its integration variable.
+/// that closes an integral body and names its integration variable. The
+/// FrontEnd sometimes inserts an explicit space box between the glyph and
+/// the variable (`RowBox[{"\[DifferentialD]", " ", x}]`), which is dropped
+/// before checking the shape.
 fn differential_variable(s: &str) -> Option<String> {
   let inner = s.trim().strip_prefix("RowBox[")?.strip_suffix(']')?;
   let inner = inner.trim().strip_prefix('{')?.strip_suffix('}')?;
-  let args = split_top_level_commas(inner);
+  let mut args = split_top_level_commas(inner);
+  if args.len() == 3 && args[1].trim().trim_matches('"').trim().is_empty() {
+    args.remove(1);
+  }
   if args.len() != 2 {
     return None;
   }
@@ -4273,6 +4279,27 @@ Cell[BoxData[
       panic!("expected a single cell");
     };
     assert_eq!(cell.content, "Integrate[((x)^(2)+1), {x, 0, 2}]");
+  }
+
+  /// Some notebooks typeset the `ⅆx` that closes an integral body with an
+  /// explicit space box between the glyph and the variable
+  /// (`RowBox[{"\[DifferentialD]", " ", "x"}]`) rather than gluing them
+  /// directly (`RowBox[{"\[DifferentialD]", "x"}]`, covered above). The
+  /// integration variable must still be recovered either way.
+  #[test]
+  fn definite_integral_with_spaced_differential_becomes_integrate() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{
+  SubsuperscriptBox["\[Integral]", RowBox[{"-", "1"}], "1"],
+  RowBox[{"g", " ",
+   RowBox[{"\[DifferentialD]", " ", "t"}]}]}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert_eq!(cell.content, "Integrate[g , {t, -1, 1}]");
   }
 
   /// Without an integral sign the differential is content of its own:

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -841,6 +841,74 @@ mod integrate_with_sum {
     );
   }
 
+  /// `Sin[a x] Sin[b x]` with `a != b` is the same-argument product's
+  /// same-argument neighbour: the double-angle identity above only applies
+  /// when both factors share one argument, so a genuinely different pair
+  /// of frequencies needs the product-to-sum identity
+  /// `Sin[A] Sin[B] = (Cos[A-B] - Cos[A+B]) / 2` instead. This is the
+  /// orthogonality integral a Fourier series relies on.
+  #[test]
+  fn integrate_sin_sin_product_different_frequencies() {
+    assert_eq!(
+      interpret("Integrate[Sin[x] * Sin[2*x], x]").unwrap(),
+      "Sin[x]/2 - Sin[3*x]/6"
+    );
+  }
+
+  #[test]
+  fn integrate_cos_cos_product_different_frequencies() {
+    // Cos[A] Cos[B] = (Cos[A-B] + Cos[A+B]) / 2
+    assert_eq!(
+      interpret("Integrate[Cos[x] * Cos[3*x], x]").unwrap(),
+      "Sin[2*x]/4 + Sin[4*x]/8"
+    );
+  }
+
+  #[test]
+  fn integrate_sin_cos_product_different_frequencies() {
+    // Sin[A] Cos[B] = (Sin[A+B] + Sin[A-B]) / 2
+    assert_eq!(
+      interpret("Integrate[Sin[2*x] * Cos[3*x], x]").unwrap(),
+      "Cos[x]/2 - Cos[5*x]/10"
+    );
+  }
+
+  /// The orthogonality relations a Fourier series is built on: sines and
+  /// cosines of different integer multiples of `Pi` over a symmetric
+  /// period integrate to exactly zero, while a matching pair of
+  /// frequencies integrates to a nonzero constant. Regression test for a
+  /// bug where `Integrate[Sin[m Pi x] Sin[n Pi x], {x, -1, 1}]` (m != n)
+  /// was left unevaluated instead of reducing to `0`, because the
+  /// same-argument product handler bails out on differing arguments and
+  /// nothing else picked up the product-to-sum identity.
+  #[test]
+  fn orthogonality_of_sines_and_cosines_over_symmetric_period() {
+    assert_eq!(
+      interpret("Integrate[Sin[1*Pi*x] * Sin[2*Pi*x], {x, -1, 1}]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("Integrate[Cos[1*Pi*x] * Cos[2*Pi*x], {x, -1, 1}]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("Integrate[Sin[2*Pi*x] * Sin[3*Pi*x], {x, -1, 1}]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("Integrate[Sin[2*Pi*x] * Cos[3*Pi*x], {x, -1, 1}]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("Integrate[Sin[2*Pi*x] * Sin[2*Pi*x], {x, -1, 1}]").unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret("Integrate[Cos[3*Pi*x] * Cos[3*Pi*x], {x, -1, 1}]").unwrap(),
+      "1"
+    );
+  }
+
   #[test]
   fn integrate_sin_cos_cubed() {
     // ∫ Sin[x]*Cos[x]^3 dx = -1/4*Cos[x]^4


### PR DESCRIPTION
## Summary

I downloaded a random Wolfram Demonstration ("Orthogonality of Sines and Cosines") and checked whether Woxi Studio fully supports it. It didn't, for two independent reasons that this PR fixes:

- **Notebook box parsing**: the notebook's `Integrate[...]` box form typesets the differential as `RowBox[{"\[DifferentialD]", " ", var}]` — with an explicit space box between the ⅆ glyph and the variable. `differential_variable` in `src/notebook.rs` only recognized the two-element form (`RowBox[{"\[DifferentialD]", var}]`), so the whole `PlotLabel` construction failed to reconstruct into evaluable source and the cell came back as a parse error.
- **Integrate correctness**: once parsed, `Integrate[Sin[m Pi x] Sin[n Pi x], {x, -1, 1}]` (and the `Cos`/`Cos` and `Sin`/`Cos` variants) stayed unevaluated whenever `m != n`, because the only existing product handler (`try_integrate_sin_cos_product`) required both trig factors to share the same argument. Added a product-to-sum handler (`try_integrate_trig_product_to_sum` in `src/functions/calculus_ast.rs`) for two differently-argued `Sin`/`Cos` factors — which is exactly the orthogonality relation this demonstration exists to show (different frequencies integrate to `0`, matching frequencies integrate to `1`).

No code from the demonstration notebook itself was copied — the fixes and tests use self-authored expressions with different variable names/values that exercise the same underlying language constructs.

## Test plan

- [x] Added a regression test in `src/notebook.rs` for the spaced-differential box form (`definite_integral_with_spaced_differential_becomes_integrate`)
- [x] Added regression tests in `tests/interpreter_tests/calculus.rs` for the trig product-to-sum integration (different-frequency `Sin`/`Cos` products, plus the orthogonality-over-`[-1,1]` cases)
- [x] `make test` — all 27,611 tests pass
- [x] `make test-studio` — all 184 tests pass
- [x] `make format`
- [x] Verified end-to-end against the actual downloaded notebook via `cargo run --example test_notebook -p woxi-studio`: it now parses and evaluates cleanly instead of erroring


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8RPgYDyUR1J3nx3LeQX7m)_