### PR TITLE
Flatten PaneSelector controls nested inside a Manipulate Grid layout

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -18437,9 +18437,19 @@ fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
       _ => item,
     };
     match item {
-      // A Grid's first level is its list of layout rows; their elements
-      // are the actual items.
-      Expr::List(row) if name == "Grid" => out.extend(row.iter().cloned()),
+      // A Grid's first level is its list of layout rows; their elements are
+      // the actual items, each flattened the same way any other layout
+      // item is below — a row cell can itself be a `PaneSelector`/`Row`/
+      // `Column` grouping further controls (the Demonstrations idiom of a
+      // custom Grid-based control panel), not just a bare `Control`/`Button`.
+      Expr::List(row) if name == "Grid" => {
+        for cell in row {
+          match control_group_items(cell) {
+            Some(nested) => out.extend(nested),
+            None => out.push(cell.clone()),
+          }
+        }
+      }
       // Nested layout containers flatten recursively.
       other => match control_group_items(other) {
         Some(nested) => out.extend(nested),
@@ -18448,6 +18458,27 @@ fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
     }
   }
   Some(out)
+}
+
+/// A `PaneSelector[{…}, sel]` selector is commonly written `Dynamic[var]`
+/// (the form the front end itself writes when a Demonstration's author
+/// inserts the control from the authoring toolbar) rather than the bare
+/// `var` the hand-written examples use. `Dynamic` is `HoldFirst`, so
+/// evaluating `Dynamic[var]` never reduces to `var`'s value — comparing it
+/// against a pane's pattern would never match, leaving every pane hidden
+/// (or, for a caption-style `PaneSelector`, no pane's content rendered at
+/// all). The wrapper is only a FrontEnd update hint here, exactly as for
+/// `Dynamic[Control[…]]` in `unwrap_control_wrapper` below, so it is
+/// stripped before the selector is evaluated or compared.
+fn unwrap_pane_selector(selector: &Expr) -> &Expr {
+  match selector {
+    Expr::FunctionCall { name, args }
+      if name == "Dynamic" && args.len() == 1 =>
+    {
+      &args[0]
+    }
+    _ => selector,
+  }
 }
 
 /// `Dynamic[Control[…]]` (the Demonstrations idiom `Dynamic@Control@{…}`)
