### PR TITLE
Support CDF of bivariate MultinormalDistribution and fix constrained FindMaximum/FindMinimum

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1057,7 +1057,7 @@ TimeSeries,Represents a time series of values paired with time stamps,✅,pure,1
 VectorPoints,,🚫,,7.0,1039
 NextPrime,Returns the smallest prime greater than n (Listable),✅,pure,6.0,1040
 PreDecrement,Decrements a variable by 1 and returns the new value,✅,stateful,1.0,1041
-MultinormalDistribution,Multivariate normal distribution (PDF for diagonal covariance plus Mean Covariance Variance),✅,pure,8.0,1042
+MultinormalDistribution,Multivariate normal distribution (PDF for diagonal covariance plus numeric bivariate CDF Mean Covariance Variance),✅,pure,8.0,1042
 UnitBox,Unit box function (1 for |x| <= 1/2),✅,pure,7.0,1043
 Today,Returns a DateObject representing the current date,✅,contextual,10.0,1044
 ClippingStyle,,🚫,,6.0,1046

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -2336,7 +2336,146 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "WaringYuleDistribution" => cdf_waring_yule(dargs, x),
     "ZipfDistribution" => cdf_zipf(dargs, x),
     "JohnsonDistribution" => cdf_johnson(dargs, x),
+    "MultinormalDistribution" => cdf_multinormal(dargs, x),
     _ => Ok(unevaluated("CDF", args)),
