### PR TITLE
Fix Plus/Minus printer dropping parens around ReplaceAll operands

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -8066,16 +8066,36 @@ fn comparison_operand_needs_parens(e: &Expr) -> bool {
     || printed_infix_precedence(e).is_some_and(|p| p < 30)
 }
 
-/// Whether a term of a `Plus`/`Subtract` chain must be parenthesized in
-/// InputForm so the printed form re-parses to the same tree. `+`/`-` bind
-/// tighter than every looser operator (`Rule`, `ReplaceAll`, `Or`, `And`,
-/// `CompoundExpression`, …), so a term printing with one of those needs
-/// parens: `(x /. sol) - 0.05`, not `x /. sol - 0.05`, which re-parses as
-/// `x /. (sol - 0.05)` — a genuine Wolfram Demonstrations regression this
-/// once caused, since `ReplaceAll` (precedence 7) binds far looser than
-/// `Plus`/`Minus` (precedence 30).
+/// Whether the *leading* term of a `Plus`/`Subtract` chain must be
+/// parenthesized in InputForm so the printed form re-parses to the same
+/// tree. `+`/`-` bind tighter than every looser operator (`Rule`,
+/// `ReplaceAll`, `Or`, `And`, `CompoundExpression`, …), so a term printing
+/// with one of those needs parens: `(x /. sol) - 0.05`, not
+/// `x /. sol - 0.05`, which re-parses as `x /. (sol - 0.05)` — a genuine
+/// Wolfram Demonstrations regression this once caused, since `ReplaceAll`
+/// (precedence 7) binds far looser than `Plus`/`Minus` (precedence 30).
+///
+/// A term at precedence exactly 30 (a nested `Plus`/`Minus`/`StringJoin`)
+/// does *not* need parens here: text re-parses `+`/`-` left-associatively,
+/// so a left-nested chain round-trips whether or not the leading term was
+/// itself a `Plus` — unlike a *non*-leading term at the same precedence,
+/// see `plus_nonleading_term_needs_parens`.
 fn plus_term_needs_parens(e: &Expr) -> bool {
   printed_infix_precedence(e).is_some_and(|p| p < 30)
+}
+
+/// Whether a *non-leading* term of a `Plus`/`Subtract` chain — one printed
+/// after a `+` or `-` — must be parenthesized in InputForm. Unlike the
+/// leading term (`plus_term_needs_parens`), a term at precedence exactly 30
+/// (a nested `Plus`/`Minus`/`StringJoin`) also needs parens here:
+/// left-associative re-parsing only reconstructs a *left*-nested tree, so a
+/// bare non-leading `Plus`/`Minus` term — which can only have survived
+/// un-flattened under `Hold` — silently regroups. Following a `-` this is
+/// not just a shape change but a value change: printing `Plus[a,
+/// -(b + c)]` as `a - b + c` drops the sign that should apply to `c`
+/// (`a - b + c` re-parses as `Plus[a, -b, c]`, not `Plus[a, -b, -c]`).
+fn plus_nonleading_term_needs_parens(e: &Expr) -> bool {
+  printed_infix_precedence(e).is_some_and(|p| p <= 30)
 }
 
 /// Render an application shorthand (`f /@ list`, `f @@ list`, `f @@@ list`)
