### PR TITLE
Reset dashing for Dashing[None] so later strokes render solid

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -452,7 +452,7 @@ Control,Represents a standalone interactive control such as a slider or popup me
 WorkingPrecision,Option for numerical precision,✅,pure,1.0,412
 Hypergeometric2F1,Gauss hypergeometric function 2F1,✅,pure,1.0,413
 Complement,Returns elements in first list or association not in the others,✅,pure,1.0,414
-Dashing,Sets line dashing in graphics,✅,pure,1.0,416
+Dashing,"Sets line dashing in graphics; Dashing[None] and Dashing[{}] go back to solid strokes",✅,pure,1.0,416
 StreamPlot,Creates a streamline plot of a vector field,✅,pure,7.0,416
 Animate,Animated version of an expression (stays symbolic in script mode),✅,unevaluated,6.0,417
 Contours,Option specifying contour levels in contour plots,✅,none,2.0,418

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1305,6 +1305,11 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
         // Dashing[{d1, d2, ...}] or Dashing[d]
         // Supports named sizes: Tiny, Small, Medium, Large
         match &args[0] {
+          // `Dashing[None]` and `Dashing[{}]` go back to solid strokes,
+          // the way a Demonstration turns `Dashed` off again partway
+          // through a Graphics list.
+          Expr::Identifier(s) if s == "None" => style.dashing = None,
+          Expr::List(items) if items.is_empty() => style.dashing = None,
           Expr::List(items) => {
             let dashes: Vec<f64> = items
               .iter()

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -864,6 +864,40 @@ mod graphics {
       assert_eq!(dashes(&line("Dashing[{0.05, 0.05}]", 800)), ["40.0,40.0"]);
     }
 
+    /// `Dashing[None]` (and the equivalent `Dashing[{}]`) turns dashing
+    /// back off, so everything drawn after it is stroked solid again.
+    /// Neither form names a length, so both used to fall through the
+    /// numeric branch without touching the style — leaving an earlier
+    /// `Dashed` in force and dashing every later stroke. A Demonstration
+    /// that dashes one orbit circle and then draws solid arrows relies on
+    /// the reset.
+    #[test]
+    fn dashing_none_returns_to_solid_strokes() {
+      let dasharrays = |code: &str| -> Vec<String> {
+        export_svg(code)
+          .split("stroke-dasharray=\"")
+          .skip(1)
+          .filter_map(|s| s.split('"').next().map(str::to_string))
+          .collect()
+      };
+      let two_lines = |reset: &str| {
+        format!(
+          "Graphics[{{Dashed, Line[{{{{0, 0}}, {{10, 0}}}}], {reset}, \
+           Line[{{{{0, 1}}, {{10, 1}}}}]}}, \
+           PlotRange -> {{{{0, 10}}, {{-1, 2}}}}, ImageSize -> 400]"
+        )
+      };
+      // Without a reset both strokes are dashed.
+      assert_eq!(
+        dasharrays(&two_lines("Dashing[{Small, Small}]")),
+        ["4.0,4.0", "4.0,4.0"]
+      );
+      // With one, only the first stroke carries a dash array.
+      for reset in ["Dashing[None]", "Dashing[{}]"] {
+        assert_eq!(dasharrays(&two_lines(reset)), ["4.0,4.0"], "for {reset}");
+      }
+    }
+
     #[test]
     fn dashed_shorthand() {
       insta::assert_snapshot!(export_svg(


### PR DESCRIPTION
Sampled a random Wolfram Demonstration ("Condition for Free Fall around Earth") and checked it against Woxi Studio. The notebook parses fully — all 46 cells, including the `Manipulate` source cell and its stored widget dump — and the widget instantiates and re-renders correctly across the whole reversed-range slider. But the picture came out wrong: every arrow was dashed.

## The bug

The Graphics list dashes the white orbit circle, then calls `Dashing[None]` before drawing the solid velocity and gravity arrows.

`apply_directive` only understood a *length* argument — a named size (`Tiny`/`Small`/`Medium`/`Large`) or a number. `Dashing[None]` matched neither helper, fell through the numeric branch without touching the style, and left the earlier `Dashed` in force. Everything drawn afterwards inherited it.

At the slider's default the demonstration drew twelve dashed arrows where Wolfram draws twelve solid ones, and the divergence grew with the arrow count as the slider swept toward zero (36 arrows at θ = 0).

## The fix

Reset `style.dashing` for `Dashing[None]`, and for the equally length-free `Dashing[{}]`, which Wolfram also renders solid and which hit the same fall-through via the empty-list branch.

## Verification

Confirmed the bug empirically before fixing — a two-line `Graphics` with `Dashed … Dashing[None] …` emitted `stroke-dasharray` on **both** strokes; after the fix, only on the first.

The demonstration's full `Manipulate` body now renders with exactly one dashed stroke (the orbit circle) at every slider position:

| θ | arrows | dashed strokes |
|---|---|---|
| π/2 | 4 | 1 |
| 1.1 (default) | 12 | 1 |
| 0.6 | 24 | 1 |
| 0 | 36 | 1 |

Added a regression test asserting both reset forms drop the dash array from the following stroke while leaving the preceding one dashed, and pinning the *unreset* case so the assertion cannot pass vacuously.

`cargo test` is green: 27,074 tests, 0 failures. `make format` reports no changes.

No code was copied from the demonstration notebook; the test uses an independently written two-line graphic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGCeuCVnQRtaiahUfeBua1)_