+  }
+}
+
+/// CDF[MultinormalDistribution[mu, sigma], {x1, x2}] for the bivariate case,
+/// via numeric integration of the classical reduction to a single integral:
+/// Φ2(h, k; ρ) = ∫_{-∞}^{h} φ(t) Φ((k - ρt)/√(1-ρ²)) dt
+/// where h, k are the standardized coordinates and ρ is the correlation.
+/// Only the fully numeric bivariate case is handled; anything else (symbolic
+/// parameters, or a dimension other than 2) is left unevaluated.
+fn cdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
+  let unevaluated_call = || {
+    unevaluated(
+      "CDF",
+      &[unevaluated("MultinormalDistribution", dargs), x.clone()],
+    )
+  };
+  let [Expr::List(mu), Expr::List(sigma)] = dargs else {
+    return Ok(unevaluated_call());
+  };
+  let Expr::List(point) = &x else {
+    return Ok(unevaluated_call());
+  };
+  if mu.len() != 2 || sigma.len() != 2 || point.len() != 2 {
+    return Ok(unevaluated_call());
+  }
+  let (Some(mu1), Some(mu2)) = (expr_to_num(&mu[0]), expr_to_num(&mu[1]))
+  else {
+    return Ok(unevaluated_call());
+  };
+  let (Expr::List(row1), Expr::List(row2)) = (&sigma[0], &sigma[1]) else {
+    return Ok(unevaluated_call());
+  };
+  if row1.len() != 2 || row2.len() != 2 {
+    return Ok(unevaluated_call());
+  }
+  let (Some(s11), Some(s12), Some(s22)) = (
+    expr_to_num(&row1[0]),
+    expr_to_num(&row1[1]),
+    expr_to_num(&row2[1]),
+  ) else {
+    return Ok(unevaluated_call());
+  };
+  let (Some(x1), Some(x2)) = (expr_to_num(&point[0]), expr_to_num(&point[1]))
+  else {
+    return Ok(unevaluated_call());
+  };
+  if s11 <= 0.0 || s22 <= 0.0 {
+    return Ok(unevaluated_call());
+  }
+  let rho = s12 / (s11.sqrt() * s22.sqrt());
+  if !(-1.0..=1.0).contains(&rho) {
+    return Ok(unevaluated_call());
+  }
+  let h = (x1 - mu1) / s11.sqrt();
+  let k = (x2 - mu2) / s22.sqrt();
+  Ok(Expr::Real(bivariate_normal_cdf(h, k, rho)))
+}
+
+fn std_normal_pdf(t: f64) -> f64 {
+  (-t * t / 2.0).exp() / (2.0 * std::f64::consts::PI).sqrt()
+}
+
+fn std_normal_cdf(t: f64) -> f64 {
+  0.5 * (1.0 + erf_f64(t / std::f64::consts::SQRT_2))
+}
+
+/// CDF of the standard bivariate normal distribution, P(X <= h, Y <= k) for
+/// unit-variance X, Y with correlation `rho`.
+fn bivariate_normal_cdf(h: f64, k: f64, rho: f64) -> f64 {
+  if rho >= 1.0 - 1e-12 {
+    return std_normal_cdf(h.min(k));
+  }
+  if rho <= -1.0 + 1e-12 {
+    return (std_normal_cdf(h) + std_normal_cdf(k) - 1.0).max(0.0);
+  }
+  if rho == 0.0 {
+    return std_normal_cdf(h) * std_normal_cdf(k);
+  }
+  let denom = (1.0 - rho * rho).sqrt();
+  let integrand =
+    |t: f64| std_normal_pdf(t) * std_normal_cdf((k - rho * t) / denom);
+  // φ(t) is negligible (< 1e-17) beyond ~9 standard deviations from either 0
+  // or h, so a window covering both bounds the integral to full precision.
+  // This function is evaluated in the inner loop of numeric optimizers (e.g.
+  // FindMaximum on an objective built from it), so adaptive refinement — a
+  // few dozen evaluations for a smooth bell-shaped integrand — matters far
+  // more than a fixed high node count would.
+  let lower = h.min(0.0) - 9.0;
+  if lower >= h {
+    return 0.0;
+  }
+  adaptive_simpson(&integrand, lower, h, 1e-12, 30)
+}
+
+/// Adaptive Simpson's rule: recursively bisects until the local error
+/// estimate is within `tol`, or `max_depth` is reached.
+fn adaptive_simpson(
+  f: &dyn Fn(f64) -> f64,
+  a: f64,
+  b: f64,
+  tol: f64,
+  max_depth: u32,
+) -> f64 {
+  let fa = f(a);
+  let fb = f(b);
+  let m = f64::midpoint(a, b);
+  let fm = f(m);
+  let whole = (b - a) / 6.0 * (fa + 4.0 * fm + fb);
+  adaptive_simpson_rec(f, a, b, tol, whole, fa, fm, fb, max_depth)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn adaptive_simpson_rec(
+  f: &dyn Fn(f64) -> f64,
+  a: f64,
+  b: f64,
+  tol: f64,
+  whole: f64,
+  fa: f64,
+  fm: f64,
+  fb: f64,
+  depth: u32,
+) -> f64 {
+  let m = f64::midpoint(a, b);
+  let m1 = f64::midpoint(a, m);
+  let m2 = f64::midpoint(m, b);
+  let fm1 = f(m1);
+  let fm2 = f(m2);
+  let h = b - a;
+  let left = h / 12.0 * (fa + 4.0 * fm1 + fm);
+  let right = h / 12.0 * (fm + 4.0 * fm2 + fb);
+  let refined = left + right;
+  let error = (refined - whole) / 15.0;
+  if depth == 0 || error.abs() < tol {
+    refined + error
+  } else {
+    adaptive_simpson_rec(f, a, m, tol / 2.0, left, fa, fm1, fm, depth - 1)
+      + adaptive_simpson_rec(f, m, b, tol / 2.0, right, fm, fm2, fb, depth - 1)
   }
 }
 

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -2336,7 +2336,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "WaringYuleDistribution" => cdf_waring_yule(dargs, x),
     "ZipfDistribution" => cdf_zipf(dargs, x),
     "JohnsonDistribution" => cdf_johnson(dargs, x),
-    "MultinormalDistribution" => cdf_multinormal(dargs, x),
+    "MultinormalDistribution" => Ok(cdf_multinormal(dargs, &x)),
     _ => Ok(unevaluated("CDF", args)),
   }
 }
@@ -2347,7 +2347,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// where h, k are the standardized coordinates and ρ is the correlation.
 /// Only the fully numeric bivariate case is handled; anything else (symbolic
 /// parameters, or a dimension other than 2) is left unevaluated.
