### PR TITLE
Fix Through[...] and Set[Evaluate[...], ...] for Woxi Studio compatibility

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1160,7 +1160,12 @@ pub fn evaluate_expr_to_expr_inner(
         }
         // Special handling for Set - first arg must be identifier or Part, second gets evaluated
         if name == "Set" && args.len() == 2 {
-          return set_ast(&args[0], &args[1]);
+          // Set has HoldFirst, but Evaluate[...] still forces evaluation of
+          // the LHS even through the hold — the standard idiom for
+          // assigning to a programmatically-built symbol, e.g.
+          // `Evaluate[Symbol["p" <> ToString[i]]] = value`.
+          let lhs = unwrap_top_level_evaluate(&args[0])?;
+          return set_ast(&lhs, &args[1]);
         }
         // Special handling for SetDelayed - stores function definitions
         if name == "SetDelayed" && args.len() == 2 {

--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -1883,6 +1883,17 @@ pub fn thread_ast_positions(
   }
 }
 
+/// If `head` is (or evaluates to) a List or a compound FunctionCall head
+/// like `Plus[f, g]`, return its Wolfram head name and its elements/args —
+/// the `(h, {f1, f2, ...})` pair `Through` distributes over.
+fn resolve_through_head(head: &Expr) -> Option<(String, Vec<Expr>)> {
+  match head {
+    Expr::FunctionCall { name, args } => Some((name.clone(), args.to_vec())),
+    Expr::List(items) => Some(("List".to_string(), items.to_vec())),
+    _ => None,
+  }
+}
+
 /// AST-based Through: apply multiple functions.
 /// Through[{f, g}[x]] -> {f[x], g[x]}
 /// Through[f[g][x]] -> f[g[x]]
