### PR TITLE
Support the legacy BarCharts` package for the Grover's Quantum Search Algorithm demonstration

### DIFF
--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -651,6 +651,7 @@ fn evaluate_function_call_ast_inner(
   // dispatch rather than reimplementing the legacy function separately.
   let name = match name {
     "VectorFieldPlots`ListVectorFieldPlot" => "ListVectorPlot",
+    "BarCharts`BarChart" => "BarChart",
     other => other,
   };
 

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -1369,7 +1369,11 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
             opts.full_width = fw;
           }
         }
-        "ChartLabels" => {
+        // `BarLabels` is the legacy `BarCharts` package's name for this
+        // option; `BarCharts`BarChart` is normalized to `BarChart` before
+        // dispatch (see `evaluate_function_call_ast_inner`), so the same
+        // options parser has to accept its option names too.
+        "ChartLabels" | "BarLabels" => {
           // ChartLabels can be `Placed[labels, position]`,
           // `Placed[labels, position, styleFn]`, or a list containing such a
           // `Placed[...]` (e.g. `{values, Placed[days, Center, fn]}`). Check
@@ -1481,7 +1485,8 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
           // Stored unevaluated (it's a pure function applied per value).
           opts.labeling_function = Some(replacement.clone());
         }
-        "ChartStyle" => {
+        // `BarStyle` is the legacy `BarCharts` package's name for this option.
+        "ChartStyle" | "BarStyle" => {
           let val = evaluate_expr_to_expr(replacement)
             .unwrap_or_else(|_| replacement.clone());
           match &val {

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -786,6 +786,41 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_legacy_barcharts_barchart_context_qualified() {
+    // Regression: a Wolfram Demonstration authored before `BarChart` was a
+    // built-in (e.g. "Grover's Quantum Search Algorithm") loads the old
+    // `BarCharts` package and calls its bar chart fully context-qualified,
+    // `BarCharts`BarChart[...]`, with the package's own `BarLabels`/
+    // `BarStyle` option names rather than the modern `ChartLabels`/
+    // `ChartStyle`. Woxi has no package system, so the qualified call must
+    // normalize to the built-in `BarChart` (like `VectorFieldPlots`
+    // ListVectorFieldPlot` already does) and accept the legacy option names.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Needs[\"BarCharts`\"]; \
+       BarCharts`BarChart[{0.3, 0.7}, \
+       BarLabels -> {\"classical\", \"quantum\"}, \
+       BarStyle -> {Pink, LightBlue}, \
+       PlotLabel -> \"probability\"]",
+    )
+    .unwrap()
+    .graphics
+    .expect("BarCharts`BarChart should produce a graphics SVG");
+    for label in ["classical", "quantum", "probability"] {
+      assert!(
+        svg.contains(&format!(">{label}</text>")),
+        "BarCharts`BarChart SVG missing label `{label}`:\n{svg}"
+      );
+    }
+    for hex in ["#FF8080", "#DEF0FF"] {
+      assert!(
+        svg.contains(hex),
+        "BarCharts`BarChart SVG missing BarStyle color {hex}:\n{svg}"
+      );
+    }
+  }
+
+  #[test]
   fn test_piechart_chartstyle_and_chartlabels() {
     // Regression: PieChart must honor `ChartStyle` (per-slice fill colors,
     // keyed by data index) and `ChartLabels` (text drawn on each wedge).


### PR DESCRIPTION
## Summary

As part of a routine check, I downloaded a random notebook from the Wolfram Demonstrations Project ("[Grover's Quantum Search Algorithm](https://demonstrations.wolfram.com/GroversQuantumSearchAlgorithm/)" by Tad Hogg) and checked whether Woxi Studio fully supports it. It didn't — the demonstration predates the modern `BarChart` built-in, so its `Manipulate` body loads the legacy `BarCharts` package and calls its bar chart fully context-qualified: `BarCharts\`BarChart[...]`, with the package's own `BarLabels`/`BarStyle` option names instead of the modern `ChartLabels`/`ChartStyle`.

Woxi has no package system and didn't recognize the context-qualified call, so it stayed unevaluated and the widget rendered as literal text (`BarCharts\`BarChart[...]`) instead of an actual bar chart.

- **`src/evaluator/dispatch/evaluate_functions.rs`** — `evaluate_function_call_ast_inner` now normalizes `BarCharts\`BarChart` to the built-in `BarChart` before dispatch, the same way it already does for `VectorFieldPlots\`ListVectorFieldPlot`. This delegates to the single canonical `BarChart` implementation rather than reimplementing the legacy package's renderer.
- **`src/functions/chart.rs`** — `parse_chart_options` accepts `BarLabels`/`BarStyle` as aliases for `ChartLabels`/`ChartStyle`, so the legacy option names used by the pre-`BarChart` idiom still apply.

With both fixed, the demonstration's `Manipulate` widget evaluates cleanly and renders its bar chart correctly (verified via `woxi-studio`'s `dump_manipulate` example, which drives the exact same pipeline the Studio GUI uses).

I did not copy any code from the downloaded notebook — only Woxi source files were modified, and none of the notebook's own content was committed.

## Test plan

- [x] Added a regression test (`tests/interpreter_tests.rs`)
- [x] `make test` (via `cargo nextest`) — 27687 tests passed, 0 failed
- [x] `make format`
- [x] Manually verified the fixed demonstration renders correctly end-to-end via `woxi-studio`'s `dump_manipulate` example (bar chart with `classical`/`quantum` labels and the `PlotLabel` now appear in the rendered SVG, instead of the unevaluated `BarCharts\`BarChart[...]` call as literal text)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeEPjMt9am4EwV7KnQZrBF)_