-fn cdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
+fn cdf_multinormal(dargs: &[Expr], x: &Expr) -> Expr {
   let unevaluated_call = || {
     unevaluated(
       "CDF",
@@ -2355,45 +2355,45 @@ fn cdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     )
   };
   let [Expr::List(mu), Expr::List(sigma)] = dargs else {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   };
-  let Expr::List(point) = &x else {
-    return Ok(unevaluated_call());
+  let Expr::List(point) = x else {
+    return unevaluated_call();
   };
   if mu.len() != 2 || sigma.len() != 2 || point.len() != 2 {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   }
   let (Some(mu1), Some(mu2)) = (expr_to_num(&mu[0]), expr_to_num(&mu[1]))
   else {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   };
   let (Expr::List(row1), Expr::List(row2)) = (&sigma[0], &sigma[1]) else {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   };
   if row1.len() != 2 || row2.len() != 2 {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   }
   let (Some(s11), Some(s12), Some(s22)) = (
     expr_to_num(&row1[0]),
     expr_to_num(&row1[1]),
     expr_to_num(&row2[1]),
   ) else {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   };
   let (Some(x1), Some(x2)) = (expr_to_num(&point[0]), expr_to_num(&point[1]))
   else {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   };
   if s11 <= 0.0 || s22 <= 0.0 {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   }
   let rho = s12 / (s11.sqrt() * s22.sqrt());
   if !(-1.0..=1.0).contains(&rho) {
-    return Ok(unevaluated_call());
+    return unevaluated_call();
   }
   let h = (x1 - mu1) / s11.sqrt();
   let k = (x2 - mu2) / s22.sqrt();
-  Ok(Expr::Real(bivariate_normal_cdf(h, k, rho)))
+  Expr::Real(bivariate_normal_cdf(h, k, rho))
 }
 
 fn std_normal_pdf(t: f64) -> f64 {
@@ -2401,7 +2401,7 @@ fn std_normal_pdf(t: f64) -> f64 {
 }
 
 fn std_normal_cdf(t: f64) -> f64 {
-  0.5 * (1.0 + erf_f64(t / std::f64::consts::SQRT_2))
+  f64::midpoint(1.0, erf_f64(t / std::f64::consts::SQRT_2))
 }
 
 /// CDF of the standard bivariate normal distribution, P(X <= h, Y <= k) for

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6867,12 +6867,27 @@ fn find_root_multivariate(
 /// Check if an expression contains an unevaluated D[...] or Dt[...] call.
 fn contains_unevaluated_d(expr: &Expr) -> bool {
   match expr {
-    Expr::FunctionCall { name, .. } if name == "D" || name == "Dt" => true,
+    // "D"/"Dt" catches an unevaluated D[...] left as-is; "Derivative" catches
+    // the `Derivative[n1, n2, ...][f][args]` form a partial derivative of a
+    // function with no symbolic derivative rule (e.g. CDF of a distribution
+    // Woxi only evaluates numerically) is left in.
+    Expr::FunctionCall { name, .. }
+      if name == "D" || name == "Dt" || name == "Derivative" =>
+    {
+      true
+    }
     Expr::FunctionCall { args, .. } => args.iter().any(contains_unevaluated_d),
+    Expr::CurriedCall { func, args } => {
+      contains_unevaluated_d(func) || args.iter().any(contains_unevaluated_d)
+    }
     Expr::BinaryOp { left, right, .. } => {
       contains_unevaluated_d(left) || contains_unevaluated_d(right)
     }
     Expr::UnaryOp { operand, .. } => contains_unevaluated_d(operand),
+    // A malformed derivative can surface wrapped in a List (e.g. the
+    // mis-threaded per-component result of differentiating a function whose
+    // argument is itself a list), so recurse into list elements too.
+    Expr::List(items) => items.iter().any(contains_unevaluated_d),
     _ => false,
   }
 }
@@ -10077,12 +10092,14 @@ pub fn find_minimum_ast(
     && let Some(vars) = optimization_variable_names(&args[1])
     && !vars.is_empty()
   {
-    return nminimize_ast(
+    let step_monitor = find_option(&args[2..], "StepMonitor");
+    return nminimize_ast_impl(
       &[
         args[0].clone(),
         Expr::List(vars.into_iter().map(Expr::Identifier).collect()),
       ],
       maximize,
+      step_monitor,
     );
   }
 
@@ -10845,9 +10862,49 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
 /// NMinimize[{f, constraints...}, vars] / NMaximize[{f, constraints...}, vars]
 /// Numerical global optimization using sampling + local refinement.
 /// Returns {opt_value, {var -> val, ...}}.
+/// The value of option `key` among a call's trailing `opt -> value` /
+/// `opt :> value` arguments.
+fn find_option<'a>(opts: &'a [Expr], key: &str) -> Option<&'a Expr> {
+  opts.iter().find_map(|o| match o {
+    Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } if matches!(pattern.as_ref(), Expr::Identifier(k) if k == key) => {
+      Some(replacement.as_ref())
+    }
+    _ => None,
+  })
+}
+
+/// Evaluate a `StepMonitor :> expr` option at one solver step: substitute
+/// each variable with its current numeric value and evaluate purely for
+/// side effect (e.g. `Sow[{x, y}]`), discarding the result.
+fn fire_step_monitor(monitor: Option<&Expr>, vars: &[String], x: &[f64]) {
+  let Some(monitor) = monitor else {
+    return;
+  };
+  let mut e = monitor.clone();
+  for (i, var) in vars.iter().enumerate() {
+    e = crate::syntax::substitute_variable(&e, var, &Expr::Real(x[i]));
+  }
+  let _ = crate::evaluator::evaluate_expr_to_expr(&e);
+}
+
 pub fn nminimize_ast(
   args: &[Expr],
   maximize: bool,
+) -> Result<Expr, InterpreterError> {
+  nminimize_ast_impl(args, maximize, None)
+}
+
+fn nminimize_ast_impl(
+  args: &[Expr],
+  maximize: bool,
+  step_monitor: Option<&Expr>,
 ) -> Result<Expr, InterpreterError> {
   let func_name = if maximize { "NMaximize" } else { "NMinimize" };
   if args.len() != 2 {
@@ -11179,6 +11236,7 @@ pub fn nminimize_ast(
           // would recompute the same failure.
           break;
         }
+        fire_step_monitor(step_monitor, &vars, &x);
       }
       let fval = eval_at(&objective, &x).unwrap_or(f64::INFINITY);
       (x, fval)
@@ -11217,6 +11275,7 @@ pub fn nminimize_ast(
   } else {
     // Gradient-free refinement: coordinate-wise golden section
     let golden_ratio = 0.6180339887498949;
+    let mut prev_f = eval_at(&objective, &x).ok();
     for _ in 0..max_iter {
       let mut improved = false;
       for i in 0..n {
@@ -11262,6 +11321,19 @@ pub fn nminimize_ast(
       }
       if !improved {
         break;
+      }
+      fire_step_monitor(step_monitor, &vars, &x);
+      // A coordinate can keep drifting by noise-level amounts (e.g. from an
+      // objective built on an adaptively-integrated CDF) long after the
+      // objective value itself has stopped meaningfully improving. Stop the
+      // sweep once a full pass over all coordinates no longer moves the
+      // objective by more than a relative 1e-10, rather than waiting out
+      // `max_iter` sweeps of pure jitter.
+      if let (Some(prev), Ok(cur)) = (prev_f, eval_at(&objective, &x)) {
+        if (cur - prev).abs() < 1e-10 * (1.0 + prev.abs()) {
+          break;
+        }
+        prev_f = Some(cur);
       }
     }
   }
@@ -11482,6 +11554,13 @@ enum NumNode {
   Pow(Box<Self>, Box<Self>),
   Unary(fn(f64) -> f64, Box<Self>),
   Binary(fn(f64, f64) -> f64, Box<Self>, Box<Self>),
+  // A subexpression compile_numeric doesn't otherwise recognise (e.g. a
+  // distribution's CDF/PDF), evaluated via the full AST evaluator with the
+  // current point substituted in. Isolating just this piece — rather than
+  // failing the whole compile and re-cloning/substituting/evaluating the
+  // entire objective through the slow path on every call — keeps the rest
+  // of a large expression on the fast numeric path.
+  Fallback(std::rc::Rc<Expr>, std::rc::Rc<[String]>),
 }
 
 impl NumNode {
@@ -11506,6 +11585,17 @@ impl NumNode {
       }
       Self::Unary(f, a) => f(a.eval(point)),
       Self::Binary(f, a, b) => f(a.eval(point), b.eval(point)),
+      Self::Fallback(expr, vars) => {
+        let mut e = (**expr).clone();
+        for (i, var) in vars.iter().enumerate() {
+          e =
+            crate::syntax::substitute_variable(&e, var, &Expr::Real(point[i]));
+        }
+        crate::evaluator::evaluate_expr_to_expr(&e)
+          .ok()
+          .and_then(|v| expr_to_f64(&v).ok())
+          .unwrap_or(f64::NAN)
+      }
     }
   }
 }
@@ -11615,10 +11705,21 @@ fn compile_numeric(expr: &Expr, vars: &[String]) -> Option<NumNode> {
           .collect::<Option<Vec<_>>>()
           .filter(|nodes| !nodes.is_empty())
           .map(|nodes| fold_binary(nodes, f64::max)),
-        _ => None,
+        // An unrecognised function (e.g. CDF of a distribution) still
+        // compiles: it's isolated in a `Fallback` node rather than failing
+        // the whole expression's compilation.
+        _ => Some(NumNode::Fallback(
+          std::rc::Rc::new(expr.clone()),
+          std::rc::Rc::from(vars.to_vec()),
+        )),
       }
     }
-    _ => None,
+    // Anything else unrecognised (comparisons, curried calls, …) also falls
+    // back in isolation rather than failing the whole compile.
+    _ => Some(NumNode::Fallback(
+      std::rc::Rc::new(expr.clone()),
+      std::rc::Rc::from(vars.to_vec()),
+    )),
   }
 }
 

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -6292,6 +6292,52 @@ mod find_minimum {
       interpret("FindMaximum[-10*^-30 *(x-3)^2+2., {x, 1}]").unwrap();
     assert_eq!(result, "{2., {x -> 3.}}");
   }
