### PR TITLE
Render Subsuperscript in Manipulate control labels

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -19609,6 +19609,25 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       },
       "Subscript" => script_runs(args, italic, false),
       "Superscript" => script_runs(args, italic, true),
+      // `Subsuperscript[base, sub, sup]` — a Demonstration's slider label for
+      // an initial derivative writes `y0'` as `Subsuperscript[y, 0, "\[Prime]"]`.
+      // Plain text can't stack a sub- and superscript at once, so the two
+      // render in sequence: the subscript first, then the superscript.
+      "Subsuperscript" if args.len() == 3 => {
+        let mut runs = script_runs(&args[..2], italic, false);
+        let sup = to_unicode_script(
+          &flatten_label_runs(&manipulate_label_runs(&args[2], false)),
+          true,
+        );
+        if !sup.is_empty() {
+          runs.push(LabelRun {
+            text: sup,
+            italic: false,
+            ..Default::default()
+          });
+        }
+        runs
+      }
       // `Underscript[base, mark]` — the limit written under a base, e.g. a
       // sum's index. No diacritic reads as an under-mark in practice, so
       // the mark simply sits in subscript position like `Subscript` does.

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21387,4 +21387,65 @@ SaveDefinitions -> True]";
       "the construction must still render with the new radii"
     );
   }
+
+  #[test]
+  fn damped_pendulum_manipulate_labels_initial_angular_velocity() {
+    // End-to-end regression for the "Active Shock Absorbers" Demonstration's
+    // control-panel shape: a slider for an initial derivative labels itself
+    // `Text@Subsuperscript[Style["y", Italic], "0", "\[Prime]"]` (y₀′).
+    // `Subsuperscript` used to fall through to `manipulate_label_runs`'s
+    // catch-all, which just echoes the expression's OutputForm dump
+    // (`"Subsuperscript[θ, 0, ′]"`) — only `Subscript` and `Superscript` had
+    // dedicated cases.
+    let code = "Manipulate[\
+      With[{sol = Quiet@NDSolve[\
+        {θ''[t] + damping θ'[t] + Sin[θ[t]] == 0, \
+         θ[0] == θ0, θ'[0] == ω0}, θ, {t, 0, 20}]}, \
+        Plot[Evaluate[θ[t] /. sol], {t, 0, 20}, PlotRange -> All]], \
+      {{θ0, 0.5, Text@Subscript[Style[\"θ\", Italic], \"0\"]}, \
+        0, 3, 0.01, ImageSize -> Tiny, Appearance -> \"Labeled\"}, \
+      {{ω0, 0, Text@Subsuperscript[Style[\"θ\", Italic], \"0\", \"′\"]}, \
+        -2, 2, 0.01, ImageSize -> Tiny, Appearance -> \"Labeled\"}, \
+      {{damping, 0.2, Style[\"damping\", Italic]}, 0, 2, 0.01, \
+        ImageSize -> Tiny, Appearance -> \"Labeled\"}, \
+      SaveDefinitions -> True]";
+
+    let widget = instantiate_stored_manipulate(code, "")
+      .expect("the Manipulate must build a widget");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the pendulum-angle plot must render"
+    );
+    match &widget.controls[..] {
+      [_theta0, omega0, _damping] => match omega0 {
+        manipulate::ControlState::Continuous {
+          name,
+          label,
+          label_runs,
+          ..
+        } => {
+          assert_eq!(name, "ω0");
+          assert_eq!(
+            label, "θ₀′",
+            "Subsuperscript must typeset as base + subscript + superscript, \
+             not echo its OutputForm"
+          );
+          assert_eq!(
+            label_runs
+              .iter()
+              .map(|r| r.text.as_str())
+              .collect::<String>(),
+            "θ₀′"
+          );
+        }
+        other => panic!("expected a continuous control, got {other:?}"),
+      },
+      other => panic!("expected three controls, got {other:?}"),
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Checked Woxi Studio against the Wolfram Demonstration "Active Shock Absorbers" (randomly picked from the Wolfram Demonstrations Project resource system).
- Its `Manipulate` labels the initial-angular-velocity slider with `Text@Subsuperscript[Style["y", Italic], "0", "\[Prime]"]` (rendered as `y0'`). `manipulate_label_runs` in `src/functions/graphics.rs` only had dedicated cases for `Subscript` and `Superscript`, so `Subsuperscript` fell through to the catch-all and the slider showed the literal OutputForm dump `Subsuperscript[y, 0, ′]` instead of a typeset label.
- Added a `Subsuperscript[base, sub, sup]` case that renders the base with its subscript, then appends the superscript — matching how `Subscript`/`Superscript` are already handled.
- With this fix, the notebook's `Manipulate` now builds and renders its widget with no errors (verified by rebuilding the notebook's `Manipulate` expression against `ManipulateState::from_expr`).

## Test plan

- [x] Added `damped_pendulum_manipulate_labels_initial_angular_velocity` in `woxi-studio/src/main.rs`, an end-to-end regression test asserting the `Subsuperscript`-labeled slider typesets as `θ₀′` (not its OutputForm dump) and that the widget's graphics render.
- [x] `cargo test -p woxi-studio` — 185 passed, 0 failed.
- [x] `cargo test --workspace --exclude woxi-studio --exclude woxi-py` — all passed.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WeQft5Q4Fmwh68iYioEz5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeQft5Q4Fmwh68iYioEz5y)_