@@ -1891,59 +1902,86 @@ pub fn through_ast(
   expr: &Expr,
   head_filter: Option<&str>,
 ) -> Result<Expr, InterpreterError> {
-  // Through operates on CurriedCall: h[f1, f2, ...][args...]
-  // It threads the args through each fi, wrapping the result in h.
-  match expr {
-    Expr::CurriedCall { func, args } => {
-      // func is the head expression, e.g. f[g], {f, g}, Plus[f, g]
-      // args are the outer arguments to thread through
-      let (head_name, functions) = match func.as_ref() {
-        Expr::FunctionCall { name, args: fns } => {
-          (name.as_str(), fns.as_slice())
+  // Through operates on `h[f1, f2, ...][args...]`. Depending on how the
+  // `h[f1, f2, ...]` part was written, it parses as one of two shapes:
+  //   - CurriedCall, when the head token was itself a compound expression
+  //     (`{f, g}[x]`, `Plus[f, g][x]`), or a variable bound to one written
+  //     the same way it would need parens to re-apply (`t = {f, g}; t[x]`
+  //     still parses as a *plain* call — see below — so this path mainly
+  //     covers literal heads and `f[g][x]`-style chains).
+  //   - a plain FunctionCall, when the head token was a bare identifier
+  //     (`rots[pt]`) — Wolfram's `f[x]` syntax doesn't distinguish "call
+  //     built-in f" from "apply whatever f is bound to" at parse time, so
+  //     `rots[pt]` with `rots = {r1, r2, …}` parses exactly like a normal
+  //     function call and only resolves to a list-application once `rots`
+  //     is looked up.
+  let (outer_args, resolved): (&[Expr], Option<(String, Vec<Expr>)>) =
+    match expr {
+      Expr::CurriedCall { func, args } => {
+        let evaluated_func;
+        let func_ref: &Expr = match func.as_ref() {
+          Expr::List(_) | Expr::FunctionCall { .. } => func.as_ref(),
+          _ => {
+            evaluated_func = crate::evaluator::evaluate_expr_to_expr(func)?;
+            &evaluated_func
+          }
+        };
+        (args.as_slice(), resolve_through_head(func_ref))
+      }
+      Expr::FunctionCall { name, args } => {
+        let bound = crate::ENV.with(|e| {
+          e.borrow().get(name).and_then(|v| match v {
+            crate::StoredValue::ExprVal(bound_expr) => Some(bound_expr.clone()),
+            _ => None,
+          })
+        });
+        (
+          args.as_slice(),
+          bound.as_ref().and_then(resolve_through_head),
+        )
+      }
+      _ => (&[], None),
+    };
+
+  let Some((head_name, functions)) = resolved else {
+    return if head_filter.is_some() {
+      // With head filter and no resolvable head: return expression as-is
+      Ok(expr.clone())
+    } else {
+      // Not a curried call - return unevaluated
+      Ok(call1("Through", expr.clone()))
+    };
+  };
+
+  // Check head filter if provided
+  if let Some(filter) = head_filter
+    && head_name != filter
+  {
+    // Head doesn't match filter - return the inner expression unchanged
+    return Ok(expr.clone());
+  }
+
+  // Thread: apply each function to the outer args. Uses the general
+  // curried-call applier so compound function values (e.g.
+  // `TransformationFunction[matrix]`) are actually invoked rather than
+  // stringified into a bogus function name.
+  let threaded: Vec<Expr> = functions
+    .iter()
+    .map(|f| {
+      crate::evaluator::apply_curried_call(f, outer_args).unwrap_or_else(|_| {
+        Expr::CurriedCall {
+          func: Box::new(f.clone()),
+          args: outer_args.to_vec(),
         }
-        Expr::List(items) => ("List", items.as_slice()),
-        _ => {
-          // Not a compound head - return unevaluated
-          return Ok(call1("Through", expr.clone()));
-        }
-      };
+      })
+    })
+    .collect();
 
-      // Check head filter if provided
-      if let Some(filter) = head_filter
-        && head_name != filter
-      {
-        // Head doesn't match filter - return the inner expression unchanged
-        return Ok(expr.clone());
-      }
-
-      // Thread: apply each function to the outer args, then evaluate
-      let threaded: Vec<Expr> = functions
-        .iter()
-        .map(|f| {
-          let call = Expr::FunctionCall {
-            name: crate::syntax::expr_to_string(f),
-            args: args.clone().into(),
-          };
-          crate::evaluator::evaluate_expr_to_expr(&call).unwrap_or(call)
-        })
-        .collect();
-
-      // Wrap in the head
-      if head_name == "List" {
-        Ok(Expr::List(threaded.into()))
-      } else {
-        Ok(call(head_name, threaded))
-      }
-    }
-    _ => {
-      if head_filter.is_some() {
-        // With head filter and non-CurriedCall: return expression as-is
-        Ok(expr.clone())
-      } else {
-        // Not a curried call - return unevaluated
-        Ok(call1("Through", expr.clone()))
-      }
-    }
+  // Wrap in the head
+  if head_name == "List" {
+    Ok(Expr::List(threaded.into()))
+  } else {
+    Ok(call(&head_name, threaded))
   }
 }
 

--- a/tests/interpreter_tests/attributes.rs
+++ b/tests/interpreter_tests/attributes.rs
@@ -1561,6 +1561,21 @@ mod cases {
     );
   }
   #[test]
+  fn set_evaluate_lhs() {
+    // Set has HoldFirst, but `Evaluate[...]` still forces evaluation of the
+    // LHS even through the hold — the standard idiom for assigning to a
+    // programmatically-built symbol name.
+    assert_case(r#"Evaluate[Symbol["qq1"]] = 42; qq1"#, r#"42"#);
+    // The idiom as it appears inside a Table, building a family of symbols
+    // named from their loop index (e.g. the Soma Cube Demonstration).
+    assert_case(
+      r#"Table[Evaluate[Symbol["qq" <> ToString[i]]] = i^2, {i, 3}]; {qq1, qq2, qq3}"#,
+      r#"{1, 4, 9}"#,
+    );
+    // A plain (non-Evaluate) LHS is unaffected.
+    assert_case(r#"qq2 = 7; qq2"#, r#"7"#);
+  }
+  #[test]
   fn f_16() {
     assert_case(
       r#"Sqrt[Unevaluated[x]]; Length[Unevaluated[1+2+3+4]]; Attributes[Unevaluated]; f[Unevaluated[x]]"#,

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -13889,6 +13889,38 @@ mod through {
   fn through_single_function() {
     assert_eq!(interpret("Through[{f}[x, y]]").unwrap(), "{f[x, y]}");
   }
+
+  #[test]
+  fn through_variable_bound_list() {
+    // `Through[h[args]]` must resolve `h` through the environment when it
+    // is a plain identifier bound to a list, not just when the list is
+    // written literally as the head.
+    assert_eq!(
+      interpret("lst = {Sin, Cos, Tan}; Through[lst[Pi/4]]").unwrap(),
+      "{1/Sqrt[2], 1/Sqrt[2], 1}"
+    );
+    assert_eq!(
+      interpret("lst = {f, g, h}; Through[lst[x]]").unwrap(),
+      "{f[x], g[x], h[x]}"
+    );
+  }
+
+  #[test]
+  fn through_compound_function_values() {
+    // Each element of the threaded list can itself be a compound
+    // expression (not a bare symbol) that must be genuinely applied to
+    // the argument, not stringified into a bogus function name — as
+    // happens e.g. threading a list of `TransformationFunction`s built
+    // from `RotationTransform`/`TranslationTransform` (the "Search for
+    // Soma Cube Solutions" Demonstration's rotation-group idiom).
+    assert_eq!(
+      interpret(
+        "rots = {RotationTransform[Pi/2, {1, 0, 0}], TranslationTransform[{0, 0, 0}]}; Through[rots[{1, 2, 3}]]"
+      )
+      .unwrap(),
+      "{{1, -3, 2}, {1, 2, 3}}"
+    );
+  }
 }
 
 mod replace_level_spec {

--- a/tests/script_snapshot_tests.rs
+++ b/tests/script_snapshot_tests.rs
@@ -1081,7 +1081,13 @@ script_test!(
   script_sorting_algorithms_radix_sort,
   "sorting_algorithms_radix_sort.wls"
 );
-script_test!(
+// Uses `Through[And[f, g]@l]` to check both sort helpers against randomly
+// sized lists (up to 1000 elements, up to 150 trials) — now that Through
+// correctly applies its predicates (see the `Through` variable-bound-head
+// fix), this genuinely runs SelectSort's O(n^2) list-slice reassignment
+// at real scale and takes tens of seconds in debug builds, like the other
+// heavy scripts below.
+slow_script_test!(
   script_sorting_algorithms_selection_sort,
   "sorting_algorithms_selection_sort.wls"
 );


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration notebook ("Search for Soma Cube Solutions") via the scheduled Woxi Studio compatibility check.
- Its `Initialization` code uses two idioms that were silently broken:
  - `Evaluate[Symbol[...]] = value` inside a `Table` — the standard idiom for assigning to a programmatically-built symbol name. `Set` intercepts its LHS before the generic `Evaluate`-unwrapping path runs, so `Evaluate[...]` on `Set`'s LHS never forced evaluation, producing `Set::write: Tag Evaluate ... is Protected` instead of assigning the symbol.
  - `Through[rots[pt]]` where `rots` is a variable bound to a list of `TransformationFunction`s. `Through` only recognized a *literal* `{f, g}` or `h[f, g]` head; a bare identifier bound to such a value (`rots[pt]`) parses as a plain `FunctionCall`, not a `CurriedCall`, so `Through` silently no-op'd. Its per-function application also stringified each function into a bogus function name instead of genuinely invoking it, so compound values like `TransformationFunction[matrix]` never actually ran even when the head *was* a literal list.
  - The `Through` bug happened to mask a real O(n²) list-slice cost in one existing script snapshot test (`sorting_algorithms_selection_sort.wls` — it also uses `Through[And[f, g]@l]`), which now correctly executes its predicates and needs the same `slow_script_test!` gating the other heavy RosettaCode scripts already use.
- Added regression tests for both fixes (`Set`/`Evaluate` LHS, `Through` on a variable-bound list, `Through` applying compound function values like `TransformationFunction`).

No verbatim notebook content was copied into the repository — the regression tests use hand-crafted expressions matching the pattern found in the notebook, not its code.

## Test plan

- [x] `cargo test --test interpreter_tests` (targeted `Set`/`Evaluate`/`Through` tests) — pass
- [x] `make test` — full suite: 27651/27651 pass
- [x] `make format`
- [x] Re-verified the downloaded notebook's `Initialization` code (the exact `Evaluate[Symbol[...]] = ...` / `Through[rots[...]]` patterns) via `woxi eval` before and after the fix — errored/hung before, now evaluates correctly and completes fast

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4Dv5w8PMVkNLXFCgFxs4)_