### PR TITLE
Typeset Overscript/Underscript/OverBar/UnderBar accents

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -3725,6 +3725,40 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
         vec![expr_to_box_form(&args[0]), expr_to_box_form(&args[1])],
       )
     }
+    // `Overscript[a, b]` / `Underscript[a, b]` place `b` as an annotation
+    // above/below `a` — the box form is a direct `OverscriptBox`/
+    // `UnderscriptBox`, matching how the FrontEnd stores an
+    // `OverscriptBox["x", "_"]`/`UnderscriptBox` cell as `Overscript`/
+    // `Underscript` once turned back into an expression (see
+    // `notebook::box_source_to_expression`). `OverBar`/`UnderBar` are the
+    // named-accent shorthands: `OverBar[x]` boxes exactly like
+    // `Overscript[x, "_"]`.
+    Expr::FunctionCall { name, args }
+      if (name == "Overscript" || name == "Underscript") && args.len() == 2 =>
+    {
+      let box_name = if name == "Overscript" {
+        "OverscriptBox"
+      } else {
+        "UnderscriptBox"
+      };
+      call(
+        box_name,
+        vec![expr_to_box_form(&args[0]), expr_to_box_form(&args[1])],
+      )
+    }
+    Expr::FunctionCall { name, args }
+      if (name == "OverBar" || name == "UnderBar") && args.len() == 1 =>
+    {
+      let box_name = if name == "OverBar" {
+        "OverscriptBox"
+      } else {
+        "UnderscriptBox"
+      };
+      call(
+        box_name,
+        vec![expr_to_box_form(&args[0]), Expr::String("_".to_string())],
+      )
+    }
     expr if is_sqrt(expr).is_some() => {
       let sqrt_arg = is_sqrt(expr).unwrap();
       call1("SqrtBox", expr_to_box_form(sqrt_arg))
@@ -5203,6 +5237,25 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
     }
     "Superscript" if args.len() == 2 => {
       tf_box("SuperscriptBox", vec![tf(&args[0]), tf(&args[1])])
+    }
+    // `Overscript[a, b]` / `Underscript[a, b]` and their `OverBar`/`UnderBar`
+    // accent shorthands — same `…Box` mapping as the StandardForm converter
+    // (`expr_to_box_form`), just recursing through `tf` for the pieces.
+    "Overscript" | "Underscript" if args.len() == 2 => {
+      let box_name = if name == "Overscript" {
+        "OverscriptBox"
+      } else {
+        "UnderscriptBox"
+      };
+      tf_box(box_name, vec![tf(&args[0]), tf(&args[1])])
+    }
+    "OverBar" | "UnderBar" if args.len() == 1 => {
+      let box_name = if name == "OverBar" {
+        "OverscriptBox"
+      } else {
+        "UnderscriptBox"
+      };
+      tf_box(box_name, vec![tf(&args[0]), tf_string("_")])
     }
     // A single-order derivative arrives flattened: `f''[x]` is held as
     // `Derivative[2, f, x]`, so the order leads, the differentiated function

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -9470,6 +9470,49 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
           )
         }
 