+
+  #[test]
+  fn constrained_maximum_step_monitor_collects_points() {
+    // A `StepMonitor :> Sow[...]` option on a constrained FindMaximum
+    // (the `{f, cons}` form, which delegates to the NMaximize solver) must
+    // actually fire at each solver step, so Reap collects the sown points
+    // instead of returning an empty tag list.
+    clear_state();
+    let result = interpret(
+      "p = Reap[FindMaximum[{-((x - 2)^2 + (y - 3)^2), \
+       0 < x < 10 && 0 < y < 10}, {{x, 5}, {y, 5}}, \
+       StepMonitor :> Sow[{x, y}]]]; \
+       {p[[1]], Length[p[[2]]], Length[p[[2, 1]]] > 0}",
+    )
+    .unwrap();
+    assert_eq!(result, "{{0., {x -> 2., y -> 3.}}, 1, True}");
+  }
+
+  #[test]
+  fn constrained_maximum_without_step_monitor_unaffected() {
+    // The StepMonitor plumbing must not change the plain constrained
+    // FindMaximum result when the option isn't supplied.
+    clear_state();
+    let result = interpret(
+      "FindMaximum[{-((x - 2)^2 + (y - 3)^2), 0 < x < 10 && 0 < y < 10}, \
+       {{x, 5}, {y, 5}}]",
+    )
+    .unwrap();
+    assert_eq!(result, "{0., {x -> 2., y -> 3.}}");
+  }
+
+  #[test]
+  fn constrained_maximum_over_black_box_function() {
+    // Regression: an objective built on a function Woxi can only evaluate
+    // numerically (no symbolic derivative rule, here a distribution's CDF)
+    // must not be mistaken for one with a valid symbolic gradient — that
+    // silently broke optimization, converging on a fixed grid-search sample
+    // instead of refining it. The maximum of CDF[NormalDistribution[],x-c]
+    // over a bounded x range is at the upper bound.
+    clear_state();
+    let result = interpret(
+      "FindMaximum[{CDF[NormalDistribution[], x - 3], 0 < x < 5}, {x, 1}]",
+    )
+    .unwrap();
+    assert_eq!(result, "{0.9772498680518208, {x -> 5.}}");
+  }
 }
 
 mod dt {

--- a/tests/interpreter_tests/distributions.rs
+++ b/tests/interpreter_tests/distributions.rs
@@ -2919,6 +2919,70 @@ mod multinormal_distribution {
       "PDF[MultinormalDistribution[{0, 0}, {{2, 1}, {1, 3}}], {x, y}]"
     );
   }
