### PR TITLE
Fix FindRoot for indexed/collocation variables and held arguments

### DIFF
--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5701,10 +5701,27 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
+  // FindRoot holds its arguments, so a spec built programmatically and
+  // passed by name — `initguess = Flatten[Table[{u[i], 0.5}, ...]];
+  // FindRoot[sys, initguess]`, the idiom collocation methods use to name
+  // one unknown per grid point — reaches here as a bare identifier rather
+  // than a literal list. Resolve it once to reveal that list structure. A
+  // `{var, x0}` written directly at the call site is left untouched (not
+  // re-evaluated) so a variable that happens to carry an unrelated global
+  // value isn't substituted into the "variable" slot.
+  let arg1_owned;
+  let arg1: &Expr = if matches!(&args[1], Expr::List(_)) {
+    &args[1]
+  } else {
+    arg1_owned = crate::evaluator::evaluate_expr_to_expr(&args[1])
+      .unwrap_or_else(|_| args[1].clone());
+    &arg1_owned
+  };
+
   // Multivariate form: FindRoot[{eqns}, {{x, x0}, {y, y0}, ...}] — every
   // variable spec is itself a {var, start} list. Solved with multidimensional
   // Newton iteration.
-  if let Expr::List(specs) = &args[1]
+  if let Expr::List(specs) = arg1
     && !specs.is_empty()
     && specs.iter().all(|s| {
       matches!(s, Expr::List(p)
@@ -5780,7 +5797,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // First peek at the variable name and start point; if the start point
   // evaluates to a complex number we route to a complex Newton iteration
   // before the real-only path below.
-  let (var_name, x_start_expr) = match &args[1] {
+  let (var_name, x_start_expr) = match arg1 {
     Expr::List(items) if items.len() == 2 || items.len() == 3 => {
       let name = match &items[0] {
         Expr::Identifier(n) => n.clone(),
@@ -5817,7 +5834,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       im0,
     );
   }
-  let (var, x0, x1_opt) = match &args[1] {
+  let (var, x0, x1_opt) = match arg1 {
     Expr::List(items) if items.len() == 2 => {
       let var_name = match &items[0] {
         Expr::Identifier(name) => name.clone(),
@@ -6544,6 +6561,19 @@ fn find_root_multivariate(
       _ => None,
     })
     .collect();
+  // As with the spec argument, the equations are often built and named
+  // separately (`sys = Join[{bc1, ...}, Table[Eq[...], ...]] // Flatten;
+  // FindRoot[sys, ...]`) rather than written literally, so `eqns_arg` may
+  // reach here as a bare identifier rather than a literal list. Resolve it
+  // (search variables localized, same as each individual equation below)
+  // to reveal the list of equations.
+  let eqns_owned;
+  let eqns_arg: &Expr = if matches!(eqns_arg, Expr::List(_)) {
+    eqns_arg
+  } else {
+    eqns_owned = evaluate_with_vars_localized(eqns_arg, &var_refs);
+    &eqns_owned
+  };
   let eqns: Vec<Expr> = match eqns_arg {
     Expr::List(es) => es
       .iter()

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6429,38 +6429,177 @@ fn find_root_eval_number(expr: &Expr) -> Result<f64, InterpreterError> {
 fn is_findroot_var_expr(e: &Expr) -> bool {
   match e {
     Expr::Identifier(_) => true,
-    Expr::FunctionCall { args, .. } => !args.is_empty()
-      && args
-        .iter()
-        .all(|a| matches!(a, Expr::Integer(_) | Expr::Real(_) | Expr::String(_))),
+    Expr::FunctionCall { args, .. } => {
+      !args.is_empty()
+        && args.iter().all(|a| {
+          matches!(a, Expr::Integer(_) | Expr::Real(_) | Expr::String(_))
+        })
+    }
     _ => false,
   }
 }
 
-/// Evaluate `expr` to an f64 with every variable in `vars` bound to the
-/// corresponding value in `vals`. Plain-symbol variables use the fast
-/// name-based substitution; indexed variables (e.g. `u[1]`) are replaced by
-/// exact structural match, the same machinery `/.` uses.
-fn find_root_eval_multivar(
+/// A hashable key for a FindRoot indexed-variable's literal arguments
+/// (`u[1]` → `[Int(1)]`, `a[2, "x"]` → `[Int(2), Str("x")]`).
+#[derive(PartialEq, Eq, Hash, Clone)]
+enum FindRootIndexKey {
+  Int(i128),
+  RealBits(u64),
+  Str(String),
+}
+
+fn find_root_index_key(e: &Expr) -> Option<FindRootIndexKey> {
+  match e {
+    Expr::Integer(n) => Some(FindRootIndexKey::Int(*n)),
+    Expr::Real(r) => Some(FindRootIndexKey::RealBits(r.to_bits())),
+    Expr::String(s) => Some(FindRootIndexKey::Str(s.clone())),
+    _ => None,
+  }
+}
+
+/// Replace every var in `vars` (matched by exact structural equality —
+/// including indexed variables like `u[1]`) with the corresponding
+/// expression in `replacements`, in a single pass over `expr`.
+///
+/// `find_root_multivariate` uses this once, up front, to rename every
+/// search variable — plain or indexed — to a fresh plain symbol, so the
+/// rest of the solve (symbolic differentiation, localization, per-iteration
+/// substitution) can reuse the existing name-based machinery unchanged
+/// instead of paying a structural-match cost at every Newton step. Doing
+/// the rename with a per-node hashmap lookup, in one pass, also keeps this
+/// one-off step itself linear in the equations' size rather than linear in
+/// the number of variables times their size.
+///
+/// Covers the constructs a FindRoot equation can contain: arithmetic,
+/// comparisons and their containers. Any other construct is left as
+/// written — the caller detects an unrenamed variable when the result
+/// fails to reduce to a number, rather than this silently skipping it.
+fn find_root_rename_vars(
   expr: &Expr,
   vars: &[Expr],
+  replacements: &[Expr],
+) -> Expr {
+  let mut id_map: std::collections::HashMap<&str, &Expr> =
+    std::collections::HashMap::with_capacity(vars.len());
+  let mut idx_map: std::collections::HashMap<
+    (&str, Vec<FindRootIndexKey>),
+    &Expr,
+  > = std::collections::HashMap::new();
+  for (v, r) in vars.iter().zip(replacements) {
+    match v {
+      Expr::Identifier(name) => {
+        id_map.insert(name.as_str(), r);
+      }
+      Expr::FunctionCall { name, args } => {
+        if let Some(keys) = args
+          .iter()
+          .map(find_root_index_key)
+          .collect::<Option<Vec<_>>>()
+        {
+          idx_map.insert((name.as_str(), keys), r);
+        }
+      }
+      _ => {}
+    }
+  }
+  find_root_rename_walk(expr, &id_map, &idx_map)
+}
+
+fn find_root_rename_walk(
+  expr: &Expr,
+  id_map: &std::collections::HashMap<&str, &Expr>,
+  idx_map: &std::collections::HashMap<(&str, Vec<FindRootIndexKey>), &Expr>,
+) -> Expr {
+  match expr {
+    Expr::Identifier(name) => match id_map.get(name.as_str()) {
+      Some(r) => (*r).clone(),
+      None => expr.clone(),
+    },
+    Expr::FunctionCall { name, args } => {
+      if let Some(keys) = args
+        .iter()
+        .map(find_root_index_key)
+        .collect::<Option<Vec<_>>>()
+        && let Some(r) = idx_map.get(&(name.as_str(), keys))
+      {
+        return (*r).clone();
+      }
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: args
+          .iter()
+          .map(|a| find_root_rename_walk(a, id_map, idx_map))
+          .collect(),
+      }
+    }
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|a| find_root_rename_walk(a, id_map, idx_map))
+        .collect(),
+    ),
+    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
+      op: *op,
+      left: Box::new(find_root_rename_walk(left, id_map, idx_map)),
+      right: Box::new(find_root_rename_walk(right, id_map, idx_map)),
+    },
+    Expr::UnaryOp { op, operand } => Expr::UnaryOp {
+      op: *op,
+      operand: Box::new(find_root_rename_walk(operand, id_map, idx_map)),
+    },
+    Expr::Comparison {
+      operands,
+      operators,
+    } => Expr::Comparison {
+      operands: operands
+        .iter()
+        .map(|a| find_root_rename_walk(a, id_map, idx_map))
+        .collect(),
+      operators: operators.clone(),
+    },
+    Expr::CompoundExpr(exprs) => Expr::CompoundExpr(
+      exprs
+        .iter()
+        .map(|a| find_root_rename_walk(a, id_map, idx_map))
+        .collect(),
+    ),
+    Expr::Rule {
+      pattern,
+      replacement,
+    } => Expr::Rule {
+      pattern: Box::new(find_root_rename_walk(pattern, id_map, idx_map)),
+      replacement: Box::new(find_root_rename_walk(
+        replacement,
+        id_map,
+        idx_map,
+      )),
+    },
+    Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } => Expr::RuleDelayed {
+      pattern: Box::new(find_root_rename_walk(pattern, id_map, idx_map)),
+      replacement: Box::new(find_root_rename_walk(
+        replacement,
+        id_map,
+        idx_map,
+      )),
+    },
+    other => other.clone(),
+  }
+}
+
+/// Evaluate `expr` to an f64 with every variable in `vars` bound to the
+/// corresponding value in `vals`, in a single substitution pass.
+fn find_root_eval_multivar(
+  expr: &Expr,
+  vars: &[String],
   vals: &[f64],
 ) -> Result<f64, InterpreterError> {
-  let mut e = expr.clone();
-  for (v, &x) in vars.iter().zip(vals) {
-    e = match v {
-      Expr::Identifier(name) => {
-        crate::syntax::substitute_variable(&e, name, &Expr::Real(x))
-      }
-      other => crate::evaluator::apply_replace_all_ast(
-        &e,
-        &Expr::Rule {
-          pattern: Box::new(other.clone()),
-          replacement: Box::new(Expr::Real(x)),
-        },
-      )?,
-    };
-  }
+  let reals: Vec<Expr> = vals.iter().map(|&x| Expr::Real(x)).collect();
+  let bindings: Vec<(&str, &Expr)> =
+    vars.iter().map(String::as_str).zip(reals.iter()).collect();
+  let e = crate::syntax::substitute_variables(expr, &bindings);
   let evaled = crate::evaluator::evaluate_expr_to_expr(&e)?;
   match &evaled {
     Expr::Integer(k) => Ok(*k as f64),
@@ -6527,7 +6666,7 @@ fn find_root_multivariate(
 ) -> Result<Expr, InterpreterError> {
   // Variables and starting points. A spec's variable is either a plain
   // symbol or an indexed variable like `u[1]` — see `is_findroot_var_expr`.
-  let mut vars: Vec<Expr> = Vec::new();
+  let mut raw_vars: Vec<Expr> = Vec::new();
   let mut x: Vec<f64> = Vec::new();
   for spec in specs {
     if let Expr::List(p) = spec {
@@ -6536,45 +6675,54 @@ fn find_root_multivariate(
           "FindRoot: variable must be a symbol".into(),
         ));
       }
-      vars.push(p[0].clone());
+      raw_vars.push(p[0].clone());
       x.push(find_root_eval_number(&p[1])?);
     }
   }
-  let n = vars.len();
+  let n = raw_vars.len();
 
-  // Equations as f_i = lhs - rhs (or bare expression). Each side is
-  // evaluated symbolically first — with every search variable localized, see
-  // `evaluate_with_vars_localized` — so user-defined functions expand
-  // through their downvalues (`r[s, t, 0, 1]` becomes its explicit formula)
-  // and a variable that happens to carry a stale global value elsewhere
-  // still searches fresh. FindRoot holds its arguments, so this is the
-  // first chance to do so. An expression that fails to evaluate stays as
-  // written and is handled numerically per iteration point instead.
-  //
-  // Only plain-symbol variables are localized this way — an indexed
-  // variable like `u[1]` has no global binding under a literal name to
-  // remove, so it is left out of the set.
-  let var_refs: Vec<&str> = vars
+  // Only plain-symbol variables can carry a stale global binding under a
+  // literal name — an indexed variable like `u[1]` has no such binding to
+  // remove.
+  let raw_var_refs: Vec<&str> = raw_vars
     .iter()
     .filter_map(|v| match v {
       Expr::Identifier(name) => Some(name.as_str()),
       _ => None,
     })
     .collect();
-  // As with the spec argument, the equations are often built and named
-  // separately (`sys = Join[{bc1, ...}, Table[Eq[...], ...]] // Flatten;
-  // FindRoot[sys, ...]`) rather than written literally, so `eqns_arg` may
-  // reach here as a bare identifier rather than a literal list. Resolve it
-  // (search variables localized, same as each individual equation below)
-  // to reveal the list of equations.
+  // The equations are often built and named separately (`sys =
+  // Join[{bc1, ...}, Table[Eq[...], ...]] // Flatten; FindRoot[sys, ...]`)
+  // rather than written literally, so `eqns_arg` may reach here as a bare
+  // identifier rather than a literal list. Resolve it (search variables
+  // localized, see `evaluate_with_vars_localized`) to reveal the list of
+  // equations, so a variable that happens to carry a stale global value
+  // elsewhere doesn't leak into this evaluation. FindRoot holds its
+  // arguments, so this is the first chance to do so.
   let eqns_owned;
   let eqns_arg: &Expr = if matches!(eqns_arg, Expr::List(_)) {
     eqns_arg
   } else {
-    eqns_owned = evaluate_with_vars_localized(eqns_arg, &var_refs);
+    eqns_owned = evaluate_with_vars_localized(eqns_arg, &raw_var_refs);
     &eqns_owned
   };
-  let eqns: Vec<Expr> = match eqns_arg {
+
+  // Every search variable — plain or indexed — is renamed to a fresh plain
+  // symbol before anything else. Collocation methods can name hundreds of
+  // `u[i]` variables for a dense system; treating them as plain symbols
+  // from here on lets the rest of the solve reuse the existing name-based
+  // substitution (`substitute_variables`, one pass over the equation) and
+  // symbolic differentiation (`differentiate_expr`) instead of a much
+  // slower structural-match or finite-difference fallback per indexed
+  // variable. The rename is reversed only in the final `var -> value`
+  // rules.
+  let vars: Vec<String> = (0..n).map(|i| format!("$FindRootVar{i}$")).collect();
+  let syn_idents: Vec<Expr> =
+    vars.iter().map(|s| Expr::Identifier(s.clone())).collect();
+  let renamed_eqns_arg =
+    find_root_rename_vars(eqns_arg, &raw_vars, &syn_idents);
+  let var_refs: Vec<&str> = vars.iter().map(String::as_str).collect();
+  let eqns: Vec<Expr> = match &renamed_eqns_arg {
     Expr::List(es) => es
       .iter()
       .map(|e| build_find_root_func(e, &var_refs))
@@ -6587,26 +6735,20 @@ fn find_root_multivariate(
     ));
   }
 
-  // Jacobian J[i][j] = d f_i / d x_j (symbolic where possible). An entry
-  // that cannot be differentiated symbolically (e.g. the equation still
-  // contains an opaque function call) is left `None` and approximated by a
-  // central finite difference at each iteration point. Only plain-symbol
-  // variables are differentiated symbolically — `differentiate_expr` takes a
-  // named variable, so an indexed variable like `u[1]` always falls back to
-  // the finite-difference path.
+  // Jacobian J[i][j] = d f_i / d x_j (symbolic where possible — every
+  // variable is now a plain symbol, so this applies uniformly to indexed
+  // variables too). An entry that cannot be differentiated symbolically
+  // (e.g. the equation still contains an opaque function call) is left
+  // `None` and approximated by a central finite difference at each
+  // iteration point.
   let mut jac: Vec<Vec<Option<Expr>>> = Vec::with_capacity(n);
   for f in &eqns {
     let mut row = Vec::with_capacity(n);
     for v in &vars {
-      let d = match v {
-        Expr::Identifier(name) => {
-          crate::functions::calculus_ast::differentiate_expr(f, name)
-            .map(simplify)
-            .ok()
-            .filter(|d| !contains_unevaluated_d(d))
-        }
-        _ => None,
-      };
+      let d = crate::functions::calculus_ast::differentiate_expr(f, v)
+        .map(simplify)
+        .ok()
+        .filter(|d| !contains_unevaluated_d(d));
       row.push(d);
     }
     jac.push(row);
@@ -6659,8 +6801,7 @@ fn find_root_multivariate(
       break;
     }
   }
-
-  let rules: Vec<Expr> = vars
+  let rules: Vec<Expr> = raw_vars
     .iter()
     .zip(&x)
     .map(|(v, &xv)| Expr::Rule {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5708,7 +5708,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && !specs.is_empty()
     && specs.iter().all(|s| {
       matches!(s, Expr::List(p)
-      if p.len() == 2 && matches!(&p[0], Expr::Identifier(_)))
+      if p.len() == 2 && is_findroot_var_expr(&p[0]))
     })
   {
     return find_root_multivariate(&args[0], specs);
@@ -5726,7 +5726,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .iter()
       .take_while(|s| {
         matches!(s, Expr::List(p)
-        if p.len() == 2 && matches!(&p[0], Expr::Identifier(_)))
+        if p.len() == 2 && is_findroot_var_expr(&p[0]))
       })
       .cloned()
       .collect();
@@ -6404,16 +6404,45 @@ fn find_root_eval_number(expr: &Expr) -> Result<f64, InterpreterError> {
   }
 }
 
+/// True when `e` is a valid FindRoot search variable: a plain symbol, or an
+/// indexed variable such as `u[1]` or `a[2, 3]` — a symbol applied to
+/// literal numeric or string indices. Collocation methods for boundary-value
+/// problems name one unknown per grid point this way (`FindRoot[{eqns},
+/// {{u[1], 0.5}, {u[2], 0.5}, ...}]`), and real Wolfram accepts both forms.
+fn is_findroot_var_expr(e: &Expr) -> bool {
+  match e {
+    Expr::Identifier(_) => true,
+    Expr::FunctionCall { args, .. } => !args.is_empty()
+      && args
+        .iter()
+        .all(|a| matches!(a, Expr::Integer(_) | Expr::Real(_) | Expr::String(_))),
+    _ => false,
+  }
+}
+
 /// Evaluate `expr` to an f64 with every variable in `vars` bound to the
-/// corresponding value in `vals`.
+/// corresponding value in `vals`. Plain-symbol variables use the fast
+/// name-based substitution; indexed variables (e.g. `u[1]`) are replaced by
+/// exact structural match, the same machinery `/.` uses.
 fn find_root_eval_multivar(
   expr: &Expr,
-  vars: &[String],
+  vars: &[Expr],
   vals: &[f64],
 ) -> Result<f64, InterpreterError> {
   let mut e = expr.clone();
   for (v, &x) in vars.iter().zip(vals) {
-    e = crate::syntax::substitute_variable(&e, v, &Expr::Real(x));
+    e = match v {
+      Expr::Identifier(name) => {
+        crate::syntax::substitute_variable(&e, name, &Expr::Real(x))
+      }
+      other => crate::evaluator::apply_replace_all_ast(
+        &e,
+        &Expr::Rule {
+          pattern: Box::new(other.clone()),
+          replacement: Box::new(Expr::Real(x)),
+        },
+      )?,
+    };
   }
   let evaled = crate::evaluator::evaluate_expr_to_expr(&e)?;
   match &evaled {
@@ -6479,20 +6508,18 @@ fn find_root_multivariate(
   eqns_arg: &Expr,
   specs: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  // Variables and starting points.
-  let mut vars: Vec<String> = Vec::new();
+  // Variables and starting points. A spec's variable is either a plain
+  // symbol or an indexed variable like `u[1]` — see `is_findroot_var_expr`.
+  let mut vars: Vec<Expr> = Vec::new();
   let mut x: Vec<f64> = Vec::new();
   for spec in specs {
     if let Expr::List(p) = spec {
-      let v = match &p[0] {
-        Expr::Identifier(n) => n.clone(),
-        _ => {
-          return Err(InterpreterError::EvaluationError(
-            "FindRoot: variable must be a symbol".into(),
-          ));
-        }
-      };
-      vars.push(v);
+      if !is_findroot_var_expr(&p[0]) {
+        return Err(InterpreterError::EvaluationError(
+          "FindRoot: variable must be a symbol".into(),
+        ));
+      }
+      vars.push(p[0].clone());
       x.push(find_root_eval_number(&p[1])?);
     }
   }
@@ -6506,7 +6533,17 @@ fn find_root_multivariate(
   // still searches fresh. FindRoot holds its arguments, so this is the
   // first chance to do so. An expression that fails to evaluate stays as
   // written and is handled numerically per iteration point instead.
-  let var_refs: Vec<&str> = vars.iter().map(String::as_str).collect();
+  //
+  // Only plain-symbol variables are localized this way — an indexed
+  // variable like `u[1]` has no global binding under a literal name to
+  // remove, so it is left out of the set.
+  let var_refs: Vec<&str> = vars
+    .iter()
+    .filter_map(|v| match v {
+      Expr::Identifier(name) => Some(name.as_str()),
+      _ => None,
+    })
+    .collect();
   let eqns: Vec<Expr> = match eqns_arg {
     Expr::List(es) => es
       .iter()
@@ -6523,15 +6560,23 @@ fn find_root_multivariate(
   // Jacobian J[i][j] = d f_i / d x_j (symbolic where possible). An entry
   // that cannot be differentiated symbolically (e.g. the equation still
   // contains an opaque function call) is left `None` and approximated by a
-  // central finite difference at each iteration point.
+  // central finite difference at each iteration point. Only plain-symbol
+  // variables are differentiated symbolically — `differentiate_expr` takes a
+  // named variable, so an indexed variable like `u[1]` always falls back to
+  // the finite-difference path.
   let mut jac: Vec<Vec<Option<Expr>>> = Vec::with_capacity(n);
   for f in &eqns {
     let mut row = Vec::with_capacity(n);
     for v in &vars {
-      let d = crate::functions::calculus_ast::differentiate_expr(f, v)
-        .map(simplify)
-        .ok()
-        .filter(|d| !contains_unevaluated_d(d));
+      let d = match v {
+        Expr::Identifier(name) => {
+          crate::functions::calculus_ast::differentiate_expr(f, name)
+            .map(simplify)
+            .ok()
+            .filter(|d| !contains_unevaluated_d(d))
+        }
+        _ => None,
+      };
       row.push(d);
     }
     jac.push(row);
@@ -6589,7 +6634,7 @@ fn find_root_multivariate(
     .iter()
     .zip(&x)
     .map(|(v, &xv)| Expr::Rule {
-      pattern: Box::new(Expr::Identifier(v.clone())),
+      pattern: Box::new(v.clone()),
       replacement: Box::new(Expr::Real(xv)),
     })
     .collect();

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -8341,6 +8341,51 @@ mod find_root {
     );
   }
 
+  // Regression: collocation methods for boundary-value problems name one
+  // unknown per grid point as an indexed variable (`u[1]`, `u[2]`, ...)
+  // rather than a plain symbol — real Wolfram accepts any FindRoot variable
+  // that isn't a bare symbol, not just plain identifiers. The multivariate
+  // spec detection previously required every variable to be
+  // `Expr::Identifier`, so this form errored with "second argument must be
+  // {var, x0} or {var, x0, x1}" (the Laplace-equation-on-a-square
+  // Demonstration hits this).
+  #[test]
+  fn multivariate_indexed_variables() {
+    assert_eq!(
+      interpret(
+        "FindRoot[{u[1] + u[2] == 3, u[1] - u[2] == 1}, \
+         {{u[1], 0}, {u[2], 0}}]"
+      )
+      .unwrap(),
+      "{u[1] -> 2., u[2] -> 1.}"
+    );
+  }
+
+  // Regression: FindRoot is HoldAll, so equations and a spec list built
+  // separately and passed by name (`sys = {...}; initguess = {{x, x0},
+  // ...}; FindRoot[sys, initguess]` — the idiom collocation methods use to
+  // build a long spec list programmatically) reached find_root_ast as bare
+  // unevaluated identifiers rather than literal lists, so neither the
+  // equations nor the variable specs were ever recognised.
+  #[test]
+  fn equations_and_spec_passed_by_name() {
+    assert_eq!(
+      interpret(
+        "eqns = {x^2 - 2 == 0}; spec = {{x, 1}}; \
+         FindRoot[eqns, spec]"
+      )
+      .unwrap(),
+      "{x -> 1.4142135623730951}"
+    );
+    // A literal spec written directly at the call site must still work
+    // (and must not have its variable name resolved against some unrelated
+    // stray global value).
+    assert_eq!(
+      interpret("FindRoot[x^2 - 2 == 0, {x, 1}]").unwrap(),
+      "{x -> 1.4142135623730951}"
+    );
+  }
+
   #[test]
   fn trivial() {
     assert_eq!(interpret("FindRoot[x, {x, 5}]").unwrap(), "{x -> 0.}");


### PR DESCRIPTION
## Summary

This came out of a scheduled routine that downloads a random Wolfram Demonstration notebook and checks whether Woxi Studio fully supports it. This run downloaded "Solution of the Laplace Equation for Temperature Distribution in a Square" — a Demonstration that solves the Laplace PDE on a unit square using a Chebyshev–Gauss–Lobatto spectral collocation method inside a `Manipulate`. (No demonstration text or code is reproduced here — it's copyrighted; the patterns below are described generically.)

Woxi's `FindRoot` couldn't evaluate the notebook's `Manipulate` body for three separate reasons, all fixed in this branch:

1. **Indexed/collocation variables rejected.** Collocation methods for boundary-value problems commonly name one unknown per grid point as an indexed variable (`u[1]`, `u[2]`, ...) rather than a plain symbol. `FindRoot`'s multivariate spec detection required every variable in `{{var, x0}, ...}` to be a bare `Identifier`, so this form errored with `"second argument must be {var, x0} or {var, x0, x1}"`. Real Wolfram accepts any non-atomic-symbol form here.

2. **Held equations/spec not resolved when passed by name.** `FindRoot` is `HoldAll`. When a large system's equations and initial-guess spec are built programmatically and passed in by name (e.g. `sys = ...; initguess = ...; FindRoot[sys, initguess]` — the standard idiom for a system too large to write out literally) rather than written literally at the call site, both arguments reached the implementation as unevaluated bare identifiers, so neither the equations nor the variable specs were ever recognized.

3. **Severe slowdown once (1) and (2) were fixed.** With indexed variables now accepted, an initial fix substituted each one via per-node structural matching on every Newton iteration and Jacobian finite-difference evaluation, and never attempted symbolic differentiation for them. This made the notebook's default 121-unknown system (`Np = 10`, an 11×11 grid) take well over 9 minutes without finishing. Fixed by renaming every search variable — plain or indexed — to a fresh plain symbol once, up front. The rest of the solve then reuses the existing fast name-based substitution and symbolic differentiation unchanged, recovering an exact analytic Jacobian for this linear system (constant coefficients, so Newton converges in a couple of iterations) instead of falling back to finite differences per entry. The rename is translated back to the original variable names only in the final `var -> value` rules. The notebook's default case now solves in under 3 seconds.

## Test plan

- [x] Added `multivariate_indexed_variables` regression test (indexed variables in the multivariate spec)
- [x] Added `equations_and_spec_passed_by_name` regression test (equations/spec resolved when passed by variable name, plus a literal-spec case to guard against accidentally resolving a variable name against a stray global value)
- [x] `make test` — all 27,608 tests pass
- [x] `make format`
- [x] Manually verified the notebook's `Manipulate` body (121-unknown collocation system) now evaluates correctly and returns a `Graphics` result in ~3 seconds, down from not finishing within 9+ minutes
- [x] Verified existing FindRoot forms (single-variable, multivariate literal, downvalue-expanding) still produce identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqLLFi6BQkHyK1Lxv1vUhb)_