### PR TITLE
Fix FindRoot and SubValue matching for curried indexed variables

### DIFF
--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -983,6 +983,45 @@ fn date_object_tag_property(
   components.get(index).cloned()
 }
 
+/// Try to match `func[args...]` against a SubValue rule registered via
+/// `f[a][b] := …` (also deeper curried nestings like `f[a][b][c] := …`).
+/// Reconstructs the full curried call and matches it against each rule
+/// stored under the outermost head; on a match, substitutes the bindings
+/// into the body. `None` when there's no head to key on or no rule matches
+/// (the caller then falls back to preserving the call symbolically).
+fn try_sub_value_curried_match(
+  func: &Expr,
+  args: &[Expr],
+) -> Option<Result<Expr, InterpreterError>> {
+  let outer_head = {
+    let mut inner: &Expr = func;
+    loop {
+      match inner {
+        Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
+        Expr::FunctionCall { name, .. } => break Some(name.clone()),
+        _ => break None,
+      }
+    }
+  };
+  let head = outer_head?;
+  let rules = crate::evaluator::assignment::SUB_VALUES
+    .with(|m| m.borrow().get(&head).cloned())?;
+  let actual = Expr::CurriedCall {
+    func: Box::new(func.clone()),
+    args: args.to_vec(),
+  };
+  for (lhs, body) in &rules {
+    if let Some(bindings) =
+      crate::evaluator::pattern_matching::match_pattern(&actual, lhs)
+    {
+      return Some(crate::evaluator::pattern_matching::apply_bindings(
+        body, &bindings,
+      ));
+    }
+  }
+  None
+}
+
 pub fn apply_curried_call(
   func: &Expr,
   args: &[Expr],
@@ -2172,39 +2211,9 @@ pub fn apply_curried_call(
             crate::syntax::substitute_variables(body, &bindings);
           evaluate_expr_to_expr(&substituted)
         }
+      } else if let Some(result) = try_sub_value_curried_match(func, args) {
+        result
       } else {
-        // Try SubValue rules registered via `f[a][b] := …`. Reconstruct the
-        // full curried call and match it against each stored rule keyed by the
-        // outermost head; on a match, substitute the bindings into the body.
-        let outer_head = {
-          let mut inner: &Expr = func;
-          loop {
-            match inner {
-              Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
-              Expr::FunctionCall { name, .. } => break Some(name.clone()),
-              _ => break None,
-            }
-          }
-        };
-        if let Some(head) = outer_head {
-          let rules = crate::evaluator::assignment::SUB_VALUES
-            .with(|m| m.borrow().get(&head).cloned());
-          if let Some(rules) = rules {
-            let actual = Expr::CurriedCall {
-              func: Box::new(func.clone()),
-              args: args.to_vec(),
-            };
-            for (lhs, body) in &rules {
-              if let Some(bindings) =
-                crate::evaluator::pattern_matching::match_pattern(&actual, lhs)
-              {
-                return crate::evaluator::pattern_matching::apply_bindings(
-                  body, &bindings,
-                );
-              }
-            }
-          }
-        }
         // Unknown/symbolic curried call: preserve the CurriedCall form
         // e.g. f[g][x] stays as f[g][x], not f[g, x]
         Ok(Expr::CurriedCall {
@@ -2238,10 +2247,19 @@ pub fn apply_curried_call(
     }
     Expr::CurriedCall { .. } => {
       // Nested curried call: `s[a][b][c]` arrives here as
-      // `apply_curried_call(CurriedCall{s[a], [b]}, [c])`. Preserve the
-      // structure rather than collapsing the head to a string-named
-      // FunctionCall (which loses the AST shape that pattern-matchers
-      // rely on, e.g. `s[a][b][c] /. s[x_][y_][z_] -> …`).
+      // `apply_curried_call(CurriedCall{s[a], [b]}, [c])`. A SubValue rule
+      // spanning this many curry levels (`y[3][i_][t_] := …`, where the
+      // first level's argument is a literal rather than itself a pattern)
+      // only becomes matchable once every level has been applied, so check
+      // for one here before falling back to preserving the bare structure —
+      // otherwise `func` (itself already a CurriedCall from the previous,
+      // unmatched level) never reaches a SubValue lookup at all.
+      if let Some(result) = try_sub_value_curried_match(func, args) {
+        return result;
+      }
+      // Preserve the structure rather than collapsing the head to a
+      // string-named FunctionCall (which loses the AST shape that
+      // pattern-matchers rely on, e.g. `s[a][b][c] /. s[x_][y_][z_] -> …`).
       Ok(Expr::CurriedCall {
         func: Box::new(func.clone()),
         args: args.to_vec(),

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6422,31 +6422,33 @@ fn find_root_eval_number(expr: &Expr) -> Result<f64, InterpreterError> {
   }
 }
 
-/// True when `e` is a valid FindRoot search variable: a plain symbol, or an
+/// True when `e` is a valid FindRoot search variable: a plain symbol, an
 /// indexed variable such as `u[1]` or `a[2, 3]` — a symbol applied to
-/// literal numeric or string indices. Collocation methods for boundary-value
-/// problems name one unknown per grid point this way (`FindRoot[{eqns},
-/// {{u[1], 0.5}, {u[2], 0.5}, ...}]`), and real Wolfram accepts both forms.
+/// literal numeric or string indices — or a curried chain of those such as
+/// `T[0][t]`. Collocation methods for boundary-value problems name one
+/// unknown per grid point this way (`FindRoot[{eqns}, {{u[1], 0.5}, {u[2],
+/// 0.5}, ...}]`), and time-dependent families use the curried form
+/// (`FindRoot[eqns, {T[0][t], 354.3}, {T[1][t], 357.7}, ...]`); real
+/// Wolfram accepts all of these.
 fn is_findroot_var_expr(e: &Expr) -> bool {
   match e {
     Expr::Identifier(_) => true,
-    Expr::FunctionCall { args, .. } => {
-      !args.is_empty()
-        && args.iter().all(|a| {
-          matches!(a, Expr::Integer(_) | Expr::Real(_) | Expr::String(_))
-        })
+    Expr::FunctionCall { .. } | Expr::CurriedCall { .. } => {
+      flatten_findroot_var(e).is_some()
     }
     _ => false,
   }
 }
 
-/// A hashable key for a FindRoot indexed-variable's literal arguments
-/// (`u[1]` → `[Int(1)]`, `a[2, "x"]` → `[Int(2), Str("x")]`).
+/// A hashable key for a FindRoot indexed-variable's literal or symbolic
+/// arguments (`u[1]` → `[Int(1)]`, `a[2, "x"]` → `[Int(2), Str("x")]`,
+/// `T[0][t]` → `[Int(0), Sym("t")]`).
 #[derive(PartialEq, Eq, Hash, Clone)]
 enum FindRootIndexKey {
   Int(i128),
   RealBits(u64),
   Str(String),
+  Sym(String),
 }
 
 fn find_root_index_key(e: &Expr) -> Option<FindRootIndexKey> {
@@ -6454,6 +6456,38 @@ fn find_root_index_key(e: &Expr) -> Option<FindRootIndexKey> {
     Expr::Integer(n) => Some(FindRootIndexKey::Int(*n)),
     Expr::Real(r) => Some(FindRootIndexKey::RealBits(r.to_bits())),
     Expr::String(s) => Some(FindRootIndexKey::Str(s.clone())),
+    Expr::Identifier(s) => Some(FindRootIndexKey::Sym(s.clone())),
+    _ => None,
+  }
+}
+
+/// Flatten an indexed FindRoot variable — a plain `u[1]` or a curried chain
+/// of those like `T[0][t]` — into its base name and the sequence of index
+/// keys across every level. `None` when any level isn't a recognized
+/// indexed-variable shape (e.g. an empty-arg call, or a level whose
+/// argument isn't a literal or symbol).
+fn flatten_findroot_var(e: &Expr) -> Option<(&str, Vec<FindRootIndexKey>)> {
+  match e {
+    Expr::FunctionCall { name, args } => {
+      if args.is_empty() {
+        return None;
+      }
+      let keys = args
+        .iter()
+        .map(find_root_index_key)
+        .collect::<Option<Vec<_>>>()?;
+      Some((name.as_str(), keys))
+    }
+    Expr::CurriedCall { func, args } => {
+      if args.is_empty() {
+        return None;
+      }
+      let (name, mut keys) = flatten_findroot_var(func)?;
+      for a in args {
+        keys.push(find_root_index_key(a)?);
+      }
+      Some((name, keys))
+    }
     _ => None,
   }
 }
@@ -6491,13 +6525,9 @@ fn find_root_rename_vars(
       Expr::Identifier(name) => {
         id_map.insert(name.as_str(), r);
       }
-      Expr::FunctionCall { name, args } => {
-        if let Some(keys) = args
-          .iter()
-          .map(find_root_index_key)
-          .collect::<Option<Vec<_>>>()
-        {
-          idx_map.insert((name.as_str(), keys), r);
+      Expr::FunctionCall { .. } | Expr::CurriedCall { .. } => {
+        if let Some((name, keys)) = flatten_findroot_var(v) {
+          idx_map.insert((name, keys), r);
         }
       }
       _ => {}
@@ -6517,16 +6547,27 @@ fn find_root_rename_walk(
       None => expr.clone(),
     },
     Expr::FunctionCall { name, args } => {
-      if let Some(keys) = args
-        .iter()
-        .map(find_root_index_key)
-        .collect::<Option<Vec<_>>>()
-        && let Some(r) = idx_map.get(&(name.as_str(), keys))
+      if let Some((flat_name, keys)) = flatten_findroot_var(expr)
+        && let Some(r) = idx_map.get(&(flat_name, keys))
       {
         return (*r).clone();
       }
       Expr::FunctionCall {
         name: name.clone(),
+        args: args
+          .iter()
+          .map(|a| find_root_rename_walk(a, id_map, idx_map))
+          .collect(),
+      }
+    }
+    Expr::CurriedCall { func, args } => {
+      if let Some((flat_name, keys)) = flatten_findroot_var(expr)
+        && let Some(r) = idx_map.get(&(flat_name, keys))
+      {
+        return (*r).clone();
+      }
+      Expr::CurriedCall {
+        func: Box::new(find_root_rename_walk(func, id_map, idx_map)),
         args: args
           .iter()
           .map(|a| find_root_rename_walk(a, id_map, idx_map))

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6463,10 +6463,15 @@ fn find_root_index_key(e: &Expr) -> Option<FindRootIndexKey> {
 
 /// Flatten an indexed FindRoot variable — a plain `u[1]` or a curried chain
 /// of those like `T[0][t]` — into its base name and the sequence of index
-/// keys across every level. `None` when any level isn't a recognized
-/// indexed-variable shape (e.g. an empty-arg call, or a level whose
-/// argument isn't a literal or symbol).
-fn flatten_findroot_var(e: &Expr) -> Option<(&str, Vec<FindRootIndexKey>)> {
+/// keys across every level, one inner `Vec` per application level so that
+/// a single multi-arg call (`T[0, 1]`) and a curried chain of single-arg
+/// calls (`T[0][1]`) — structurally distinct expressions in Wolfram — key
+/// differently instead of colliding on the same flattened index sequence.
+/// `None` when any level isn't a recognized indexed-variable shape (e.g. an
+/// empty-arg call, or a level whose argument isn't a literal or symbol).
+fn flatten_findroot_var(
+  e: &Expr,
+) -> Option<(&str, Vec<Vec<FindRootIndexKey>>)> {
   match e {
     Expr::FunctionCall { name, args } => {
       if args.is_empty() {
@@ -6476,17 +6481,19 @@ fn flatten_findroot_var(e: &Expr) -> Option<(&str, Vec<FindRootIndexKey>)> {
         .iter()
         .map(find_root_index_key)
         .collect::<Option<Vec<_>>>()?;
-      Some((name.as_str(), keys))
+      Some((name.as_str(), vec![keys]))
     }
     Expr::CurriedCall { func, args } => {
       if args.is_empty() {
         return None;
       }
-      let (name, mut keys) = flatten_findroot_var(func)?;
-      for a in args {
-        keys.push(find_root_index_key(a)?);
-      }
-      Some((name, keys))
+      let (name, mut levels) = flatten_findroot_var(func)?;
+      let keys = args
+        .iter()
+        .map(find_root_index_key)
+        .collect::<Option<Vec<_>>>()?;
+      levels.push(keys);
+      Some((name, levels))
     }
     _ => None,
   }
@@ -6517,7 +6524,7 @@ fn find_root_rename_vars(
   let mut id_map: std::collections::HashMap<&str, &Expr> =
     std::collections::HashMap::with_capacity(vars.len());
   let mut idx_map: std::collections::HashMap<
-    (&str, Vec<FindRootIndexKey>),
+    (&str, Vec<Vec<FindRootIndexKey>>),
     &Expr,
   > = std::collections::HashMap::new();
   for (v, r) in vars.iter().zip(replacements) {
@@ -6539,7 +6546,10 @@ fn find_root_rename_vars(
 fn find_root_rename_walk(
   expr: &Expr,
   id_map: &std::collections::HashMap<&str, &Expr>,
-  idx_map: &std::collections::HashMap<(&str, Vec<FindRootIndexKey>), &Expr>,
+  idx_map: &std::collections::HashMap<
+    (&str, Vec<Vec<FindRootIndexKey>>),
+    &Expr,
+  >,
 ) -> Expr {
   match expr {
     Expr::Identifier(name) => match id_map.get(name.as_str()) {

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -8361,6 +8361,25 @@ mod find_root {
     );
   }
 
+  // Regression: time-dependent families in Demonstrations name one unknown
+  // per grid point *and* time as a curried indexed variable (`T[0][t]`,
+  // `T[1][t]`, ...) rather than a single-level `u[1]`. `is_findroot_var_expr`
+  // only recognized a symbol applied once to literal indices, so a curried
+  // chain like `T[0][t]` (`Expr::CurriedCall`) fell through to "variable
+  // must be a symbol" (the Multicomponent Distillation Column Demonstration
+  // hits this).
+  #[test]
+  fn multivariate_curried_indexed_variables() {
+    assert_eq!(
+      interpret(
+        "FindRoot[{T[0][t] + T[1][t] == 3, T[0][t] - T[1][t] == 1}, \
+         {T[0][t], 0}, {T[1][t], 0}]"
+      )
+      .unwrap(),
+      "{T[0][t] -> 2., T[1][t] -> 1.}"
+    );
+  }
+
   // Regression: FindRoot is HoldAll, so equations and a spec list built
   // separately and passed by name (`sys = {...}; initguess = {{x, x0},
   // ...}; FindRoot[sys, initguess]` — the idiom collocation methods use to

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -8380,6 +8380,27 @@ mod find_root {
     );
   }
 
+  // Regression: `T[0, 1]` (one call, two arguments) and `T[0][1]` (a curried
+  // chain of single-argument calls) are structurally distinct expressions in
+  // Wolfram, so a search variable written in one notation must not rename
+  // occurrences of the other. Flattening a curried chain into one index
+  // sequence made both key as `("T", [0, 1])`, and this call silently solved
+  // for variables that never appear in the equations. The index key is
+  // level-aware, so the mismatch is now what it should be: the residual never
+  // reduces to a number, and FindRoot reports `nlnum` and stays unevaluated.
+  #[test]
+  fn curried_and_multiarg_variables_do_not_collide() {
+    assert_eq!(
+      interpret(
+        "FindRoot[{T[0][1] + T[1][1] == 3, T[0][1] - T[1][1] == 1}, \
+         {T[0, 1], 0}, {T[1, 1], 0}]"
+      )
+      .unwrap(),
+      "FindRoot[{T[0][1] + T[1][1] == 3, T[0][1] - T[1][1] == 1}, \
+       {T[0, 1], 0}, {T[1, 1], 0}]"
+    );
+  }
+
   // Regression: FindRoot is HoldAll, so equations and a spec list built
   // separately and passed by name (`sys = {...}; initguess = {{x, x0},
   // ...}; FindRoot[sys, initguess]` — the idiom collocation methods use to

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -4184,6 +4184,33 @@ mod curried_and_head_patterns {
     );
   }
 
+  // Regression: a SubValue spanning *three* curry levels — `Y[n][i_][t_] :=
+  // …`, where the first argument is a literal index (evaluated before
+  // storing, per `curried_subvalue_index_is_evaluated_before_storing`
+  // above) and the next two are patterns. `apply_curried_call` resolves a
+  // curried call one level at a time: applying `[i_]` to `Y[5]` reached the
+  // SubValue lookup and found no 2-level rule for it (the stored rule is
+  // 3 levels deep), so it fell back to preserving `Y[5][3]` symbolically —
+  // and the *outer* application of `[t_]` on top of that never even
+  // attempted a SubValue lookup, since `func` was by then already a
+  // CurriedCall rather than a plain FunctionCall. Real Wolfram fires this
+  // rule (families of time-dependent per-stage quantities in Demonstrations
+  // — `T[i][t] := …`, `y[3][i][t] := 1 - y[1][i][t] - y[2][i][t]` — use
+  // exactly this shape, and the Multicomponent Distillation Column
+  // Demonstration hits it).
+  #[test]
+  fn triple_curried_subvalue_with_literal_index() {
+    assert_eq!(
+      interpret("n = 5; Y[n][i_][t_] := i + t; Y[5][3][s]").unwrap(),
+      "3 + s"
+    );
+    assert_eq!(
+      interpret("n = 5; Y[n][i_][t_] := i + t; Y[4][3][s]").unwrap(),
+      "Y[4][3][s]",
+      "an unrelated index stays unevaluated"
+    );
+  }
+
   #[test]
   fn head_pattern_definition_symbol_head() {
     // `f[a_[b__]] := …` binds the head pattern and the argument sequence.


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstration notebook (**Multicomponent Distillation Column**, downloaded via the `RandomResourcePage` API), its `Manipulate` failed to evaluate. Root-caused it to two separate interpreter bugs, both common idioms for indexed families of time-dependent functions in Demonstrations:

- **`FindRoot` rejected curried indexed variables.** The notebook's steady-state solve is `FindRoot[EQU, {T[0][t], 354.305}, {T[1][t], 357.663}, ...]` (89 variables). Real Wolfram accepts any expression as a `FindRoot` search variable, including a curried chain like `T[0][t]`, not just a plain symbol or single-level `u[1]`-style indexed variable. `is_findroot_var_expr` now flattens an arbitrary curried chain (`flatten_findroot_var`) into a base name plus index keys, so the rename/match/differentiate machinery treats it the same as any other indexed variable.

- **`SubValue`/`DownValue` definitions on curried heads only fired for exactly 2 curry levels.** The notebook defines `y[3][i_][t_] := 1 - y[1][i][t] - y[2][i][t]` (a literal index at the first level, patterns after). `apply_curried_call` resolves a curried call one level at a time — by the time the outermost `[t_]` is applied, `func` is already an unresolved `CurriedCall` from the unmatched middle level, and that branch preserved the call structure unconditionally instead of attempting a lookup. Extracted the lookup into `try_sub_value_curried_match` and call it from both the `FunctionCall` and `CurriedCall` arms of `apply_curried_call`.

## Verification

- Isolated repros for both bugs added as unit tests.
- The notebook's `FindRoot[EQU, ...]` call (89 variables) now converges correctly in ~5s (previously errored immediately).
- `make test`: 27677/27677 passed.
- `make format` run.

## Known remaining limitation (out of scope here)

The notebook's `Manipulate` also calls `NDSolve` over the same system extended to ~100 coupled differential-algebraic equations, integrated over `{t, 0, 18}`. That doesn't complete within several minutes in the current implementation — a separate, much larger NDSolve/stiff-DAE performance limitation, not something these two correctness fixes address.

## Test plan

- [x] `make test` (27677/27677 passed)
- [x] `make format`
- [x] New regression tests: `multivariate_curried_indexed_variables` (algebra.rs), `triple_curried_subvalue_with_literal_index` (function_definitions.rs)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NvDGd7SbUYwa3W6RCFEE57


---
_Generated by [Claude Code](https://claude.ai/code/session_01NvDGd7SbUYwa3W6RCFEE57)_