+
+  // CDF of the bivariate case: numeric integration of the standard
+  // reduction to a single integral over the standardized coordinates.
+  #[test]
+  fn cdf_independent_matches_product_of_marginals() {
+    // Zero correlation: Φ2(h, k; 0) = Φ(h) * Φ(k) exactly.
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{0, 0}, {{1, 0}, {0, 1}}], {1, 1}]"
+      )
+      .unwrap(),
+      "0.7078609817371407"
+    );
+  }
+
+  #[test]
+  fn cdf_shifted_mean_and_scaled_covariance() {
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{1, 2}, {{4, -2}, {-2, 9}}], {3, 5}]"
+      )
+      .unwrap(),
+      "0.6917121699457104"
+    );
+  }
+
+  #[test]
+  fn cdf_perfect_correlation_edge_cases() {
+    // rho = 1: P(X <= h, Y <= k) = P(X <= min(h, k)) = Phi(min(h, k)).
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{0, 0}, {{1, 1}, {1, 1}}], {0.5, 1.0}]"
+      )
+      .unwrap(),
+      "0.6914624612740131"
+    );
+    // rho = -1: P(X <= h, Y <= k) = max(Phi(h) + Phi(k) - 1, 0).
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{0, 0}, {{1, -1}, {-1, 1}}], {0.5, 1.0}]"
+      )
+      .unwrap(),
+      "0.532807207342556"
+    );
+  }
+
+  #[test]
+  fn cdf_symbolic_or_trivariate_stays_unevaluated() {
+    // Only the fully numeric bivariate case is handled.
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{0, 0}, {{1, 0}, {0, 1}}], {x, y}]"
+      )
+      .unwrap(),
+      "CDF[MultinormalDistribution[{0, 0}, {{1, 0}, {0, 1}}], {x, y}]"
+    );
+    assert_eq!(
+      interpret(
+        "CDF[MultinormalDistribution[{0, 0, 0}, {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}], {x, y, z}]"
+      )
+      .unwrap(),
+      "CDF[MultinormalDistribution[{0, 0, 0}, {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}], {x, y, z}]"
+    );
+  }
 }
 
 mod empirical_distribution {


### PR DESCRIPTION
## Summary

While testing whether Woxi Studio fully supports a random Wolfram Demonstration Project notebook ("Maximizing a Bermudan Put with a Single Early-Exercise Temporal Point"), several real interpreter gaps surfaced. This PR fixes them:

- **`CDF[MultinormalDistribution[...], {x, y}]` (bivariate case)** was unimplemented — any objective built on it stayed symbolic, so `FindMaximum` failed with `"Cannot evaluate expression numerically"`. Implemented via adaptive-Simpson numeric integration of the standard single-integral reduction of the bivariate normal CDF (verified against known closed forms and high-precision reference values).
- **`StepMonitor`** was accepted as an option name but never actually invoked by the constrained `FindMaximum`/`FindMinimum` path (which delegates to `NMinimize`/`NMaximize`), so `Reap[FindMaximum[{f, cons}, ..., StepMonitor :> Sow[...]]]` always returned an empty tag list. Wired it into both the gradient-based and gradient-free refinement loops.
- **`contains_unevaluated_d`** (used to decide whether a symbolic gradient is safe to use) missed the `Derivative[n1,n2,...][f][args]` form left behind when differentiating a function with no symbolic derivative rule (e.g. a distribution's `CDF`), and didn't recurse into `List` — so a malformed, vector-valued "gradient" was silently accepted, breaking the optimizer outright instead of falling back to derivative-free search.
- **`compile_numeric`** only handled a fixed whitelist of built-ins, failing compilation of the *entire* objective whenever it contained one unrecognized function. Added a `Fallback` node that isolates just that subexpression to the slow AST-eval path instead of the whole tree. Combined with a relative-objective-change stall check on the gradient-free sweep loop (the previous absolute-tolerance check could jitter for hundreds of iterations on a numerically-noisy objective), this keeps optimization over such objectives fast (from timing out to converging in ~10s).

Together these let the downloaded demonstration's `Manipulate` body evaluate to valid `Graphics` instead of erroring out. No code from the notebook itself is included here (only original test expressions).

## Test plan
- [x] `cargo test` — full suite passes (25570 interpreter tests, 576 script snapshot tests, 44 CLI tests, 1262 misc tests, 241 lib tests; 0 failures)
- [x] New regression tests for the bivariate CDF (independent, shifted/scaled covariance, ±1 correlation edge cases, symbolic/trivariate fallback)
- [x] New regression tests for `StepMonitor` (collects sown points, black-box-function objective, plain-call baseline unaffected)
- [x] `make format`
- [x] Manually verified the downloaded demonstration notebook's `Manipulate` body now evaluates to `-Graphics-` instead of erroring


---
_Generated by [Claude Code](https://claude.ai/code/session_01EH86P2xLtHuv6gABXdUqG3)_