### PR TITLE
Fix Spacer inside a Row plot label being dropped by real SVG renderers

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -124,17 +124,20 @@ impl StyledLabel {
   }
 }
 
-/// Multiply the absolute lengths in SVG markup — `font-size="N"` and the
-/// `letter-spacing:Npx` a `Spacer` becomes — by `scale`, leaving relative
-/// ones (`70%`, `1.2em`) as they are.
+/// Multiply the absolute lengths in SVG markup — `font-size="N"`, the
+/// `letter-spacing:Npx` a lone `Spacer` becomes, and the `dx="N"` a
+/// `Spacer` next to other Row content becomes — by `scale`, leaving
+/// relative ones (`70%`, `1.2em`) as they are.
 fn scale_markup_lengths(markup: &str, scale: f64) -> String {
   if scale == 1.0 {
     return markup.to_string();
   }
   let mut out = markup.to_string();
-  for (attr, terminator, unit) in
-    [("font-size=\"", '"', ""), ("letter-spacing:", 'p', "px")]
-  {
+  for (attr, terminator, unit) in [
+    ("font-size=\"", '"', ""),
+    ("letter-spacing:", 'p', "px"),
+    ("dx=\"", '"', ""),
+  ] {
     out = scale_lengths_after(&out, attr, terminator, unit, scale);
   }
   out

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -9264,6 +9264,10 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
         // appears — among a `Row`'s items as readily as as its separator.
         // The width is absolute, not relative to the font: `Spacer[25]`
         // is the same gap next to 8-point text as next to 30-point text.
+        // With no following element to carry a `dx` (see the `Row` case
+        // below), the best this lone-item fallback can do is the
+        // letter-spacing trick — real renderers keep it for a non-final
+        // character, just not a trailing one.
         "Spacer" => {
           let pts = args.first().and_then(expr_to_f64).unwrap_or(1.0);
           format!("<tspan style=\"letter-spacing:{pts:.2}px\"> </tspan>")
@@ -9279,30 +9283,59 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
         }
 
         // Row[{a, b, …}] concatenates its parts; Row[{…}, sep] joins
-        // them with the separator.
+        // them with the separator. A `Spacer[n]` gap — as a bare item or
+        // as the separator — is carried as a `dx` on the *next* rendered
+        // part rather than printed as its own trailing tspan: SVG
+        // renderers (including the one Woxi Studio rasterizes with)
+        // don't apply `letter-spacing` after the last character of a
+        // tspan, so a gap placed there is silently dropped. `dx` on the
+        // following content has no such last-character special case.
         "Row" if !args.is_empty() => match &args[0] {
           Expr::List(parts) => {
-            let sep = args
-              .get(1)
-              .map(|s| match s {
-                // `Spacer[n]` separates with a gap n ems wide, rather
-                // than printing itself.
-                Expr::FunctionCall { name, args: sargs }
-                  if name == "Spacer" =>
-                {
-                  let pts = sargs.first().and_then(expr_to_f64).unwrap_or(1.0);
-                  format!(
-                    "<tspan style=\"letter-spacing:{pts:.2}px\"> </tspan>"
-                  )
+            let sep_gap = match args.get(1) {
+              Some(Expr::FunctionCall { name, args: sargs })
+                if name == "Spacer" =>
+              {
+                Some(sargs.first().and_then(expr_to_f64).unwrap_or(1.0))
+              }
+              _ => None,
+            };
+            let sep_markup =
+              if sep_gap.is_none() { args.get(1).map(expr_to_svg_markup) }
+              else { None };
+
+            let mut out = String::new();
+            let mut pending_gap = 0.0_f64;
+            let mut first = true;
+            for part in parts {
+              // A `Spacer[n]` item is a gap, not something to print —
+              // fold its width into whatever comes next.
+              if let Expr::FunctionCall { name, args: sargs } = part
+                && name == "Spacer"
+              {
+                pending_gap +=
+                  sargs.first().and_then(expr_to_f64).unwrap_or(1.0);
+                continue;
+              }
+              if !first {
+                if let Some(pts) = sep_gap {
+                  pending_gap += pts;
+                } else if let Some(m) = &sep_markup {
+                  out.push_str(m);
                 }
-                other => expr_to_svg_markup(other),
-              })
-              .unwrap_or_default();
-            parts
-              .iter()
-              .map(expr_to_svg_markup)
-              .collect::<Vec<_>>()
-              .join(&sep)
+              }
+              let markup = expr_to_svg_markup(part);
+              if pending_gap > 0.0 {
+                out.push_str(&format!(
+                  "<tspan dx=\"{pending_gap:.2}\">{markup}</tspan>"
+                ));
+                pending_gap = 0.0;
+              } else {
+                out.push_str(&markup);
+              }
+              first = false;
+            }
+            out
           }
           other => expr_to_svg_markup(other),
         },

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -4380,17 +4380,51 @@ mod plot3d {
         "a 16-point run must stay legible beside a {outer}-unit label, \
          got {styled}: {label}"
       );
-      // `Spacer[25]` is 25 points of gap, so it scales with the picture
-      // rather than with whatever font size it lands next to.
+      // `Spacer[25]` is 25 points of gap, carried as a `dx` on the run
+      // that follows it (not `letter-spacing` on a trailing tspan of its
+      // own — real SVG renderers, including the one Woxi Studio uses,
+      // drop letter-spacing after a tspan's last character, which made
+      // the gap invisible). It scales with the picture rather than with
+      // whatever font size it lands next to.
       let spacing: f64 = label
-        .split_once("letter-spacing:")
-        .and_then(|(_, r)| r.split_once("px"))
+        .split_once("dx=\"")
+        .and_then(|(_, r)| r.split_once('"'))
         .and_then(|(v, _)| v.parse().ok())
         .expect("the spacer gap");
       assert!(
         (spacing - styled * 25.0 / 16.0).abs() < 1.0,
         "a Spacer[25] beside 16-point text is 25/16 of its size, \
          got {spacing} against {styled}: {label}"
+      );
+    }
+
+    /// Regression: a `Spacer[n]` between differently-styled `Row` parts
+    /// (a plain string and a `Subscript`, say) used to become its own
+    /// trailing `<tspan style="letter-spacing:…">` — which real SVG
+    /// renderers, including the one Woxi Studio rasterizes plots with,
+    /// silently drop because it is the last character of that tspan. The
+    /// gap must survive as a `dx` on the *next* run instead, so the text
+    /// on either side of the spacer doesn't visually run together (found
+    /// via a downloaded Wolfram Demonstrations Project notebook whose
+    /// `PlotLabel` glued "...C" straight onto "Ea1=145..." with no gap).
+    #[test]
+    fn plot_label_spacer_next_to_subscript_leaves_a_visible_gap() {
+      let svg = export_svg(
+        "Plot[x, {x, 0, 1}, PlotLabel -> Style[Row[Flatten[{\"A\", \
+         Spacer[40], Subscript[\"Ea\", 1], \" = \", 145}]], 18]]",
+      );
+      let label = svg
+        .split("<text ")
+        .find(|t| t.contains("Ea"))
+        .expect("the plot label");
+      assert!(
+        !label.contains("letter-spacing"),
+        "the gap must not be a trailing letter-spacing tspan, which \
+         renderers drop: {label}"
+      );
+      assert!(
+        label.contains("dx=\""),
+        "the gap must be a dx on the run after the spacer: {label}"
       );
     }
 


### PR DESCRIPTION
## Summary

- Checked whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook ("Series Reactions in a Batch Reactor" — a `Manipulate` with an `NDSolve`-driven kinetics plot). The interactive widget itself built and rendered correctly (controls, ODE solve, plot), but the `PlotLabel` — `Style[Row[Flatten[{"A → B → C", Spacer[40], Subscript["Ea",1], " = ", 145, " kJ/mol", ...}]], 18]` — rendered with no gap between differently-styled runs: `"A → B → CEa₁ = 145 kJ/molEa₂ = 155 kJ/mol"` instead of properly spaced text.
- Root cause: `Spacer[n]` next to other `Row` content was emitted as its own trailing `<tspan style="letter-spacing:Npx"> </tspan>`. Real SVG renderers — including resvg, which Woxi Studio rasterizes plots with — don't apply `letter-spacing` after the *last* character of a `tspan`, so the gap silently collapsed to zero whenever a `Spacer` was followed by a differently-styled sibling run (e.g. a `Subscript`).
- Fix: carry the gap as a `dx` attribute on the run that *follows* the `Spacer` instead, which has no such last-character special case, and scale it the same way `letter-spacing` was already scaled when a label is embedded in a larger plot canvas.
- Per repo guidelines, did not copy any code from the downloaded (copyrighted) Demonstration notebook — the fix and its regression test use an independently written minimal reproduction.

## Test plan

- [x] Added `plot_label_spacer_next_to_subscript_leaves_a_visible_gap` regression test in `tests/interpreter_tests/graphics.rs`.
- [x] Updated `plot_label_style_size_and_spacer_scale_with_the_picture` to assert on the new `dx="..."` markup instead of the removed trailing `letter-spacing:`.
- [x] `cargo test --lib --tests` — all 6 test binaries pass (27,607 tests, 0 failures).
- [x] `make format`.
- [x] Manually verified via `dump_manipulate`/`rasterize_svg` (Woxi Studio's own interactive-cell pipeline) that the downloaded Demonstration's `PlotLabel` now renders with correct spacing between `"A → B → C"`, `"Ea₁ = 145 kJ/mol"`, and `"Ea₂ = 155 kJ/mol"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01231zPxSR8ZzKau8pPVbeEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01231zPxSR8ZzKau8pPVbeEu)_