### PR TITLE
Fix Woxi Studio Manipulate widgets shadowing a same-named builtin

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1954,6 +1954,48 @@ pub fn extract_saved_initialization(box_dump: &str) -> Option<String> {
   None
 }
 
+/// The distinct symbol names Wolfram qualified with `` $CellContext` `` in a
+/// saved `Initialization :> ( … )` block — i.e. the names
+/// [`extract_saved_initialization`] strips down to bare identifiers.
+///
+/// `` $CellContext` `` is the DynamicModule's own private context: a
+/// Demonstration's `SaveDefinitions -> True` helper (say a `Midpoint` the
+/// author wrote before Wolfram ever shipped a built-in of that name) lives
+/// there specifically so it can never collide with a same-named symbol
+/// anywhere else — including one a *later* Wolfram Language version adds to
+/// `System\``. Once the prefix is stripped for evaluation, that protection
+/// is gone: the bare name is looked up exactly where the real built-in
+/// lives, and redefining a Protected symbol fails. Unprotecting these names
+/// first (the caller's job) restores the isolation the prefix used to give.
+pub fn saved_initialization_context_symbols(box_dump: &str) -> Vec<String> {
+  const PREFIX: &str = "$CellContext`";
+  let mut names: Vec<String> = Vec::new();
+  let mut search_from = 0;
+  while let Some(rel) = box_dump[search_from..].find("Initialization") {
+    let after_kw = search_from + rel + "Initialization".len();
+    let rest = box_dump[after_kw..].trim_start();
+    if let Some(rest) = rest.strip_prefix(":>")
+      && let Some(body) = rest.trim_start().strip_prefix('(')
+      && let Some(inner) = matching_paren_prefix(body)
+    {
+      let mut scan_from = 0;
+      while let Some(rel2) = inner[scan_from..].find(PREFIX) {
+        let start = scan_from + rel2 + PREFIX.len();
+        let end = inner[start..]
+          .find(|c: char| !(c.is_alphanumeric() || c == '$'))
+          .map_or(inner.len(), |i| start + i);
+        let name = &inner[start..end];
+        if !name.is_empty() && !names.iter().any(|n| n == name) {
+          names.push(name.to_string());
+        }
+        scan_from = end.max(start + 1);
+      }
+    }
+    search_from = after_kw;
+  }
+  names
+}
+
 /// The prefix of `s` up to (excluding) the `)` matching an already-consumed
 /// `(`. Skips over string literals, where parentheses are just text.
 fn matching_paren_prefix(s: &str) -> Option<&str> {
@@ -4504,6 +4546,32 @@ yf4GL4DwC5VA4w
       SynchronousInitialization->True]";
     let init = extract_saved_initialization(dump).unwrap();
     assert_eq!(init, "{a = 1, b = {2, 3}}; Typeset`initDone$$ = True");
+  }
+
+  #[test]
+  fn test_saved_initialization_context_symbols() {
+    let dump = "DynamicModuleBox[{$CellContext`k$$ = 0}, \
+      DynamicBox[…],\n\
+      Initialization:>($CellContext`Midpoint[\
+      Pattern[$CellContext`a, Blank[]], Pattern[$CellContext`b, Blank[]]] := \
+      ($CellContext`a + $CellContext`b)/2; \
+      Typeset`initDone$$ = True)]";
+    let mut names = saved_initialization_context_symbols(dump);
+    names.sort();
+    // `a` and `b` are pattern variable names, `Midpoint` is the helper
+    // being defined; each appears once even though `Midpoint` and `a`/`b`
+    // each occur more than once in the dump.
+    assert_eq!(names, vec!["Midpoint", "a", "b"]);
+  }
+
+  #[test]
+  fn test_saved_initialization_context_symbols_none() {
+    assert_eq!(
+      saved_initialization_context_symbols(
+        "DynamicModuleBox[{}, DynamicBox[…]]"
+      ),
+      Vec::<String>::new()
+    );
   }
 
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -5063,6 +5063,19 @@ fn instantiate_stored_manipulate(
   if let Some(init) =
     woxi::notebook::extract_saved_initialization(stored_output)
   {
+    // These names lived in the DynamicModule's private `$CellContext`` in
+    // Wolfram, isolated from anything of the same name elsewhere —
+    // including a built-in a later Wolfram Language version introduces
+    // (e.g. a Demonstration's own pre-12.0 `Midpoint` helper, now shadowed
+    // by the real `Midpoint` function). `extract_saved_initialization`
+    // strips that prefix so the body's bare references resolve, which
+    // reopens exactly that collision: unprotect them first so the
+    // notebook's own definition can still win, as it does in Wolfram.
+    let names =
+      woxi::notebook::saved_initialization_context_symbols(stored_output);
+    if !names.is_empty() {
+      let _ = woxi::interpret(&format!("Unprotect[{}]", names.join(", ")));
+    }
     let _ = woxi::interpret(&init);
   }
   let expr = woxi::interpret_to_expr(&statements[0]).ok()?;
@@ -8048,6 +8061,42 @@ Cell[BoxData["standalone output"], "Output"]
     )
     .unwrap();
     assert_eq!(state.text_output.as_deref(), Some("41"));
