### PR TITLE
Follow a Manipulate Trigger's Dynamic max bound instead of defaulting to infinity

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -20959,18 +20959,29 @@ fn parse_manipulate_control(
   // check and only this control's `animate` field takes effect, so building
   // the dedicated widget here is safe either way.
   if control_type.as_deref() == Some("Trigger") {
-    let min = bounds
+    let (min, min_dynamic) = bounds
       .first()
-      .and_then(|e| {
-        crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
-      })
-      .unwrap_or(0.0);
-    let max = bounds
+      .and_then(|e| eval_manipulate_bound(e))
+      .unwrap_or((0.0, false));
+    let (max, max_dynamic) = bounds
       .get(1)
-      .and_then(|e| {
-        crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
+      .and_then(|e| eval_manipulate_bound(e))
+      .unwrap_or((f64::INFINITY, false));
+    // A bound that only resolved through the environment names another
+    // control's variable — e.g. a projectile's flight Trigger capped by
+    // `Dynamic[range[angle, speed]]` — so keep its code, the same as a
+    // Continuous control's dynamic bound, and let the frontend re-resolve
+    // it against the live bindings whenever `angle`/`speed` move.
+    let min_code = min_dynamic
+      .then(|| {
+        crate::syntax::expr_to_input_form(manipulate_bound_expr(bounds[0]).0)
       })
-      .unwrap_or(f64::INFINITY);
+      .filter(|_| min.is_finite());
+    let max_code = max_dynamic
+      .then(|| {
+        crate::syntax::expr_to_input_form(manipulate_bound_expr(bounds[1]).0)
+      })
+      .filter(|_| max.is_finite());
     let step = bounds
       .get(2)
       .and_then(|e| crate::functions::math_ast::try_eval_to_f64(e))
@@ -21002,8 +21013,8 @@ fn parse_manipulate_control(
         label_runs,
       },
       enabled,
-      min_code: None,
-      max_code: None,
+      min_code,
+      max_code,
       values_code: None,
       animate: Some(running),
       tracking: tracking.clone(),

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7746,6 +7746,62 @@ mod tests {
   }
 
   #[test]
+  fn trigger_dynamic_max_bound_resolves_and_follows_another_control() {
+    // A projectile/shooting-range style Demonstration (independently
+    // written, not copied from any specific one): a Trigger sweeps a
+    // position variable up to a range that is itself computed from another
+    // control's value via `Dynamic[…]`, exactly like a Continuous slider's
+    // dynamic bound (see `manipulate_emblem_dynamic_bound_clamps_and_places_
+    // controls_left`) — but on the dedicated Trigger row instead.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[Graphics[{Disk[{pos, 0}, 1]}], \
+       {{speed, 40, \"speed\"}, 10, 100, 1}, \
+       {{pos, 0, \"shoot\"}, 0, Dynamic[speed/2], 1, Trigger}]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let bounds = |s: &manipulate::ManipulateState| match &s.controls[1] {
+      manipulate::ControlState::Trigger { min, max, .. } => (*min, *max),
+      other => panic!("expected a Trigger control, got {other:?}"),
+    };
+    assert_eq!(
+      bounds(&state),
+      (0.0, 20.0),
+      "the Trigger's Dynamic max must resolve against the live bindings, \
+       not default to infinity"
+    );
+
+    // Raise `speed`: the Trigger's max must follow it, the same way a
+    // Continuous slider's Dynamic bound does.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[0]
+    {
+      *current = 100.0;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert_eq!(
+      bounds(&state),
+      (0.0, 50.0),
+      "the Trigger's max must track `speed` after it changes"
+    );
+
+    // With a finite, correctly-resolved max the animation still wraps
+    // instead of growing without bound.
+    for _ in 0..51 {
+      state.advance_animation();
+    }
+    let current = match &state.controls[1] {
+      manipulate::ControlState::Trigger { current, .. } => *current,
+      other => panic!("expected a Trigger control, got {other:?}"),
+    };
+    assert!(
+      (0.0..=50.0).contains(&current),
+      "the Trigger must stay within its dynamic bound, got {current}"
+    );
+  }
+
+  #[test]
   fn locator_manipulate_builds_a_draggable_widget() {
     // The "Center of Mass of a Polygon" Demonstration pattern: a Locator
     // bound to a point list drives the polygon, with icon-labelled

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -974,13 +974,24 @@ impl ManipulateState {
     resolved: &[(String, Option<f64>, Option<f64>)],
   ) {
     for (name, new_min, new_max) in resolved {
-      let Some(ControlState::Continuous {
-        min, max, current, ..
-      }) = self.controls.iter_mut().find(
-        |c| matches!(c, ControlState::Continuous { name: n, .. } if n == name),
-      )
-      else {
-        continue;
+      // A dynamic bound may belong to either a Continuous slider or a
+      // Trigger (a projectile's flight Trigger capped by another control's
+      // computed range, e.g. `Dynamic[range[angle, speed]]`, follows that
+      // control the same way a Continuous slider's dynamic bound does).
+      let (min, max, current) = match self.controls.iter_mut().find(|c| {
+        matches!(
+          c,
+          ControlState::Continuous { name: n, .. }
+          | ControlState::Trigger { name: n, .. } if n == name
+        )
+      }) {
+        Some(ControlState::Continuous {
+          min, max, current, ..
+        })
+        | Some(ControlState::Trigger {
+          min, max, current, ..
+        }) => (min, max, current),
+        _ => continue,
       };
       if let Some(v) = new_min {
         *min = *v;


### PR DESCRIPTION
## Summary

- Randomly picked a Wolfram Demonstrations Project notebook to check against Woxi Studio (a projectile-shooting-game style Demonstration). Its `Manipulate` uses a `ControlType -> Trigger` control whose end bound is `Dynamic[…]`-wrapped and computed from other sliders' current values (the flight range depends on the current angle/speed sliders).
- Found that a `Trigger` control's min/max bounds were resolved with `try_eval_to_f64_with_infinity` directly, which cannot see through a `Dynamic[…]` wrapper or track the live bindings the way a `Continuous` slider's bound does. The bound silently fell back to `f64::INFINITY`, so the Trigger's animation never stopped or wrapped, and no `min_code`/`max_code` was ever recorded for the frontend to re-resolve after another control changed.
- Fixed `parse_manipulate_control`'s `Trigger` branch (`src/functions/graphics.rs`) to reuse `eval_manipulate_bound` — the same helper `Continuous` controls already use — and to record the dynamic bound's code the same way.
- Extended `ManipulateState::apply_dynamic_bounds` (`woxi-studio/src/manipulate.rs`) to also match `ControlState::Trigger`, not just `ControlState::Continuous`, so a Trigger's bound actually gets re-resolved on every re-evaluation.
- Added a regression test (`woxi-studio/src/main.rs`) covering both the initial resolution of a `Dynamic[…]` Trigger max and that it follows another control's value after it changes — mirroring the existing `manipulate_emblem_dynamic_bound_clamps_and_places_controls_left` test for `Continuous` controls. The test is independently authored, not copied from the source notebook (which is copyrighted).

## Test plan

- [x] `make test` — all 27,705 unit tests pass, including the new regression test
- [x] `make format`
- [x] Verified against the downloaded Demonstration notebook directly: before the fix the Trigger control's `max` resolved to `inf`; after the fix it resolves to the correct dynamic value and updates when the dependent sliders move

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NbNBfp7Nv4eciTmjQrZ6UT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbNBfp7Nv4eciTmjQrZ6UT)_