### PR TITLE
Add \[CenterDot] to the named-character table

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -3710,6 +3710,16 @@ Cell["Chapter 2", "Chapter"]
     assert_eq!(extract_cell_content(s), "a>=b");
   }
 
+  /// `\[CenterDot]` is the dot product a Demonstration's prose writes its
+  /// matrix formulas with (`T' = a · T · a^T`). It was the one named
+  /// character the operator lexer knew but the character table did not, so a
+  /// Text cell printed the escape `\[CenterDot]` verbatim mid-sentence.
+  #[test]
+  fn test_center_dot_named_character_renders_as_middle_dot() {
+    let s = r#"TextData["T'=a \[CenterDot] T \[CenterDot] a"]"#;
+    assert_eq!(extract_cell_content(s), "T'=a \u{00B7} T \u{00B7} a");
+  }
+
   #[test]
   fn test_extract_cell_content_template_box_quantity() {
     // `TemplateBox[{value, displayed, name, unit_id}, "QuantityPrefix"]` is

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -382,6 +382,7 @@ pub fn named_char_to_unicode(name: &str) -> Option<&'static str> {
     "MinusPlus" => "\u{2213}",
     "Times" => "\u{00D7}",
     "Divide" => "\u{00F7}",
+    "CenterDot" => "\u{00B7}",
     // `\[Equal]` is the typeset `==`; it has its own private-use code point
     // rather than reusing the ASCII `=` (which is `Set`).
     "Equal" => "\u{F431}",

--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -2656,6 +2656,9 @@ mod ring_operators {
       interpret(r#"a \[CenterDot] b \[CircleTimes] c"#).unwrap(),
       "a \u{00B7} b \u{2297} c"
     );
+    // Inside a string it is content, not an operator, so it still has to
+    // resolve to the middle dot rather than staying an escape.
+    assert_eq!(interpret(r#""a \[CenterDot] b""#).unwrap(), "a \u{00B7} b");
   }
 
   // \[CircleMinus] is a binary (non-flat), left-associative operator at the


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration notebook ("Coordinate Transformation of a-Matrix and alpha-Matrix") via the scheduled Woxi Studio compatibility check.
- The notebook's `Initialization Code` cells (`nFold`, `ArbMirror`, `αMatrix1`) and its `Manipulate` all evaluate correctly, and the notebook loads and runs fine in Woxi Studio without crashing.
- Found one rendering bug: the notebook's prose (Caption/Details `Text`/`InlineMath` cells) writes matrix formulas like `T'=a \[CenterDot] T \[CenterDot] a^T`. `\[CenterDot]` was the one named character the operator lexer already knew about (as a `Times`-precedence infix operator, `a \[CenterDot] b` → `a · b`) but the shared `named_char_to_unicode` table in `src/syntax.rs` did not — so outside of operator position (i.e. inside a `Text`/`TextData` cell) it fell through to its raw `\[CenterDot]` escape instead of the middle dot `·`.
- Fix: added `"CenterDot" => "\u{00B7}"` to `named_char_to_unicode`.

No verbatim notebook content was copied into the repository — the regression tests below use hand-written expressions.

## Test plan

- [x] `cargo test --lib notebook::tests::test_center_dot_named_character_renders_as_middle_dot` — new test, passes (Text-cell extraction path)
- [x] `cargo test --test interpreter_tests center_dot_operator` — extended existing test with a string-literal assertion, passes
- [x] `make test` — full suite: 27650/27650 pass
- [x] `make format`
- [x] Loaded the downloaded notebook in `woxi-studio` headlessly (Xvfb) before and after the fix to confirm no crash and that the fix takes effect

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVWKYGryuzukQUNte83iyg)_