### PR TITLE
Skip rule lists at nodes whose head no rule can match

### DIFF
--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -323,7 +323,7 @@ fn rule_with_new_head(
 /// call this; this covers blank patterns such as `x_Symbol :> f[x]`.
 fn multi_replace_head(
   name: &str,
-  rules: &[(&Expr, &Expr)],
+  rules: &RuleSet<'_>,
   held: bool,
 ) -> Result<Option<Expr>, InterpreterError> {
   let head = Expr::Identifier(name.to_string());
@@ -4850,7 +4850,118 @@ fn apply_replace_all_multi_ast(
   expr: &Expr,
   rules: &[(&Expr, &Expr)],
 ) -> Result<Expr, InterpreterError> {
-  apply_replace_all_multi_ast_impl(expr, rules, false)
+  apply_replace_all_multi_ast_impl(expr, &RuleSet::new(rules), false)
+}
+
+/// A rule list together with the set of heads its patterns demand, when they
+/// all demand one. Every node of the expression being rewritten is offered
+/// the whole list, so a Demonstration that builds one rewrite rule per
+/// lattice site — thousands of `f[x_Integer, y_Integer] :> …` rules — pays a
+/// full scan per node without this. `heads` lets a node whose head no rule
+/// names skip the scan outright.
+struct RuleSet<'a> {
+  rules: &'a [(&'a Expr, &'a Expr)],
+  heads: Option<std::collections::HashSet<&'a str>>,
+}
+
+impl<'a> RuleSet<'a> {
+  fn new(rules: &'a [(&'a Expr, &'a Expr)]) -> Self {
+    Self {
+      heads: required_rule_heads(rules),
+      rules,
+    }
+  }
+
+  /// Whether no rule can possibly match `expr` itself, so the whole list may
+  /// be skipped for this node. Only says so for the two shapes it can rule
+  /// out with certainty: an atom, which carries no head for an `f[…]`
+  /// pattern to match, and a call whose head no rule names. Every other
+  /// shape (`{…}`, `a + b`, `a -> b`, …) can stand in for a call with some
+  /// head, so it is never skipped.
+  fn cannot_match(&self, expr: &Expr) -> bool {
+    let Some(heads) = &self.heads else {
+      return false;
+    };
+    match expr {
+      Expr::Integer(_)
+      | Expr::BigInteger(_)
+      | Expr::Real(_)
+      | Expr::BigFloat(..)
+      | Expr::String(_)
+      | Expr::Identifier(_)
+      | Expr::Constant(_) => true,
+      Expr::FunctionCall { name, .. } => !heads.contains(name.as_str()),
+      _ => false,
+    }
+  }
+}
+
+/// The heads the rules' patterns demand, when every one is a plain `f[…]`
+/// call that can only match a call with that same head. `None` as soon as one
+/// rule could match anything else — a bare symbol, a blank, a `Raw` pattern —
+/// since then nothing can be ruled out from a node's head alone.
+fn required_rule_heads<'a>(
+  rules: &[(&'a Expr, &'a Expr)],
+) -> Option<std::collections::HashSet<&'a str>> {
+  let mut heads = std::collections::HashSet::new();
+  for (pattern, _) in rules {
+    // A `Condition[pat, test]` LHS demands whatever `pat` demands; the test
+    // only narrows it further.
+    let pattern = match pattern {
+      Expr::FunctionCall { name, args }
+        if name == "Condition" && args.len() == 2 =>
+      {
+        &args[0]
+      }
+      other => *other,
+    };
+    let Expr::FunctionCall { name, args } = pattern else {
+      return None;
+    };
+    if is_pattern_construct_head(name) {
+      return None;
+    }
+    // An optional argument lets a pattern match an expression that is not a
+    // call at all (`Plus[x_, y_.]` matches a bare `a`, as `Plus[a, 0]`), so
+    // its head demands nothing.
+    if args.iter().any(pattern_arg_is_optional) {
+      return None;
+    }
+    heads.insert(name.as_str());
+  }
+  (!heads.is_empty()).then_some(heads)
+}
+
+/// Whether `name` heads a pattern construct rather than naming the head an
+/// expression must have.
+fn is_pattern_construct_head(name: &str) -> bool {
+  matches!(
+    name,
+    "Blank"
+      | "BlankSequence"
+      | "BlankNullSequence"
+      | "Pattern"
+      | "PatternTest"
+      | "Optional"
+      | "OptionsPattern"
+      | "Alternatives"
+      | "Except"
+      | "Condition"
+      | "HoldPattern"
+      | "Verbatim"
+      | "Longest"
+      | "Shortest"
+      | "Repeated"
+      | "RepeatedNull"
+      | "KeyValuePattern"
+  )
+}
+
+/// Whether a pattern argument may be left out by the expression it matches.
+fn pattern_arg_is_optional(arg: &Expr) -> bool {
+  matches!(arg, Expr::PatternOptional { .. })
+    || matches!(arg, Expr::FunctionCall { name, .. }
+      if name == "Optional" || name == "OptionsPattern")
 }
 
 fn is_hold_head(name: &str) -> bool {
@@ -4866,11 +4977,15 @@ fn is_hold_head(name: &str) -> bool {
 /// yields `Hold[y]` rather than `Hold[5]`.
 fn apply_replace_all_multi_ast_impl(
   expr: &Expr,
-  rules: &[(&Expr, &Expr)],
+  rules: &RuleSet<'_>,
   held: bool,
 ) -> Result<Expr, InterpreterError> {
   // Try each rule against the whole expression
-  for (pattern, replacement) in rules {
+  for (pattern, replacement) in if rules.cannot_match(expr) {
+    &[][..]
+  } else {
+    rules.rules
+  } {
     // Handle Expr::Raw patterns (conditional patterns like n_ /; EvenQ[n])
     if let Expr::Raw(pat_str) = pattern
       && let Some(wolfram_pattern) = parse_wolfram_pattern(pat_str)
@@ -4961,7 +5076,7 @@ fn apply_replace_all_multi_ast_impl(
         .collect();
       let new_items = new_items?;
       // Check if any rule replaces the "List" head
-      for (pattern, replacement) in rules {
+      for (pattern, replacement) in rules.rules {
         if let Expr::Identifier(sym) = pattern
           && sym == "List"
         {
@@ -4989,7 +5104,7 @@ fn apply_replace_all_multi_ast_impl(
         .collect();
       let new_args = new_args?;
       // Check if any rule replaces the function head
-      for (pattern, replacement) in rules {
+      for (pattern, replacement) in rules.rules {
         if let Expr::Identifier(sym) = pattern
           && sym == name
         {

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2215,6 +2215,72 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_replace_all_head_prefilter_keeps_every_match() {
+    // ReplaceAll skips a rule list outright at nodes whose head no rule
+    // names. The shapes it must still reach:
+    clear_state();
+    // A call whose head one rule out of many does name.
+    assert_eq!(
+      interpret("g[1, 2] /. {f[a_, b_] :> \"f\", g[a_, b_] :> \"g\"}").unwrap(),
+      "g",
+    );
+    // Nested deep inside arguments no rule can match at their own level.
+    assert_eq!(
+      interpret("h[{1, {2, g[3, 4]}}, 5] /. {g[a_, b_] :> a + b}").unwrap(),
+      "h[{1, {2, 7}}, 5]",
+    );
+    // A head the rules never name is left alone, arguments included.
+    assert_eq!(
+      interpret("zz[1, 2] /. {f[a_, b_] :> \"f\", g[a_, b_] :> \"g\"}")
+        .unwrap(),
+      "zz[1, 2]",
+    );
+    // `{…}`, `a -> b` and `a + b` stand in for `List[…]`, `Rule[…]` and
+    // `Plus[…]` calls, so a rule naming those heads still reaches them.
+    assert_eq!(interpret("{1, 2} /. List[a_, b_] :> a + b").unwrap(), "3");
+    assert_eq!(interpret("(a -> b) /. Rule[p_, q_] :> q").unwrap(), "b");
+    assert_eq!(
+      interpret("1 + c /. Plus[a_, b_] :> \"hit\"").unwrap(),
+      "hit"
+    );
+    // An optional argument lets a pattern match an expression that is no
+    // call at all — `a` matches `Plus[x_, y_.]` as `Plus[a, 0]` — so such a
+    // pattern's head rules nothing out.
+    assert_eq!(interpret("a /. Plus[x_, y_.] :> \"hit\"").unwrap(), "hit");
+    assert_eq!(interpret("5 /. Plus[x_, y_.] :> \"hit\"").unwrap(), "hit");
+    // Rules that are not head-anchored at all keep matching everywhere.
+    assert_eq!(
+      interpret("h[1, {2}] /. x_Integer :> x + 10").unwrap(),
+      "h[11, {12}]",
+    );
+    assert_eq!(
+      interpret("h[a, b] /. {x_Symbol :> f[x]}").unwrap(),
+      "f[h][f[a], f[b]]",
+    );
+  }
+
+  #[test]
+  fn test_replace_all_scales_to_a_demonstrations_sized_rule_list() {
+    // Wolfram Demonstrations build one rewrite rule per lattice site and
+    // hand the whole list to `/.` — thousands of `f[x_Integer, y_Integer]
+    // :> …` rules, applied to an expression with hundreds of nodes. Every
+    // node used to be offered every rule, which put a single frame of such
+    // a notebook minutes away; a node whose head no rule names now skips
+    // the list. The rewrite itself must stay exact.
+    clear_state();
+    interpret("rules = Table[tile[i, 0] :> i^2, {i, 8000}];").unwrap();
+    interpret("data = Join[Range[3000], {tile[7, 0]}];").unwrap();
+    let start = std::time::Instant::now();
+    assert_eq!(interpret("Last[data /. rules]").unwrap(), "49");
+    let elapsed = start.elapsed();
+    assert!(
+      elapsed < std::time::Duration::from_secs(4),
+      "8000 rules over 3001 nodes took {elapsed:?} — the rule list is being \
+       re-scanned at nodes no rule can match"
+    );
+  }
+
+  #[test]
   fn test_replace_all_on_unmatched_rendered_graphic_no_op() {
     // Regression: PieChart (and the other chart functions) render straight
     // to SVG with no symbolic primitive list, so `PieChart[…][[1]]` stays


### PR DESCRIPTION
Found by checking Woxi Studio against a randomly drawn Wolfram Demonstration ([Limit-Periodic Tilings](https://demonstrations.wolfram.com/LimitPeriodicTilings/), fetched via the `RandomResourcePage` API).

## What already worked

The notebook loads correctly. All 50 of its definition cells evaluate without error, and the `Manipulate` control panel comes out exactly as Wolfram lays it out — the two `SetterBar`s and seven `PopupMenu`s, with the right choices and initial selections. That covers `Row[{"label", Control@{…}, …}]` flattening, a panel-wide `ControlType -> {…}` list assigned positionally across the flattened controls, and discrete controls whose values are lists (`{"I"} -> "I"`, `{} -> ""`).

## What didn't

The widget's body took roughly three minutes per frame, which makes the notebook unusable in Studio even though every part of it is correct.

The cause is in `ReplaceAll`. It offers every rule to every node of the expression it rewrites, so the cost is (nodes × rules). This Demonstration builds one rewrite rule per lattice site — a 4388-rule list — and applies it once per tile, 217 tiles per frame.

## The fix

When every rule's pattern is a plain `f[…]` call, the heads those patterns name are collected once per `ReplaceAll`. A node that is an atom, or a call whose head no rule names, then skips the list outright.

Nothing else is skipped. `{…}`, `a + b` and `a -> b` all stand in for a call with some head, so they always get the full scan; and a pattern with an optional argument (`Plus[x_, y_.]` matches a bare symbol, as `Plus[a, 0]`) names no head at all, so one of those turns the filter off entirely — as does any rule whose pattern is a bare symbol, a blank, or a `Raw` pattern.

**8000 rules over 3001 nodes: 8.8s before, 1.0s after.**

Per-tile cost in the Demonstration drops ~45%; the rest of that notebook's remaining time is a separate matter (re-evaluating a 4388-element list every time it is passed to a function), left for another change.

## Tests

- `test_replace_all_head_prefilter_keeps_every_match` — the shapes the filter must still reach: a call one rule out of many names, a match nested inside arguments no rule matches at their own level, `List`/`Rule`/`Plus` patterns against `{…}`/`a -> b`/`a + b`, the `Plus[x_, y_.]`-matches-an-atom case that switches the filter off, and non-head-anchored rules (`x_Integer`, `x_Symbol`) that must keep matching everywhere.
- `test_replace_all_scales_to_a_demonstrations_sized_rule_list` — the performance guard above. Verified to fail on `main` (8.8s against a 4s bound) and pass here (1.0s).

`cargo test` green: 27,685 tests across the interpreter, CLI, and script snapshots, plus 190 Woxi Studio tests. `cargo clippy --fix` and `cargo fmt` run. (`make test` itself needs `cargo-nextest`, which isn't available in this environment; `cargo test` covers the same targets. `wolframscript` is likewise unavailable here, so the new cases were not cross-checked against it — they only assert behaviour Woxi already had, at speed.)

No verbatim code from the notebook appears in this PR; the tests are self-authored and construct-equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL3yb3BasoLStcnsuDparo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL3yb3BasoLStcnsuDparo)_