+        // `OverBar[x]` / `UnderBar[x]` — the named accent shorthands for a
+        // horizontal line above/below the content (a Demonstration's sample
+        // mean/estimate notation, x̄). `text-decoration` draws the line at
+        // zero extra width, the same trick `SqrtBox`'s vinculum uses above.
+        "OverBar" | "UnderBar" if args.len() == 1 => {
+          let deco = if name == "OverBar" { "overline" } else { "underline" };
+          format!(
+            "<tspan text-decoration=\"{deco}\">{}</tspan>",
+            expr_to_svg_markup(&args[0])
+          )
+        }
+
+        // `Overscript[base, accent]` / `Underscript[base, accent]` place an
+        // arbitrary annotation above/below `base` — e.g. a hat for an
+        // estimator (σ̂) or, as the FrontEnd stores an `OverscriptBox["x",
+        // "_"]` cell once turned back into an expression, an underscore
+        // standing in for a bar (x̄, see `notebook::box_source_to_expression`).
+        // A literal underscore/hyphen accent draws as a real overline, an
+        // exact match; anything else (a hat, a tilde, …) is raised above the
+        // base and pulled back over it — inline `tspan`s share one baseline,
+        // so true 2-D stacking isn't expressible, but for the single-letter
+        // bases these accents dress (σ, x, y, ρ) the overlap reads right.
+        "Overscript" | "Underscript" if args.len() == 2 => {
+          let base_markup = expr_to_svg_markup(&args[0]);
+          let accent_markup = expr_to_svg_markup(&args[1]);
+          let is_bar_accent = matches!(&args[1],
+            Expr::String(s) if s == "_" || s == "-" || s == "\u{2013}");
+          if is_bar_accent {
+            let deco =
+              if name == "Overscript" { "overline" } else { "underline" };
+            format!("<tspan text-decoration=\"{deco}\">{base_markup}</tspan>")
+          } else {
+            let (raise, fall) = if name == "Overscript" {
+              ("-0.55em", "0.55em")
+            } else {
+              ("0.55em", "-0.55em")
+            };
+            format!(
+              "<tspan dy=\"{raise}\" font-size=\"65%\">{accent_markup}</tspan><tspan dx=\"-0.6em\" dy=\"{fall}\">{base_markup}</tspan>"
+            )
+          }
+        }
+
         // `Spacer[n]` is a gap n printer's points wide, wherever it
         // appears — among a `Row`'s items as readily as as its separator.
         // The width is absolute, not relative to the font: `Spacer[25]`
@@ -9793,6 +9836,16 @@ pub fn estimate_display_width(expr: &Expr) -> f64 {
       }
       // HoldForm[expr] → width of content
       "HoldForm" if args.len() == 1 => estimate_display_width(&args[0]),
+      // OverBar/UnderBar draw their accent as a zero-width line over the
+      // content; Overscript/Underscript's accent overlaps the base the same
+      // way `expr_to_svg_markup` draws it (see that function's comment).
+      "OverBar" | "UnderBar" if args.len() == 1 => {
+        estimate_display_width(&args[0])
+      }
+      "Overscript" | "Underscript" if args.len() == 2 => {
+        estimate_display_width(&args[0])
+          .max(estimate_display_width(&args[1]) * 0.65)
+      }
       // The presentation wrappers `expr_to_svg_markup` types out as their
       // content only — measuring the `Head[…]` source instead would leave a
       // Row cell several times too wide for the glyphs drawn in it.

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1141,6 +1141,56 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_overscript_and_underscript_accents_typeset() {
+    // Regression: `Overscript[expr, accent]` / `Underscript[expr, accent]`
+    // and their `OverBar`/`UnderBar` shorthands (a Demonstration's estimator
+    // notation — a hat or bar accent over a symbol, e.g. a sample mean) had
+    // no box-form conversion, so the typeset SVG fell back to literal
+    // `Overscript[x, "_"]`/`OverBar[x]` text instead of drawing an accent.
+    clear_state();
+    for code in [
+      "ExportString[Overscript[x, \"^\"], \"SVG\"]",
+      "ExportString[OverBar[x], \"SVG\"]",
+      "ExportString[Underscript[x, \"^\"], \"SVG\"]",
+      "ExportString[UnderBar[x], \"SVG\"]",
+      "ExportString[TraditionalForm[Overscript[x, \"^\"]], \"SVG\"]",
+      "ExportString[TraditionalForm[OverBar[x]], \"SVG\"]",
+    ] {
+      clear_state();
+      let svg = interpret(code).unwrap();
+      assert!(
+        !svg.contains("Overscript")
+          && !svg.contains("Underscript")
+          && !svg.contains("OverBar")
+          && !svg.contains("UnderBar"),
+        "accent SVG for {code} must not leak the head as literal text:\n{svg}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_overscript_accent_inside_grid_cell_typesets() {
+    // Regression: a Grid cell holding `Overscript[…]`/`OverBar[…]` (the
+    // shape of a Demonstration's summary-statistics table, e.g. a sample
+    // mean or an estimator symbol) rendered as literal `Overscript[x, "_"]`
+    // text — the grid-cell markup renderer had cases for Subscript/
+    // Superscript but none for the accent heads.
+    clear_state();
+    let svg = interpret(
+      "ExportString[Grid[{{OverBar[x], Overscript[y, \"^\"]}}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      !svg.contains("OverBar") && !svg.contains("Overscript"),
+      "grid-cell accent SVG must not leak the head as literal text:\n{svg}"
+    );
+    assert!(
+      svg.contains("text-decoration=\"overline\""),
+      "OverBar[x] in a grid cell must draw as a real overline:\n{svg}"
+    );
+  }
+
+  #[test]
   fn test_large_number_output_svg_groups_digits() {
     // The Wolfram notebook groups the integer part of large numbers into
     // 3-digit blocks (`10^10` → `10 000 000 000`). In the Playground/Studio SVG

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21695,4 +21695,28 @@ SaveDefinitions -> True]";
        {nonlinear} vertices"
     );
   }
