### PR TITLE
Absorb a /. before a trailing & into a rule argument's function body

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3422,47 +3422,53 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       let anon_idx = inner_pairs
         .iter()
         .position(|p| matches!(p.as_rule(), Rule::RuleAnonSuffix));
-      if let Some(idx) = anon_idx {
+      let boundary = anon_idx.unwrap_or(inner_pairs.len());
+      let rest: Vec<_> = inner_pairs.split_off(boundary);
+
+      // `/.`/`//.` (RuleReplaceSuffix) and a trailing `//` that appear
+      // *before* the optional `&` bind to the bare rule and get absorbed
+      // into the pure function's body — `pat -> repl /. rules &` — same as
+      // when there is no `&` at all.
+      let mut result = rule_expr;
+      for p in inner_pairs {
+        match p.as_rule() {
+          Rule::RuleReplaceSuffix => {
+            let repeated = p.as_str().trim_start().starts_with("//.");
+            let rules = pair_to_expr(p.into_inner().next().unwrap());
+            result = if repeated {
+              Expr::ReplaceRepeated {
+                expr: Box::new(result),
+                rules: Box::new(rules),
+              }
+            } else {
+              Expr::ReplaceAll {
+                expr: Box::new(result),
+                rules: Box::new(rules),
+              }
+            };
+          }
+          Rule::PostfixFunction => {
+            result = Expr::Postfix {
+              expr: Box::new(result),
+              func: Box::new(parse_postfix_function(p)),
+            };
+          }
+          _ => {}
+        }
+      }
+
+      if anon_idx.is_some() {
         // Everything after the `&` is a continuation on the pure function
         // it just produced — operator/tilde-infix chains (`pat -> repl &
         // /@ list`, the idiom for building a PopupMenu's choices from a
         // lookup table), `/.`/`//.`, and trailing `//` — shared with a
         // plain Expression's own post-& handling.
-        let post_pairs: Vec<_> = inner_pairs.split_off(idx + 1);
+        let post_pairs: Vec<_> = rest.into_iter().skip(1).collect();
         let func = Expr::Function {
-          body: Box::new(rule_expr),
+          body: Box::new(result),
         };
         apply_anon_continuation(func, post_pairs)
       } else {
-        // No `&`: only `/.`/`//.` (RuleReplaceSuffix) and trailing `//`
-        // can follow the bare rule.
-        let mut result = rule_expr;
-        for p in inner_pairs {
-          match p.as_rule() {
-            Rule::RuleReplaceSuffix => {
-              let repeated = p.as_str().trim_start().starts_with("//.");
-              let rules = pair_to_expr(p.into_inner().next().unwrap());
-              result = if repeated {
-                Expr::ReplaceRepeated {
-                  expr: Box::new(result),
-                  rules: Box::new(rules),
-                }
-              } else {
-                Expr::ReplaceAll {
-                  expr: Box::new(result),
-                  rules: Box::new(rules),
-                }
-              };
-            }
-            Rule::PostfixFunction => {
-              result = Expr::Postfix {
-                expr: Box::new(result),
-                func: Box::new(parse_postfix_function(p)),
-              };
-            }
-            _ => {}
-          }
-        }
         result
       }
     }

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -870,9 +870,13 @@ RuleAnonSuffix = { "&" ~ !"&" }
 // After a trailing `&` turns the rule into a pure function, that function
 // can itself take a further operator — `pat -> repl & /@ list` (Map over
 // the rule-producing function) is the common idiom for building PopupMenu
-// choices from a lookup table. Without RuleAnonSuffix nothing changes:
-// `RuleReplaceSuffix*` alone still lets `/.`/`//.` apply to the bare rule.
-ListItemRule = { ReplacementRule ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* | RuleReplaceSuffix*) ~ ("//" ~ PostfixFunction)* }
+// choices from a lookup table. `RuleReplaceSuffix*` before the optional `&`
+// lets `/.`/`//.` apply to the bare rule *first* and be absorbed into the
+// function body — `pat -> repl /. rules &` (as opposed to `pat -> repl & /.
+// rules`, applied to the function value, handled by the suffixes after
+// RuleAnonSuffix below) — mirroring how a plain Expression orders its own
+// ReplaceAll suffixes before its AnonymousFunctionSuffix.
+ListItemRule = { ReplacementRule ~ RuleReplaceSuffix* ~ ("//" ~ PostfixFunction)* ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* ~ ("//" ~ PostfixFunction)*)? }
 // `/.` and `//.` bind looser than `->`, so a rule written as an argument may
 // itself be replaced in: `f[a -> 5 /. 5 -> 6]` is `f[(a -> 5) /. (5 -> 6)]`.
 RuleReplaceSuffix = { ("//." | "/.") ~ (&HasRuleOperator ~ ReplacementRule | List | ConditionExpr) }