@@ -18535,6 +18566,16 @@ fn expand_conditional_control_items(
 /// honoured — a pane nested inside another pane keeps its parent's
 /// condition rather than gaining its own.
 fn collect_pane_visibility(spec: &Expr, out: &mut Vec<(String, String)>) {
+  // A `PaneSelector` may sit inside a `Grid`'s row list (the Demonstrations
+  // idiom of a custom Grid-based control panel) — descend into a bare list
+  // of items the same way a layout container's args are walked below, or a
+  // `PaneSelector` nested that way is never found.
+  if let Expr::List(items) = spec {
+    for item in items {
+      collect_pane_visibility(item, out);
+    }
+    return;
+  }
   let Expr::FunctionCall { name, args } = spec else {
     return;
   };
@@ -18549,7 +18590,8 @@ fn collect_pane_visibility(spec: &Expr, out: &mut Vec<(String, String)>) {
   else {
     return;
   };
-  let selector = crate::syntax::expr_to_input_form(selector);
+  let selector =
+    crate::syntax::expr_to_input_form(unwrap_pane_selector(selector));
   for pane in panes {
     let (Expr::Rule {
       pattern,
@@ -22451,8 +22493,9 @@ fn pane_selector_content<'a>(
   let Expr::List(panes) = args.first()? else {
     return None;
   };
-  let selector = eval_display_in_scope(&args[1], bindings).map_or_else(
-    || crate::syntax::expr_to_input_form(&args[1]),
+  let sel_arg = unwrap_pane_selector(&args[1]);
+  let selector = eval_display_in_scope(sel_arg, bindings).map_or_else(
+    || crate::syntax::expr_to_input_form(sel_arg),
     |e| crate::syntax::expr_to_input_form(&e),
   );
   panes.iter().find_map(|pane| {
@@ -23412,6 +23455,21 @@ mod manipulate_display_pane_selector_tests {
     match node {
       DisplayNode::Column(children) => assert!(children.is_empty()),
       other => panic!("expected an empty column, got {other:?}"),
+    }
+  }
+
+  /// The selector is commonly written `Dynamic[mode]` (what the front end
+  /// itself writes for a control inserted from the authoring toolbar), not
+  /// bare `mode`. Since `Dynamic` is `HoldFirst`, evaluating it never
+  /// reduces to `mode`'s value — the matching pane must still be found by
+  /// unwrapping the `Dynamic` first, or every pane would render as empty.
+  #[test]
+  fn dynamic_wrapped_selector_still_matches_its_pane() {
+    let code = r#"PaneSelector[{1 -> Row[{Style["a"], Style["b"]}], 2 -> Style["c"]}, Dynamic[mode]]"#;
+    let node = build_manipulate_display(code, &[("mode".into(), "1".into())]);
+    match node {
+      DisplayNode::Row(children) => assert_eq!(children.len(), 2),
+      other => panic!("expected a row node, got {other:?}"),
     }
   }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -20118,6 +20118,37 @@ mod manipulate {
     assert_eq!(shown("3"), vec![true, false, false]);
   }
 
+  /// A `PaneSelector` nested inside a `Grid` row (the Demonstrations idiom
+  /// of a hand-laid-out control panel with a per-mode slider swapped in via
+  /// `PaneSelector`, rather than the selector sitting directly among
+  /// Manipulate's top-level spec arguments) must still flatten into real
+  /// controls with their pane-visibility conditions — not fall through to
+  /// an inert display element.
+  #[test]
+  fn pane_selector_nested_in_grid_flattens_into_controls() {
+    let expr = interpret_to_expr(
+      "Manipulate[a + b, Control[{{q, 1}, {1, 2}, Setter}], \
+       Grid[{{Control[{{a, 5}, 0, 10}], \
+       PaneSelector[{1 -> Control[{{b, 5}, 0, 10}], \
+       2 -> Control[{{c, 5}, 20, 30}]}, Dynamic[q]], SpanFromLeft}}]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    let names: Vec<&str> = spec
+      .controls
+      .iter()
+      .map(woxi::functions::ManipulateControl::name)
+      .collect();
+    assert_eq!(names, vec!["q", "a", "b", "c"]);
+    assert_eq!(
+      spec.control_visible,
+      vec![
+        ("b".to_string(), "(q) == (1)".to_string()),
+        ("c".to_string(), "(q) == (2)".to_string()),
+      ]
+    );
+  }
+
   #[test]
   fn spec_json_includes_visible_when() {
     let expr = interpret_to_expr(


### PR DESCRIPTION
## Summary

While testing a real-world Wolfram Demonstration notebook against Woxi Studio, I found that a `Manipulate[…]` whose control panel is laid out by hand with a `Grid[…]` argument (instead of the default sequential spec list) can embed a `PaneSelector[…]` directly inside a Grid cell to swap one row's control for another based on a mode variable — a fairly common Demonstrations idiom for a "US customary vs. SI units" style toggle. Woxi Studio was only flattening `PaneSelector` panes when the selector sat directly among a Manipulate's own top-level arguments; one nested inside a `Grid` row fell through to an inert display element instead of registering its `Control[…]` specs, so the swapped sliders never appeared in the widget at all.

Fixing that also surfaced a second, related bug: a `PaneSelector`'s selector expression is commonly written `Dynamic[var]` (the form the front end itself writes for a control inserted from the authoring toolbar) rather than bare `var`. Since `Dynamic` is `HoldFirst`, evaluating `Dynamic[var]` never reduces to `var`'s value, so comparing it against a pane's pattern never matched — every pane's visibility/content resolution silently failed even once the controls were found. Both code paths that evaluate a `PaneSelector` selector (pane visibility for the control panel, and live pane-swapped caption rendering) now unwrap a `Dynamic[…]` wrapper first.

- `control_group_items` now recursively flattens each `Grid` row's cells (a cell may itself be a `PaneSelector`/`Row`/`Column` grouping further controls), instead of cloning grid cells verbatim.
- `collect_pane_visibility` now descends into a bare `Expr::List` (a `Grid`'s row list), so a `PaneSelector` nested that way still gets its pane-visibility conditions computed.
- New `unwrap_pane_selector` helper strips a `Dynamic[…]` wrapper from a `PaneSelector`'s selector argument, applied both when computing pane-visibility conditions and when resolving a caption-style `PaneSelector`'s currently-shown pane.

## Test plan

- [x] Added `pane_selector_nested_in_grid_flattens_into_controls` (tests/interpreter_tests/graphics.rs) verifying controls declared inside a `PaneSelector` nested in a `Grid` row are extracted with correct pane-visibility conditions.
- [x] Added `dynamic_wrapped_selector_still_matches_its_pane` (src/functions/graphics.rs) verifying a `Dynamic[…]`-wrapped selector still resolves to the matching pane.
- [x] `make test` — all 27,636 tests pass.
- [x] `make format`
- [x] Verified end-to-end against a real Wolfram Demonstrations notebook fetched via the Wolfram Cloud resource API: before the fix, two of the interactive sliders were silently dropped from the widget; after the fix, all controls (including the mode-toggled ones) appear and correctly show/hide as the mode changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KEzPFg7pHc1Y1tuqUC8uU

---
_Generated by [Claude Code](https://claude.ai/code/session_011KEzPFg7pHc1Y1tuqUC8uU)_