### PR TITLE
Skip Claude code review for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs get a restricted token: repository secrets are not exposed and
+    # `id-token: write` is ignored, so the action cannot authenticate and the
+    # check always fails. Skip it there instead of showing contributors a red X
+    # they cannot fix.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
Add a conditional check to the Claude code review workflow to skip execution on pull requests from forks, preventing misleading failures that contributors cannot fix.

## Changes
- Added `if` condition to the `claude-review` job that only runs the workflow when the PR originates from the same repository
- This prevents the workflow from failing on fork PRs where the restricted token cannot authenticate with the Claude API
- Includes explanatory comment documenting why fork PRs are skipped

## Details
Fork pull requests receive a restricted GitHub token that doesn't expose repository secrets and ignores `id-token: write` permissions. This causes the Claude code review action to fail authentication and always show a red X check, which is confusing to contributors since they cannot fix the issue. By skipping the workflow entirely for fork PRs, we avoid showing a misleading failure status while still running the review for PRs from the main repository.

https://claude.ai/code/session_01LfSnWJnhwVrcQRQgvSuNR3