### PR TITLE
Fix NDSolve to support {f, f'} vars and nested initial-condition lists

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -780,6 +780,17 @@ fn compound_head_renamings(vars: &Expr, domain: &Expr) -> Vec<(Expr, String)> {
       {
         continue;
       }
+      // `Derivative[k][f]` (bare) or `Derivative[k][f][x]` (applied) — a
+      // request for `f`'s derivative, not a compound head itself unless
+      // `f` is one (e.g. `Derivative[1][Subscript[c, 1]]`).
+      Expr::FunctionCall { name, args }
+        if name == "Derivative" && (args.len() == 2 || args.len() == 3) =>
+      {
+        match &args[1] {
+          Expr::Identifier(_) => continue,
+          inner => inner.clone(),
+        }
+      }
       // `Subscript[c, 1]` — bare compound head.
       Expr::FunctionCall { .. } => entry.clone(),
       // `y` — bare symbol.
@@ -960,6 +971,78 @@ fn dep_name(item: &Expr) -> Option<String> {
   }
 }
 
+/// Recognize a `Derivative[k][f]` (bare) or `Derivative[k][f][x]` (applied)
+/// second-argument entry as a request for `f`'s `k`-th derivative,
+/// returned alongside `f` itself — e.g.
+/// `NDSolve[eqns, {y, y'}, {t, t0, t1}]` returns both `y ->
+/// InterpolatingFunction[…]` and `Derivative[1][y] ->
+/// InterpolatingFunction[…]`, sparing the caller from differentiating the
+/// interpolant. Returns `(function name, order, function_form)`;
+/// `function_form` is `false` when the entry was applied to `x_name`.
+/// The parser builds `Derivative[k][f]` as nested `CurriedCall`s
+/// (`Derivative[k]` called on `f`), so that raw shape is matched first;
+/// the flattened `FunctionCall("Derivative", [k, f])` form some
+/// normalization passes produce is matched too, defensively.
+fn derivative_dep_item(
+  item: &Expr,
+  x_name: &str,
+) -> Option<(String, usize, bool)> {
+  if let Expr::CurriedCall { func, args } = item
+    && args.len() == 1
+  {
+    if let Expr::Identifier(fname) = &args[0]
+      && let Expr::FunctionCall {
+        name: deriv_name,
+        args: deriv_args,
+      } = func.as_ref()
+      && deriv_name == "Derivative"
+      && deriv_args.len() == 1
+      && let Expr::Integer(k) = &deriv_args[0]
+    {
+      return Some((fname.clone(), *k as usize, true));
+    }
+    if matches!(&args[0], Expr::Identifier(a) if a == x_name)
+      && let Some((fname, k, _)) = derivative_dep_item(func.as_ref(), x_name)
+    {
+      return Some((fname, k, false));
+    }
+  }
+  if let Expr::FunctionCall { name, args } = item
+    && name == "Derivative"
+  {
+    if args.len() == 2
+      && let Expr::Integer(k) = &args[0]
+      && let Expr::Identifier(fname) = &args[1]
+    {
+      return Some((fname.clone(), *k as usize, true));
+    }
+    if args.len() == 3
+      && let Expr::Integer(k) = &args[0]
+      && let Expr::Identifier(fname) = &args[1]
+      && matches!(&args[2], Expr::Identifier(a) if a == x_name)
+    {
+      return Some((fname.clone(), *k as usize, false));
+    }
+  }
+  None
+}
+
+/// Flatten every nesting level of `List` in an `NDSolve`/`DSolve`
+/// equations argument into individual equations. A single function's
+/// initial conditions are often grouped into their own sublist —
+/// `{ode, {ic1, ic2}}` — and that grouping can nest arbitrarily deep, so
+/// each level is flattened, not just the outermost.
+fn flatten_eq_list(expr: &Expr, out: &mut Vec<Expr>) {
+  match expr {
+    Expr::List(items) => {
+      for item in items {
+        flatten_eq_list(item, out);
+      }
+    }
+    other => out.push(other.clone()),
+  }
+}
+
 /// The function a solution rule is for: `f -> …` or `f[x] -> …`.
 fn rule_target_name(rule: &Expr) -> Option<&str> {
   let Expr::Rule { pattern, .. } = rule else {
@@ -1092,7 +1175,15 @@ fn ndsolve_system(
     other => vec![other],
   };
   let mut funcs: Vec<SysFunc> = Vec::with_capacity(dep_items.len());
+  // A `Derivative[k][f]` entry doesn't introduce a new dependent function;
+  // it asks for `f`'s k-th derivative alongside `f`'s own solution, so
+  // it's collected separately and resolved once `f`'s order is known.
+  let mut deriv_requests: Vec<(String, usize, bool)> = Vec::new();
   for item in dep_items {
+    if let Some(req) = derivative_dep_item(item, x_name) {
+      deriv_requests.push(req);
+      continue;
+    }
     match item {
       Expr::Identifier(name) => funcs.push(SysFunc {
         name: name.clone(),
@@ -1118,11 +1209,12 @@ fn ndsolve_system(
     return Ok(None);
   }
 
-  // Split equations into ODEs and initial conditions.
-  let eq_items: Vec<Expr> = match &args[0] {
-    Expr::List(items) => items.to_vec(),
-    other => vec![other.clone()],
-  };
+  // Split equations into ODEs and initial conditions. The equations
+  // argument nests arbitrarily — a common idiom groups a function's
+  // initial conditions into their own sublist, e.g. `{ode, {ic1, ic2}}` —
+  // so every level of `List` is flattened rather than just the outermost.
+  let mut eq_items: Vec<Expr> = Vec::new();
+  flatten_eq_list(&args[0], &mut eq_items);
   let mut odes: Vec<Expr> = Vec::new();
   let mut x0: Option<f64> = None;
   // (function name, derivative order, value) — by name, not index: an
@@ -1216,6 +1308,17 @@ fn ndsolve_system(
   }
   if funcs.iter().any(|f| f.order == 0) {
     return Ok(None);
+  }
+  // Every requested derivative must be of a function actually being
+  // solved for, and of an order already carried in its state vector
+  // (0..order-1); the highest derivative itself isn't stored there.
+  for (name, order, _) in &deriv_requests {
+    let Some(f) = funcs.iter().find(|f| &f.name == name) else {
+      return Ok(None);
+    };
+    if *order >= f.order {
+      return Ok(None);
+    }
   }
 
   // Validate and store the initial conditions.
@@ -1367,6 +1470,57 @@ fn ndsolve_system(
         pattern: Box::new(Expr::FunctionCall {
           name: f.name.clone(),
           args: vec![Expr::Identifier(x_name.clone())].into(),
+        }),
+        replacement: Box::new(Expr::CurriedCall {
+          func: Box::new(interp),
+          args: vec![Expr::Identifier(x_name.clone())],
+        }),
+      }
+    });
+  }
+
+  // Extra rules for `Derivative[k][f]` entries requested alongside `f`:
+  // the same points, just read from the state slot the derivative already
+  // occupies (`f`'s state runs f, f', …, f^(order-1) from `state_offset`).
+  for (name, order, function_form) in &deriv_requests {
+    let fi = funcs.iter().position(|f| &f.name == name).unwrap();
+    let domain = Expr::List(
+      vec![Expr::List(vec![Expr::Real(x_lo), Expr::Real(x_hi)].into())].into(),
+    );
+    let data = Expr::List(
+      points
+        .iter()
+        .map(|(x, s)| {
+          Expr::List(
+            vec![Expr::Real(*x), Expr::Real(s[state_offset[fi] + order])]
+              .into(),
+          )
+        })
+        .collect(),
+    );
+    let interp = call(
+      "InterpolatingFunction",
+      vec![domain, data, Expr::Integer(NDSOLVE_INTERPOLATION_ORDER)],
+    );
+    // Mirrors the parser's own shape for `Derivative[k][f]` (nested
+    // `CurriedCall`s) so `/.` matches the same expression the user wrote.
+    let deriv_pattern = Expr::CurriedCall {
+      func: Box::new(Expr::FunctionCall {
+        name: "Derivative".to_string(),
+        args: vec![Expr::Integer(*order as i128)].into(),
+      }),
+      args: vec![Expr::Identifier(name.clone())],
+    };
+    rules.push(if *function_form {
+      Expr::Rule {
+        pattern: Box::new(deriv_pattern),
+        replacement: Box::new(interp),
+      }
+    } else {
+      Expr::Rule {
+        pattern: Box::new(Expr::CurriedCall {
+          func: Box::new(deriv_pattern),
+          args: vec![Expr::Identifier(x_name.clone())],
         }),
         replacement: Box::new(Expr::CurriedCall {
           func: Box::new(interp),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -8392,9 +8392,14 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
           .join(",");
         return format!("NumericArray[<{dim_str}>, {dtype}]");
       }
-      // InputForm: falls through to default formatting (ByteArray["base64"])
-      // Special case: InterpolatingFunction[domain, data] — hide data with <>
-      if name == "InterpolatingFunction" && (args.len() == 2 || args.len() == 3)
+      // Special case: InterpolatingFunction[domain, data] — hide data with
+      // <> for display only; InputForm falls through to the full literal
+      // data so re-parsing it (e.g. Manipulate's per-frame state
+      // round-trip) recovers the same object instead of hitting `<>`,
+      // which isn't valid input syntax.
+      if name == "InterpolatingFunction"
+        && (args.len() == 2 || args.len() == 3)
+        && is_output
       {
         return format!("InterpolatingFunction[{}, <>]", fmt(&args[0]));
       }

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7558,6 +7558,82 @@ mod ndsolve {
   }
 
   #[test]
+  fn ndsolve_second_argument_requests_a_derivative_alongside_its_function() {
+    // Regression: `NDSolve[…, {y, y'}, …]` used to bail out unevaluated —
+    // `Derivative[1][y]` in the second argument wasn't recognized as a
+    // request for y's derivative and was instead treated as an opaque
+    // "compound head" to rename away. It should return both `y` and
+    // `Derivative[1][y]` as separate InterpolatingFunction rules, sparing
+    // the caller from differentiating the interpolant themselves.
+    // y'' + y == 0, y(0) = 1, y'(0) = 0 → y = Cos[t], y' = -Sin[t].
+    let result = interpret(
+      "sol = NDSolve[{y''[t] + y[t] == 0, y[0] == 1, y'[0] == 0}, {y, y'}, \
+       {t, 0, 4}]; y'[N[Pi/2]] /. sol[[1,2]]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    let expected = -(std::f64::consts::FRAC_PI_2.sin());
+    assert!(
+      (val - expected).abs() < 0.01,
+      "Expected {expected}, got {val}"
+    );
+  }
+
+  #[test]
+  fn ndsolve_requested_derivative_keeps_its_own_rule_and_function_intact() {
+    // The `y -> …` rule must still come back too, and unaffected by the
+    // extra `Derivative[1][y] -> …` rule alongside it.
+    let result = interpret(
+      "sol = NDSolve[{y''[t] + y[t] == 0, y[0] == 1, y'[0] == 0}, {y, y'}, \
+       {t, 0, 4}]; y[N[Pi]] /. sol[[1,1]]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!((val - (-1.0)).abs() < 0.01, "Expected -1.0, got {val}");
+  }
+
+  #[test]
+  fn ndsolve_flattens_a_nested_initial_condition_list() {
+    // Regression: an equations argument that groups one function's initial
+    // conditions into their own sublist — `{ode, {ic1, ic2}}`, a common
+    // Demonstrations idiom — used to be counted as a second, bogus equation
+    // (a List isn't itself an equation) rather than flattened, so the
+    // equation/function count mismatched and NDSolve bailed out unevaluated.
+    // Same system as `second_order_harmonic`: y'' + y = 0, y(0)=1, y'(0)=0,
+    // so y(Pi) ≈ -1.
+    let result = interpret(
+      "sol = NDSolve[{y''[x] + y[x] == 0, {y[0] == 1, y'[0] == 0}}, y, \
+       {x, 0, 4}]; y[N[Pi]] /. sol[[1]]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!((val - (-1.0)).abs() < 0.01, "Expected -1.0, got {val}");
+  }
+
+  #[test]
+  fn interpolating_function_input_form_has_no_placeholder() {
+    // Regression: InterpolatingFunction's `<>` data placeholder — meant
+    // only to keep display output short — was also applied under
+    // InputForm, where it isn't valid syntax at all. Manipulate relies on
+    // InputForm to round-trip a variable's value back through the parser
+    // between frames (`ManipulateState::reevaluate`), so a body that binds
+    // a Demonstration's NDSolve solution to a variable would throw a parse
+    // error on the very next frame. InputForm must print the literal data.
+    let result = interpret(
+      "ToString[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}], InputForm]",
+    )
+    .unwrap();
+    assert!(
+      result.contains("InterpolatingFunction") && !result.contains("<>"),
+      "Got: {result}"
+    );
+    // OutputForm (the default) is unaffected — it should still abbreviate.
+    let output =
+      interpret("NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]").unwrap();
+    assert!(output.contains("<>"), "Got: {output}");
+  }
+
+  #[test]
   fn ndsolve_implicit_coefficient_times_indexed_double_derivative() {
     // Regression: a coefficient placed via implicit multiplication directly
     // before an indexed function's double derivative (`mu pos[1]''[t]`, no


### PR DESCRIPTION
## Summary

Downloaded a random Wolfram Demonstration ("Mass Oscillating between a Spring and a Damper") to check whether Woxi Studio fully supports it. Its `Manipulate` failed to render the physics correctly. Three bugs conspired:

- `NDSolve[eqns, {f, f'}, ...]` bailed unevaluated: a `Derivative[k][f]` entry in the second argument was mistaken for an opaque "compound head" (the `Subscript[c,1]`-style renaming meant for indexed unknowns) and renamed away before NDSolve's own dependent-variable parsing ever saw it. Fixed both the renaming logic and the parsing itself, so `NDSolve` now returns both `f -> InterpolatingFunction[...]` and `Derivative[1][f] -> InterpolatingFunction[...]`, sparing the caller from differentiating the interpolant.
- Equations grouped as `{ode, {ic1, ic2}}` (a common Demonstrations idiom for bundling one function's initial conditions) weren't flattened, so the nested sublist was miscounted as a second equation and the system was rejected. `NDSolve`'s equations argument is now flattened recursively.
- `InterpolatingFunction`'s `<>` data placeholder — meant only to keep display output short — was also applied under `InputForm`, where it isn't valid syntax. `Manipulate` relies on `InputForm` to round-trip a variable's value between frames, so any body binding an NDSolve solution to a variable hit a parse error on the very next frame. `InputForm` now prints the literal data.

Verified against the actual downloaded notebook (not committed, since it's copyrighted): before the fix, `dump_manipulate` reported `ReplaceAll::reps` errors and (with the `InputForm` bug fixed) a parse error; after all three fixes it renders correctly, producing the expected damped-oscillator plot.

## Test plan

- [x] Added 4 regression tests in `tests/interpreter_tests/calculus.rs` covering each bug (`NDSolve` with `{f, f'}`, nested IC list flattening, and `InterpolatingFunction` `InputForm`)
- [x] `cargo test --workspace` — all 27,798 tests pass (0 failed) across every crate, including the pre-existing 184 Demonstration/Manipulate regression tests in `woxi-studio`
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_015hh9NZdp8j1pU1CXBp5rwA)_