+
+  /// A published Demonstration's summary-statistics panel typically reports
+  /// an estimator with a hat or bar accent (a sample mean, an estimated
+  /// standard deviation, …) inside a `Grid` the `Manipulate` body builds.
+  /// `Overscript`/`OverBar` had no box-form conversion and no grid-cell
+  /// markup case, so the accent leaked through as literal `Overscript[x,
+  /// "_"]`/`OverBar[…]` text instead of a typeset hat/bar over the symbol.
+  #[test]
+  fn stored_manipulate_typesets_accent_notation() {
+    let state = instantiate_stored_manipulate(
+      "Manipulate[Grid[{{OverBar[x], Overscript[s, \"^\"]}}], {x, 0, 10}]",
+      "",
+    )
+    .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "a Grid of accented symbols must draw as a picture, not fall back to text"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

While checking a random Wolfram Demonstration notebook against Woxi Studio (its `Manipulate` body builds a summary-statistics `Grid` reporting a sample mean/estimator with a hat or bar accent, e.g. x̄, σ̂), I found that `Overscript[base, accent]`, `Underscript[base, accent]`, and their `OverBar`/`UnderBar` shorthands had no rendering support at all — they fell back to literal `Overscript[x, "_"]` text instead of a typeset accent, in both the Studio and the CLI/Export SVG output.

Root cause: these heads were never converted to `OverscriptBox`/`UnderscriptBox` in the box-form converters, and the Grid-cell inline SVG renderer (`expr_to_svg_markup`) had cases for `Subscript`/`Superscript` but none for the accent heads.

- `expr_to_box_form` / `expr_to_box_form_traditional` (StandardForm/TraditionalForm) now convert `Overscript`/`Underscript`/`OverBar`/`UnderBar` to `OverscriptBox`/`UnderscriptBox`, which the existing box-layout renderer already draws correctly.
- `expr_to_svg_markup` (the inline renderer used for `Grid`/`Row`/plot-label cells) now draws a bar accent (`"_"`/`"-"`) as a real `text-decoration="overline"`/`"underline"` — the same zero-width trick already used for `Sqrt`'s vinculum — and any other accent (e.g. a hat) raised and overlapped above/below the base.
- `estimate_display_width` gets matching cases so cell/label width estimates stay consistent.

I deliberately did not copy any code from the Demonstration notebook itself (it's copyrighted); the regression tests below use minimal synthetic examples instead.

## Test plan

- [x] Added `test_overscript_and_underscript_accents_typeset` and `test_overscript_accent_inside_grid_cell_typesets` in `tests/interpreter_tests.rs`
- [x] Added `stored_manipulate_typesets_accent_notation` in `woxi-studio/src/main.rs`, exercising a `Manipulate` whose body builds a `Grid` of accented symbols end-to-end through Woxi Studio's cell-evaluation pipeline
- [x] `make test` (27,660 tests) passes
- [x] `make test-studio` (189 tests) passes
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_016x8SNtjC8btkSnmT9L3m9J)_