### PR TITLE
Keep per-surface PlotStyle when Show merges a multi-surface Plot3D

### DIFF
--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -582,8 +582,13 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             .map(|z| (z.clamp(z_lo, z_hi) - z_lo) / z_range)
             .sum::<f64>()
               / 4.0;
-            let (cr, cg, cb) =
+            let height_color =
               surface_height_color(avg_z_norm, surface_idx, num_surfaces);
+            let (cr, cg, cb) =
+              match plot_style_for_surface(&plot_styles, surface_idx) {
+                Some(style) => style.color.unwrap_or(height_color),
+                None => height_color,
+              };
             // Colour and polygon travel in a sublist so the directive does
             // not leak onto the quads drawn after it.
             content.push(Expr::List(

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1020,6 +1020,34 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_show_merged_plot3d_keeps_per_surface_plotstyle() {
+    // Regression: a Manipulate body that stacks several flat `Plot3D`
+    // surfaces with an explicit per-surface `PlotStyle` list inside a
+    // `Show[{…}]` (the shape a "sheets stacked along an axis" Demonstration
+    // uses, e.g. one built from the Riemann surface of the logarithm) lost
+    // the requested colours: merging `Plot3D`'s symbolic structure into
+    // `Show` recoloured every surface with the automatic height-based
+    // rainbow instead of honoring `PlotStyle`.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Show[{Plot3D[{-1, 0, 1}, {x, -2, 2}, {y, -2, 2}, \
+       PlotStyle -> {{LightBlue}, {Yellow}, {LightBlue}}], \
+       Graphics3D[{Thick, White, Line[{{0, 0, -1}, {2, 0, -1}}]}]}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Show should produce a graphics SVG");
+    assert!(
+      svg.contains("rgb(188,203,216)"),
+      "the two LightBlue surfaces must keep their PlotStyle colour:\n{svg}"
+    );
+    assert!(
+      svg.contains("rgb(216,216,0)"),
+      "the Yellow surface must keep its PlotStyle colour:\n{svg}"
+    );
+  }
+
+  #[test]
   fn test_column_with_nested_tableform_renders_as_graphics() {
     // In visual mode (playground / woxi-studio), a Column containing a
     // TableForm must pre-render the table as a sub-SVG instead of falling


### PR DESCRIPTION
## Summary

Scheduled routine that fetches a random Wolfram Demonstrations Project notebook and checks whether Woxi Studio fully supports it. This run pulled **"Riemann Surface of the Logarithm"** (`demonstrations.wolfram.com/RiemannSurfaceOfTheLogarithm`).

The notebook parses cleanly (46 cells, incl. 4 raster snapshot images and 2 checkbox grids — all decode correctly via existing support). Its `Manipulate` body has the shape: a `GraphicsRow` whose second panel is `Show[{Plot3D[{f1, f2, f3}, ..., PlotStyle -> {{c1}, {c2}, {c3}}], Graphics3D[...], ParametricPlot3D[...], ...}]` — three flat surfaces stacked along an axis, each given an explicit colour via a per-surface `PlotStyle` list.

Reproducing that construct (self-authored, not copied from the notebook — its code is copyrighted) surfaced a real bug: `Plot3D`'s symbolic structure — built specifically so `Show` can merge a Plot3D surface into another `Graphics3D` — recoloured every facet with the automatic height-based rainbow, ignoring the `PlotStyle` list. The standalone SVG render already honored `PlotStyle` correctly; only the structure used for `Show` merging did not, so a Manipulate combining a styled multi-surface `Plot3D` with other 3D graphics (a common Demonstrations Project idiom) lost its intended colours in Woxi Studio.

## Fix

- `src/functions/plot3d.rs`: the per-facet colour used when building `Plot3D`'s mergeable `GraphicsComplex` structure now consults the parsed `PlotStyle` (via `plot_style_for_surface`), falling back to the existing height-based colour only when no style was given for that surface — matching the standalone renderer's behavior.
- `tests/interpreter_tests.rs`: added a regression test (`test_show_merged_plot3d_keeps_per_surface_plotstyle`) covering `Show[{Plot3D[..., PlotStyle -> {...}], Graphics3D[...]}]`.

## Test plan

- [x] `make test` (full unit suite, 27724 tests incl. woxi-studio) — all passing
- [x] `make format`
- [x] Manually verified via rendered SVG screenshots that the fix produces the correct light-blue/yellow/light-blue banding instead of an automatic green/orange/blue gradient


---
_Generated by [Claude Code](https://claude.ai/code/session_011LiD1TfojNDtTeXAkidi8W)_