### PR TITLE
Fix SameQ/Equal treating all distinct Images as identical

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -3328,13 +3328,33 @@ pub fn evaluate_expr_to_expr_inner(
             // Special case: a machine-precision Real and a BigFloat with
             // a precision tag inside the machine-precision band collapse
             // to the same f64 — Wolfram treats them as SameQ.
-            expr_to_string(left) == expr_to_string(right)
-              || crate::functions::boolean_ast::same_q_real_bigfloat(
-                left, right,
-              )
+            //
+            // `expr_to_string` reports every `Image[…]` as the same
+            // `-Image-` display placeholder, so the string fast path
+            // would treat any two images as SameQ regardless of their
+            // pixel data — compare the actual raster content instead.
+            if matches!(left, Expr::Image { .. })
+              || matches!(right, Expr::Image { .. })
+            {
+              crate::evaluator::pattern_matching::expr_equal(left, right)
+            } else {
+              expr_to_string(left) == expr_to_string(right)
+                || crate::functions::boolean_ast::same_q_real_bigfloat(
+                  left, right,
+                )
+            }
           }
           ComparisonOp::Equal => {
-            if let Some(ord) = exact_integer_ord(left, right) {
+            // `expr_to_string` reports every `Image[…]` as the same
+            // `-Image-` display placeholder, so the string-identity
+            // fallback further below would treat any two images as
+            // Equal regardless of their pixel data — compare the
+            // actual raster content instead.
+            if matches!(left, Expr::Image { .. })
+              || matches!(right, Expr::Image { .. })
+            {
+              crate::evaluator::pattern_matching::expr_equal(left, right)
+            } else if let Some(ord) = exact_integer_ord(left, right) {
               matches!(ord, std::cmp::Ordering::Equal)
             } else {
               // Two BigFloats with > ~16 digits of precision can carry
@@ -3433,10 +3453,22 @@ pub fn evaluate_expr_to_expr_inner(
           }
           ComparisonOp::UnsameQ => {
             // UnsameQ tests structural non-identity, not numeric inequality.
-            expr_to_string(left) != expr_to_string(right)
+            // See the SameQ arm above: images all share the `-Image-`
+            // display placeholder, so compare pixel data instead.
+            if matches!(left, Expr::Image { .. })
+              || matches!(right, Expr::Image { .. })
+            {
+              !crate::evaluator::pattern_matching::expr_equal(left, right)
+            } else {
+              expr_to_string(left) != expr_to_string(right)
+            }
           }
           ComparisonOp::NotEqual => {
-            if let Some(ord) = exact_integer_ord(left, right) {
+            if matches!(left, Expr::Image { .. })
+              || matches!(right, Expr::Image { .. })
+            {
+              !crate::evaluator::pattern_matching::expr_equal(left, right)
+            } else if let Some(ord) = exact_integer_ord(left, right) {
               !matches!(ord, std::cmp::Ordering::Equal)
             } else if let (Some(l), Some(r)) =
               (try_eval_to_f64(left), try_eval_to_f64(right))

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -2709,6 +2709,35 @@ pub fn expr_equal(a: &Expr, b: &Expr) -> bool {
         && a1.len() == a2.len()
         && a1.iter().zip(a2.iter()).all(|(x, y)| expr_equal(x, y))
     }
+    // Images have no useful textual form (`expr_to_string` reports the
+    // `-Image-` display placeholder for every one of them), so the
+    // catch-all below would treat any two images as equal regardless of
+    // their pixel data. Compare the actual raster content instead.
+    (
+      Expr::Image {
+        width: w1,
+        height: h1,
+        channels: c1,
+        data: d1,
+        image_type: t1,
+        color_space: s1,
+      },
+      Expr::Image {
+        width: w2,
+        height: h2,
+        channels: c2,
+        data: d2,
+        image_type: t2,
+        color_space: s2,
+      },
+    ) => {
+      w1 == w2
+        && h1 == h2
+        && c1 == c2
+        && t1 == t2
+        && s1 == s2
+        && (std::sync::Arc::ptr_eq(d1, d2) || d1 == d2)
+    }
     _ => expr_to_string(a) == expr_to_string(b),
   }
 }

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -256,6 +256,17 @@ pub fn same_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let first_str = crate::syntax::expr_to_string(first);
 
   for arg in args.iter().skip(1) {
+    // `expr_to_string` reports every `Image[…]` as the same `-Image-`
+    // display placeholder, so the string fast path below would treat any
+    // two images as SameQ regardless of their pixel data. Compare the
+    // actual raster content instead whenever either side is an image.
+    if matches!(first, Expr::Image { .. }) || matches!(arg, Expr::Image { .. })
+    {
+      if !crate::evaluator::pattern_matching::expr_equal(first, arg) {
+        return Ok(bool_expr(false));
+      }
+      continue;
+    }
     let val_str = crate::syntax::expr_to_string(arg);
     if val_str != first_str && !same_q_real_bigfloat(first, arg) {
       return Ok(bool_expr(false));
@@ -359,13 +370,25 @@ pub fn unsame_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // UnsameQ is not HoldAll: arguments arrive already evaluated, so just take
   // their string forms (re-evaluating deep arguments is needlessly expensive).
+  //
+  // `expr_to_string` reports every `Image[…]` as the same `-Image-` display
+  // placeholder, so that string fast path would treat any two images as
+  // identical regardless of their pixel data — compare those pairs
+  // structurally instead.
   let strs: Vec<String> =
     args.iter().map(crate::syntax::expr_to_string).collect();
 
   // UnsameQ is True only if ALL pairs are different
   for i in 0..strs.len() {
     for j in (i + 1)..strs.len() {
-      if strs[i] == strs[j] {
+      let same = if matches!(args[i], Expr::Image { .. })
+        || matches!(args[j], Expr::Image { .. })
+      {
+        crate::evaluator::pattern_matching::expr_equal(&args[i], &args[j])
+      } else {
+        strs[i] == strs[j]
+      };
+      if same {
         return Ok(bool_expr(false));
       }
     }
@@ -648,6 +671,19 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut all_identical = true;
 
   for arg in args.iter().skip(1) {
+    // `expr_to_string` reports every `Image[…]` as the same `-Image-`
+    // display placeholder, so the string fast path below would treat any
+    // two images as Equal regardless of their pixel data. Compare the
+    // actual raster content instead whenever either side is an image.
+    if matches!(&args[0], Expr::Image { .. })
+      || matches!(arg, Expr::Image { .. })
+    {
+      if !crate::evaluator::pattern_matching::expr_equal(&args[0], arg) {
+        all_identical = false;
+        break;
+      }
+      continue;
+    }
     let val_str = crate::syntax::expr_to_string(arg);
     if val_str != first_str {
       all_identical = false;
@@ -817,17 +853,29 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Two operands also count as "equal" when they share head and arity with
   // every leaf determinably equal, e.g. RGBColor[0., 0., 1.] != RGBColor[0,
   // 0, 1] is False.
+  // `expr_to_string` reports every `Image[…]` as the same `-Image-` display
+  // placeholder, so the string-identity checks above would treat any two
+  // images as a duplicate pair regardless of their pixel data — compare
+  // those pairs structurally instead.
+  let pair_identical = |i: usize, j: usize| {
+    if matches!(args[i], Expr::Image { .. })
+      || matches!(args[j], Expr::Image { .. })
+    {
+      crate::evaluator::pattern_matching::expr_equal(&args[i], &args[j])
+    } else {
+      strs[i] == strs[j] || all_components_equal(&args[i], &args[j])
+    }
+  };
   if has_free {
     for i in 0..strs.len() - 1 {
-      if strs[i] == strs[i + 1] || all_components_equal(&args[i], &args[i + 1])
-      {
+      if pair_identical(i, i + 1) {
         return Ok(bool_expr(false));
       }
     }
   } else {
     for i in 0..strs.len() {
       for j in i + 1..strs.len() {
-        if strs[i] == strs[j] || all_components_equal(&args[i], &args[j]) {
+        if pair_identical(i, j) {
           return Ok(bool_expr(false));
         }
       }

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1653,6 +1653,60 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_distinct_images_are_not_same_q_or_equal() {
+    // `expr_to_string` reports every `Image[…]` as the same `-Image-`
+    // display placeholder. `SameQ`/`Equal` and the structural-equality
+    // helper they share must compare actual pixel data instead of that
+    // placeholder, or any two distinct images collapse into "the same
+    // value" — e.g. a Demonstration that builds a `Graph` whose vertices
+    // are image tiles (`GraphPlot[Thread[imgA -> imgB], …]`) would then
+    // see every tile dedup into a single vertex.
+    clear_state();
+    assert_eq!(
+      interpret("Image[{{1, 2}, {3, 4}}] === Image[{{5, 6}, {7, 8}}]").unwrap(),
+      "False"
+    );
+    assert_eq!(
+      interpret("SameQ[Image[{{1, 2}, {3, 4}}], Image[{{5, 6}, {7, 8}}]]")
+        .unwrap(),
+      "False"
+    );
+    assert_eq!(
+      interpret("Image[{{1, 2}, {3, 4}}] == Image[{{5, 6}, {7, 8}}]").unwrap(),
+      "False"
+    );
+    // Two images with identical pixel data are still SameQ/Equal.
+    assert_eq!(
+      interpret("Image[{{1, 2}, {3, 4}}] === Image[{{1, 2}, {3, 4}}]").unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret("Image[{{1, 2}, {3, 4}}] == Image[{{1, 2}, {3, 4}}]").unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn test_graph_plot_dedups_image_vertices_by_content() {
+    // `GraphPlot[Thread[imgA -> imgB], …]` — the pattern a Demonstration
+    // uses to plot a nearest-neighbor graph over image tiles — must build
+    // one graph vertex per distinct image, not collapse every image into
+    // one vertex because they all stringify to `-Image-`.
+    clear_state();
+    let svg = interpret(
+      "imgs = Table[Image[ConstantArray[N[i / 5], {2, 2, 3}]], {i, 1, 5}]; \
+       edges = Flatten[Table[Thread[imgs[[i]] -> {imgs[[Mod[i, 5] + 1]]}], {i, 5}]]; \
+       ExportString[GraphPlot[edges, VertexRenderingFunction -> (Inset[#2, #, Center, .5] &)], \"SVG\"]",
+    )
+    .unwrap();
+    assert_eq!(
+      svg.matches("<image").count(),
+      5,
+      "expected one <image> per distinct vertex, got: {svg}"
+    );
+  }
+
+  #[test]
   fn test_inset_labeled_graphic_embeds_picture() {
     // `Inset[Labeled[Graphics[…], caption], pos, opos, size]` — a
     // Demonstration's usual way to caption a small diagram composited into


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration notebook ("Grouping Images by Color") via the resource system's `RandomResourcePage` API to check Woxi Studio support, per the scheduled task.
- The Demonstration's `similarityGraph[n_] := GraphPlot[..., VertexRenderingFunction -> (Inset[#2, #, Center, .5] &)]` builds a nearest-neighbor graph whose vertices are `Image[…]` tiles (`Thread[images[[i]] -> nf[colorMeans[[i]], n]]`). Rendering it in Woxi produced a graph with only **1** vertex instead of the expected 60 — every image tile collapsed into a single node.
- Root cause: `Image[…]` has no useful textual form, so `expr_to_string` reports every image as the same `"-Image-"` display placeholder. `SameQ`, `Equal`, `UnsameQ`, `NotEqual` (both their function and `===`/`==`/`=!=`/`!=` operator forms) and the shared `expr_equal` structural-equality helper all used that placeholder string as a fast-path identity check — so any two images with *different* pixel data were reported as `SameQ`/`Equal`. `Graph`'s vertex-dedup logic uses `expr_equal`, so it inherited the bug and collapsed every distinct image vertex into one.
- Fixed by comparing actual raster content (width/height/channels/type/color space/data) whenever either operand of an equality comparison is an `Image`.

## Test plan

- [x] Added `test_distinct_images_are_not_same_q_or_equal` and `test_graph_plot_dedups_image_vertices_by_content` regression tests in `tests/interpreter_tests.rs`
- [x] `make test` — all 27,608 unit tests pass
- [x] `cargo test -p woxi-studio` — all 184 tests pass
- [x] `make format`
- [x] Re-ran the downloaded Demonstration notebook end-to-end before/after the fix: `GraphPlot` now renders all 60 distinct image-tile vertices (was 1)


---
_Generated by [Claude Code](https://claude.ai/code/session_0179fBf5kVqtPmYZGAdNyGrQ)_