@@ -11958,13 +11978,19 @@ fn neg_times_coeff(e: &Expr) -> Option<Option<Expr>> {
 
 /// Render a term that follows a ` - ` in a `Plus`, parenthesising a prefix
 /// `MinusPlus` so the leading `-` doesn't fuse with the `∓`, the way Wolfram
-/// prints it: `a - MinusPlus[b]` → `a - (∓b)`.
+/// prints it: `a - MinusPlus[b]` → `a - (∓b)`. Also parenthesises any term
+/// that itself prints with an operator at or below `Plus`/`Minus`'s own
+/// precedence — reached from the negative-`Times`-coefficient folding above,
+/// e.g. `Plus[0.05, Times[-1, ReplaceAll[x, sol]]]` (ordinary evaluated
+/// `0.05 - (x /. sol)` with `sol` unbound) must print `0.05 - (x /. sol)`,
+/// not `0.05 - x /. sol`, which re-parses as `(0.05 - x) /. sol`.
 fn input_form_subtracted_term(term: &Expr) -> String {
   let s = expr_to_input_form(term);
   if matches!(
     term,
     Expr::FunctionCall { name, args } if name == "MinusPlus" && args.len() == 1
-  ) {
+  ) || plus_nonleading_term_needs_parens(term)
+  {
     format!("({s})")
   } else {
     s
@@ -12872,7 +12898,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         {
           result.push_str(" - ");
           let operand_str = expr_to_input_form(operand);
-          if plus_term_needs_parens(operand) {
+          if plus_nonleading_term_needs_parens(operand) {
             result.push_str(&format!("({operand_str})"));
           } else {
             result.push_str(&operand_str);
@@ -13009,7 +13035,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         } else {
           result.push_str(" + ");
           let arg_str = expr_to_input_form(arg);
-          if plus_term_needs_parens(arg) {
+          if plus_nonleading_term_needs_parens(arg) {
             result.push_str(&format!("({arg_str})"));
           } else {
             result.push_str(&arg_str);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -8066,6 +8066,18 @@ fn comparison_operand_needs_parens(e: &Expr) -> bool {
     || printed_infix_precedence(e).is_some_and(|p| p < 30)
 }
 
+/// Whether a term of a `Plus`/`Subtract` chain must be parenthesized in
+/// InputForm so the printed form re-parses to the same tree. `+`/`-` bind
+/// tighter than every looser operator (`Rule`, `ReplaceAll`, `Or`, `And`,
+/// `CompoundExpression`, …), so a term printing with one of those needs
+/// parens: `(x /. sol) - 0.05`, not `x /. sol - 0.05`, which re-parses as
+/// `x /. (sol - 0.05)` — a genuine Wolfram Demonstrations regression this
+/// once caused, since `ReplaceAll` (precedence 7) binds far looser than
+/// `Plus`/`Minus` (precedence 30).
+fn plus_term_needs_parens(e: &Expr) -> bool {
+  printed_infix_precedence(e).is_some_and(|p| p < 30)
+}
+
 /// Render an application shorthand (`f /@ list`, `f @@ list`, `f @@@ list`)
 /// in InputForm, parenthesizing either operand when it would otherwise bind
 /// differently on re-parse. `prec` is the shorthand's own parse precedence
@@ -10918,13 +10930,18 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
             | Expr::PatternOptional { .. }
             | Expr::PatternTest { .. }
         ))
-        // Rule/RuleDelayed have very low precedence (`->`/`:>`); wrap in
-        // parens when they appear inside any binary operator so the printed
-        // form re-parses to the same structure (e.g. `(a -> b)^2`, not
-        // `a -> b^2`).
+        // Rule/RuleDelayed/ReplaceAll/ReplaceRepeated have very low
+        // precedence (`->`/`:>`/`/.`/`//.`); wrap in parens when they appear
+        // inside any binary operator so the printed form re-parses to the
+        // same structure (e.g. `(a -> b)^2`, not `a -> b^2`, and
+        // `(x /. sol) - 0.05`, not `x /. sol - 0.05`, which re-parses as
+        // `x /. (sol - 0.05)` since `/.` binds looser than `-`).
         || matches!(
           left.as_ref(),
-          Expr::Rule { .. } | Expr::RuleDelayed { .. }
+          Expr::Rule { .. }
+            | Expr::RuleDelayed { .. }
+            | Expr::ReplaceAll { .. }
+            | Expr::ReplaceRepeated { .. }
         )
         || (prints_as_not(left.as_ref())
           && !matches!(op, BinaryOperator::And | BinaryOperator::Or))
@@ -11030,12 +11047,15 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
               ..
             } if matches!(rl.as_ref(), Expr::Integer(_))
           ))
-        // Rule/RuleDelayed have very low precedence; wrap in parens when
-        // they appear inside any binary operator so the printed form
-        // re-parses to the same structure.
+        // Rule/RuleDelayed/ReplaceAll/ReplaceRepeated have very low
+        // precedence; wrap in parens when they appear inside any binary
+        // operator so the printed form re-parses to the same structure.
         || matches!(
           right.as_ref(),
-          Expr::Rule { .. } | Expr::RuleDelayed { .. }
+          Expr::Rule { .. }
+            | Expr::RuleDelayed { .. }
+            | Expr::ReplaceAll { .. }
+            | Expr::ReplaceRepeated { .. }
         )
         || (prints_as_not(right.as_ref())
           && !matches!(op, BinaryOperator::And | BinaryOperator::Or))
@@ -12837,7 +12857,12 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
     }
     // Plus in InputForm: render as infix but use expr_to_input_form for args
     Expr::FunctionCall { name, args } if name == "Plus" && args.len() >= 2 => {
-      let mut result = expr_to_input_form(&args[0]);
+      let first_str = expr_to_input_form(&args[0]);
+      let mut result = if plus_term_needs_parens(&args[0]) {
+        format!("({first_str})")
+      } else {
+        first_str
+      };
       for arg in args.iter().skip(1) {
         // Check for negation patterns
         if let Expr::UnaryOp {
@@ -12846,7 +12871,12 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         } = arg
         {
           result.push_str(" - ");
-          result.push_str(&expr_to_input_form(operand));
+          let operand_str = expr_to_input_form(operand);
+          if plus_term_needs_parens(operand) {
+            result.push_str(&format!("({operand_str})"));
+          } else {
+            result.push_str(&operand_str);
+          }
         } else if let Expr::BinaryOp {
           op: BinaryOperator::Times,
           left,
@@ -12978,7 +13008,12 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
           }
         } else {
           result.push_str(" + ");
-          result.push_str(&expr_to_input_form(arg));
+          let arg_str = expr_to_input_form(arg);
+          if plus_term_needs_parens(arg) {
+            result.push_str(&format!("({arg_str})"));
+          } else {
+            result.push_str(&arg_str);
+          }
         }
       }
       result

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -7286,6 +7286,45 @@ mod plus_rendering {
     // triggering ReplaceAll::reps on `sol - 0.05`.
     assert_eq!(interpret("(x /. {x -> 5}) - 0.05").unwrap(), "4.95");
   }
+
+  // ReplaceRepeated (`//.`) binds exactly as loose as ReplaceAll and shares
+  // the same fix path, but had no direct test coverage.
+  #[test]
+  fn replace_repeated_keeps_parens_as_leading_plus_term() {
+    assert_eq!(
+      interpret("Hold[(x //. {x -> 5}) - 0.05]").unwrap(),
+      "Hold[(x //. {x -> 5}) - 0.05]"
+    );
+  }
+
+  // A non-leading `Plus`/`Minus`-shaped term (precedence exactly 30, the
+  // same as `Plus`/`Minus` themselves) must also be parenthesized — unlike
+  // a leading term, which round-trips bare because text re-parses `+`/`-`
+  // left-associatively. Printing the negated group bare would silently flip
+  // the sign of every term after the first: `a - b + c` re-parses as
+  // `Plus[a, -b, c]`, not the original `Plus[a, -b, -c]`.
+  #[test]
+  fn negated_plus_group_keeps_parens() {
+    assert_eq!(
+      interpret("ToString[Hold[Plus[a, -(b + c)]], InputForm]").unwrap(),
+      "Hold[a - (b + c)]"
+    );
+  }
+
+  // The same non-leading-term parenthesization must apply on the
+  // negative-`Times`-coefficient path (`input_form_subtracted_term`), which
+  // is reachable from ordinary (non-`Hold`) evaluation: `Times[-1, ...]`
+  // folds into a subtraction here, not just via a literal `Plus[..., -(...)]`
+  // call. Regression: `0.05 - (x /. sol)` with `sol` unbound evaluates to
+  // `Plus[0.05, Times[-1, ReplaceAll[x, sol]]]`, which must print with the
+  // `ReplaceAll` parenthesized or it re-parses as `(0.05 - x) /. sol`.
+  #[test]
+  fn subtracted_replace_all_keeps_parens_via_times_coefficient_path() {
+    assert_eq!(
+      interpret("ToString[0.05 - (x /. sol), InputForm]").unwrap(),
+      "0.05 - (x /. sol)"
+    );
+  }
 }
 
 mod tilde_infix {

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -7239,6 +7239,53 @@ mod plus_rendering {
   fn multiple_negative_terms() {
     assert_eq!(interpret("a - 3*b - 5*c").unwrap(), "a - 3*b - 5*c");
   }
+
+  // Regression: `/.` (ReplaceAll) binds looser than `+`/`-` (Wolfram
+  // precedence 110 vs. 310), so a `ReplaceAll` term printed as an operand
+  // of `Plus`/`Minus` must keep its parentheses, or the printed form
+  // re-parses to a different expression — `x /. sol - 0.05` regroups as
+  // `x /. (sol - 0.05)`, not `(x /. sol) - 0.05`. This once broke Woxi
+  // Studio's Manipulate handling for a Wolfram Demonstrations notebook:
+  // the body is re-serialized through `expr_to_input_form` to re-evaluate
+  // it per slider change, and the missing parens silently dropped a Plot
+  // curve from the render.
+  #[test]
+  fn replace_all_keeps_parens_as_leading_plus_term() {
+    assert_eq!(
+      interpret("Hold[(x /. {x -> 5}) - 0.05]").unwrap(),
+      "Hold[(x /. {x -> 5}) - 0.05]"
+    );
+  }
+
+  #[test]
+  fn replace_all_keeps_parens_as_trailing_plus_term() {
+    assert_eq!(
+      interpret("Hold[1 + (x /. {x -> 5})]").unwrap(),
+      "Hold[1 + (x /. {x -> 5})]"
+    );
+    assert_eq!(
+      interpret("Hold[(x /. {x -> 5}) + 1]").unwrap(),
+      "Hold[(x /. {x -> 5}) + 1]"
+    );
+  }
+
+  #[test]
+  fn replace_all_keeps_parens_in_input_form() {
+    // The InputForm formatter (`ToString[_, InputForm]`, used to rebuild a
+    // Manipulate body's source) must preserve the same parens as the
+    // direct-eval formatter.
+    assert_eq!(
+      interpret("ToString[Hold[(x /. {x -> 5}) - 0.05], InputForm]").unwrap(),
+      "Hold[(x /. {x -> 5}) - 0.05]"
+    );
+  }
+
+  #[test]
+  fn replace_all_then_subtract_evaluates_correctly() {
+    // With the parens honored, this evaluates numerically instead of
+    // triggering ReplaceAll::reps on `sol - 0.05`.
+    assert_eq!(interpret("(x /. {x -> 5}) - 0.05").unwrap(), "4.95");
+  }
 }
 
 mod tilde_infix {


### PR DESCRIPTION
## Summary

- `+`/`-` bind tighter than `/.` (ReplaceAll) and `//.` (ReplaceRepeated), so an operand printing with one of those needs parens to round-trip through InputForm: `(x /. sol) - 0.05`, not `x /. sol - 0.05` — which re-parses as `x /. (sol - 0.05)`, a different expression.
- The printer already parenthesized `Rule`/`RuleDelayed` operands of a binary operator but not `ReplaceAll`/`ReplaceRepeated`, and the InputForm-specific `Plus` renderer didn't parenthesize any looser-binding term at all.
- Found via the periodic Woxi Studio compatibility check: downloaded a random Wolfram Demonstration ("Flash Distillation of a Constant Relative Volatility Mixture") and ran it through Woxi Studio's headless `dump_manipulate` harness. Its Manipulate body re-serializes through `expr_to_input_form` to re-evaluate per slider change, and the missing parens silently dropped the feed-line `Plot` curve from the render.

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/syntax.rs` (`plus_rendering` module) covering the direct-eval formatter, the InputForm formatter, and end-to-end evaluation of `(x /. sol) - 0.05`-shaped expressions.
- [x] `make test` (27,646 tests) passes.
- [x] `make format` — no changes needed.
- [x] Re-ran the affected Demonstration through `woxi-studio`'s `dump_manipulate` example: the body now prints `(x /. sol) - 0.05` with parens intact, and the rendered SVG gains the previously-missing feed-line curve (2 → 3 polylines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7D9hRZnbvgbDT4L7gpM6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7D9hRZnbvgbDT4L7gpM6J)_