@@ -961,8 +965,10 @@ AssociationExtended = {
 // A rule may be handed to a postfix function: `f[a -> 5 // Head]` is
 // `f[Head[a -> 5]]`, since `//` binds looser than `->`.
 // See ListItemRule's comment: RuleAnonSuffix gates the extra Operator
-// continuation so `pat -> repl & /@ list` parses as an argument too.
-FunctionArgRule = { ReplacementRule ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* | RuleReplaceSuffix*) ~ ("//" ~ PostfixFunction)* }
+// continuation so `pat -> repl & /@ list` parses as an argument too, and
+// RuleReplaceSuffix* before it lets `pat -> repl /. rules &` absorb the
+// `/.` into the function body instead.
+FunctionArgRule = { ReplacementRule ~ RuleReplaceSuffix* ~ ("//" ~ PostfixFunction)* ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* ~ ("//" ~ PostfixFunction)*)? }
 FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundExpression | Expression }
 // BracketArgs groups arguments within a single bracket pair, allowing proper chained call parsing
 FunctionArgOrOmitted = _{ FunctionArg | OmittedArg }

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -10717,6 +10717,37 @@ mod rule_argument_suffixes {
       );
     }
   }
+
+  #[test]
+  fn a_replacement_before_the_trailing_amp_is_absorbed_into_the_function() {
+    // A Wolfram Demonstration's `MapIndexed[... -> ... /. rule &, list]`
+    // idiom: the `/.` sits *before* the trailing `&`, so it must become
+    // part of the pure function's body (`pat -> repl /. rule` as a whole),
+    // rather than applying to the already-built `Function[pat -> repl]`
+    // (which is what `pat -> repl & /. rule` means instead).
+    clear_state();
+    for (code, expected) in [
+      (
+        "ToString[f[a -> 5 /. 5 -> 6 &], InputForm]",
+        "f[a -> 5 /. 5 -> 6 & ]",
+      ),
+      (
+        "ToString[{a -> 5 /. 5 -> 6 &}, InputForm]",
+        "{a -> 5 /. 5 -> 6 & }",
+      ),
+      (
+        "ToString[f[a -> 5 //. 5 -> 6 &], InputForm]",
+        "f[a -> 5 //. 5 -> 6 & ]",
+      ),
+      ("(a -> 5 /. 5 -> 6 &)[x]", "a -> 6"),
+      (
+        "MapIndexed[#1 -> #2[[1]] /. 1 -> 99 &, {10, 20, 30}]",
+        "{10 -> 99, 20 -> 2, 30 -> 3}",
+      ),
+    ] {
+      assert_eq!(interpret(code).unwrap(), expected, "{code}");
+    }
+  }
 }
 
 /// A rule answers to a head replacement the way any other expression does.


### PR DESCRIPTION
## Summary

- A random Wolfram Demonstrations Project notebook ("Solving the 2D Helmholtz Partial Differential Equation Using Finite Differences") failed to load in Woxi Studio with a parse error on `MapIndexed[... -> ... /. rule &, list]`.
- Root cause: `ListItemRule`/`FunctionArgRule` in the grammar only let the trailing `&` (`RuleAnonSuffix`) follow immediately after a `ReplacementRule`. When a `/.`/`//.` suffix appeared *before* the `&` (e.g. `pat -> repl /. rules &`, as opposed to `pat -> repl & /. rules`), it was left unconsumed and the parse failed.
- Fixed by reordering both grammar rules to try the `/.`/`//.`/postfix-`//` suffixes *before* the optional `&`, mirroring how the top-level `Expression` rule already orders its own suffixes, and updated the corresponding `pair_to_expr` handling so those suffixes get absorbed into the pure function's body instead of being dropped.
- With the fix, the downloaded notebook fully parses and evaluates (0 errors, checked via `woxi-studio`'s `test_notebook` example) — no other issues were found, so this PR is scoped to the parser fix.

## Test plan

- [x] Added `a_replacement_before_the_trailing_amp_is_absorbed_into_the_function` in `tests/interpreter_tests/syntax.rs`, covering `f[a -> 5 /. 5 -> 6 &]`, `{a -> 5 /. 5 -> 6 &}`, `//.`, applying the resulting function, and a `MapIndexed` case matching the notebook's usage.
- [x] `make test` — all 27684 tests pass.
- [x] `make format`.
- [x] Verified no regression on related forms (`pat -> repl & /@ list`, `f[a -> 5 // Head]`, plain `f[a -> 5]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011qZhAYpc18wx1KzMYch6tj)_