+  }
+
+  #[test]
+  fn stored_manipulate_saved_initialization_may_shadow_a_builtin() {
+    // A Demonstration written before Wolfram shipped a built-in `Midpoint`
+    // may define its own two-argument `Midpoint` helper. `SaveDefinitions
+    // -> True` stores it under the DynamicModule's private
+    // `$CellContext``, so in Wolfram it never collides with a same-named
+    // built-in a later language version adds — that's exactly what the
+    // private context is for. Regression: stripping the prefix for
+    // evaluation reopened the collision, since `Midpoint` is Protected —
+    // the stored `SetDelayed` silently failed and the body's calls fell
+    // through to the built-in's unrelated one-argument form.
+    let dump = "DynamicModuleBox[{$CellContext`x$$ = 3}, \
+      DynamicBox[…],\n\
+      Deinitialization:>None,\n\
+      Initialization:>($CellContext`Midpoint[\
+      Pattern[$CellContext`a, Blank[]], Pattern[$CellContext`b, Blank[]]] := \
+      ($CellContext`a + $CellContext`b)/2; \
+      Typeset`initDone$$ = True),\n\
+      SynchronousInitialization->True]";
+    let state = instantiate_stored_manipulate(
+      "Manipulate[Midpoint[x, 7], {{x, 3}, 0, 10}]",
+      dump,
+    )
+    .unwrap();
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state.text_output.as_deref(),
+      Some("5"),
+      "the notebook's own Midpoint must win over the built-in"
+    );
   }
 
   /// A published Demonstration lays its panel out itself — the controls


### PR DESCRIPTION
## Summary

While checking Woxi Studio's support for a random Wolfram Demonstration ("The Nagel Line"), the "show medians" / "show medial triangle" / "show medial triangle angle bisectors" toggles silently rendered nothing extra.

The Demonstration defines its own two-argument `Midpoint` helper — written before Wolfram shipped a built-in `Midpoint` of that name. `SaveDefinitions -> True` stores such helpers under the DynamicModule's private `` $CellContext` ``, so in real Wolfram they never collide with a same-named symbol a later language version introduces.

`instantiate_stored_manipulate` stripped the `` $CellContext` `` prefix down to a bare name before evaluating the saved Initialization, which reopened exactly that collision: `Midpoint` is Protected, so the notebook's own `SetDelayed` silently failed and every call fell through to the built-in's unrelated one-argument form.

- Added `notebook::saved_initialization_context_symbols` to recover the `` $CellContext` ``-qualified names before they're stripped.
- `instantiate_stored_manipulate` now unprotects those names before running the saved Initialization, restoring the isolation the prefix used to provide.

Verified against the actual downloaded notebook: before the fix, toggling any of the medians/medial/medial-bisectors checkboxes threw `SetDelayed::write: Tag Midpoint ... is Protected.` and `Midpoint::argx` on every reevaluation; after the fix, all seven checkbox toggles evaluate cleanly with no errors.

## Test plan

- [x] Added `notebook::test_saved_initialization_context_symbols` / `_none` (`src/notebook.rs`)
- [x] Added `stored_manipulate_saved_initialization_may_shadow_a_builtin` (`woxi-studio/src/main.rs`) — a synthetic regression reproducing the collision with a made-up `Midpoint`-shadowing widget
- [x] `make format`
- [x] `make test` (27,651 tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P51yBuBNHa8wVmUobAj31

---
_Generated by [Claude Code](https://claude.ai/code/session_014P51yBuBNHa8wVmUobAj31)_