### PR TITLE
Rename get_builtin_attributes_mask to get_builtin_attributes_mask

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 use std::cell::Cell;
 
@@ -1481,7 +1480,7 @@ fn is_downvalue_head_protected(name: &str) -> bool {
   if was_unprotected {
     return false;
   }
-  attributes::get_builtin_attributes_mask(name).contains(Attributes::Protected)
+  get_builtin_attributes(name).contains(Attributes::Protected)
     || crate::func_attrs_contains(name, Attributes::Protected)
 }
 
@@ -2282,7 +2281,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
     // break NumericQ value declarations, usage messages, etc. The memoization
     // idiom (`f[x_] := f[x] = …`) only ever applies to user functions.
     let is_builtin_head =
-      !attributes::get_builtin_attributes_mask(func_name.as_str()).is_empty();
+      !get_builtin_attributes(func_name.as_str()).is_empty();
     let all_literal_sameq = !is_builtin_head
       && !conditions.is_empty()
       && conditions.iter().all(|c| {
@@ -2532,8 +2531,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       _ => None,
     };
     if let Some(t) = tag
-      && crate::evaluator::get_builtin_attributes_mask(t)
-        .contains(Attributes::Protected)
+      && get_builtin_attributes(t).contains(Attributes::Protected)
     {
       let rhs_value = evaluate_expr_to_expr(rhs)?;
       crate::emit_message(&format!(
@@ -2663,8 +2661,7 @@ pub fn set_delayed_ast(
       _ => None,
     };
     if let Some(t) = tag
-      && crate::evaluator::get_builtin_attributes_mask(t)
-        .contains(Attributes::Protected)
+      && get_builtin_attributes(t).contains(Attributes::Protected)
     {
       crate::emit_message(&format!(
         "SetDelayed::write: Tag {} in {} is Protected.",

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 use std::collections::HashSet;
 use std::sync::LazyLock;
@@ -438,7 +437,7 @@ fn is_unprotected_builtin(name: &str) -> bool {
 
 /// Returns the built-in attributes for a given symbol name.
 /// Attributes are returned in alphabetical order, matching wolframscript output.
-pub fn get_builtin_attributes_mask(name: &str) -> Attributes {
+pub fn get_builtin_attributes(name: &str) -> Attributes {
   use Attributes as A;
   let mask = match name {
     // Arithmetic operators
@@ -1046,7 +1045,7 @@ pub fn dispatch_attributes(
           let mut removed = m.borrow_mut();
           let mask = Attributes::masks(&to_remove);
           for func_name in &func_names {
-            let builtin = get_builtin_attributes_mask(func_name);
+            let builtin = get_builtin_attributes(func_name);
             let mask = mask & builtin.to_u32(); // ignore attributes not on builtin.
             if mask != 0 {
               removed
@@ -1067,7 +1066,7 @@ pub fn dispatch_attributes(
           // If Protected is a builtin attribute that was previously removed,
           // restore it by pruning FUNC_ATTRS_REMOVED. Otherwise add as a
           // user-set attribute.
-          let builtin = get_builtin_attributes_mask(sym);
+          let builtin = get_builtin_attributes(sym);
           let was_builtin = builtin.contains(Attributes::Protected);
           if was_builtin {
             crate::FUNC_ATTRS_REMOVED.with(|m| {
@@ -1097,7 +1096,7 @@ pub fn dispatch_attributes(
         if let Some(sym) = symbol_name(arg) {
           let sym = &sym;
           let is_locked = {
-            let builtin = get_builtin_attributes_mask(sym);
+            let builtin = get_builtin_attributes(sym);
             if builtin.contains(Attributes::Locked) {
               true
             } else {
@@ -1127,7 +1126,7 @@ pub fn dispatch_attributes(
               false
             }
           });
-          let builtin = get_builtin_attributes_mask(sym);
+          let builtin = get_builtin_attributes(sym);
           let was_builtin_protected = builtin.contains(Attributes::Protected);
           if was_builtin_protected {
             crate::FUNC_ATTRS_REMOVED.with(|m| {

--- a/src/evaluator/contexts.rs
+++ b/src/evaluator/contexts.rs
@@ -26,10 +26,9 @@
 //! Symbols that ship with the language stay unqualified: they are `System``
 //! symbols, and Woxi implements them in one namespace.
 
+use super::*;
 use std::cell::RefCell;
 use std::collections::HashSet;
-
-use crate::syntax::Expr;
 
 thread_local! {
   /// Every symbol created so far, by full name (`Global`` symbols by their
@@ -221,7 +220,7 @@ fn is_user_symbol(name: &str) -> bool {
   {
     return false;
   }
-  if crate::evaluator::listable::is_system_variable_name(short_name(name)) {
+  if is_system_variable_name(short_name(name)) {
     return false;
   }
   // A pattern variable arrives with its blank suffix stripped, but a stray
@@ -230,8 +229,7 @@ fn is_user_symbol(name: &str) -> bool {
     return false;
   }
   let bare = short_name(name);
-  !crate::evaluator::is_builtin_symbol(bare)
-    && crate::evaluator::get_builtin_attributes_mask(bare).is_empty()
+  !is_builtin_symbol(bare) && get_builtin_attributes(bare).is_empty()
 }
 
 /// Whether a symbol with this full name exists — either created in a
@@ -392,7 +390,7 @@ pub fn display_name(full_name: &str) -> String {
 /// in their name; everything else in the stores is a `Global`` symbol.
 pub fn known_symbols() -> Vec<(String, String)> {
   let mut symbols: Vec<(String, String)> = Vec::new();
-  for builtin in crate::evaluator::all_builtin_symbol_names() {
+  for builtin in all_builtin_symbol_names() {
     symbols.push(("System`".to_string(), builtin.to_string()));
   }
   for name in created_symbols()

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 
 /// Report that an in-place modification has nothing to modify:
@@ -211,7 +210,7 @@ pub fn expand_arith_shorthand(
 
 /// Check if a function has a specific Hold attribute (built-in or user-defined).
 fn has_hold_attribute(name: &str, attr: u32) -> bool {
-  get_builtin_attributes_mask(name).contains(attr)
+  get_builtin_attributes(name).contains(attr)
     || crate::func_attrs_contains(name, attr)
 }
 

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -524,7 +524,7 @@ pub fn dispatch_complex_and_special(
       if let Expr::Identifier(sym) = first_arg {
         // Check if this is a built-in function (in functions.csv)
         let builtin_info = crate::evaluator::get_builtin_function_info(sym);
-        let builtin_attrs = get_builtin_attributes_mask(sym);
+        let builtin_attrs = get_builtin_attributes(sym);
 
         if builtin_info.is_some() || !builtin_attrs.is_empty() {
           // Built-in symbol
@@ -15085,7 +15085,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
   let user_attrs = crate::FUNC_ATTRS.with(|m| m.borrow().get(sym).cloned());
   let attrs_to_show: Attributes = match &user_attrs {
     Some(a) if !a.is_empty() => a.clone(),
-    _ => get_builtin_attributes_mask(sym),
+    _ => get_builtin_attributes(sym),
   };
   if !attrs_to_show.is_empty() {
     let vals = attrs_to_show.to_vec().join(", ");
@@ -15285,7 +15285,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
 
   // For built-in symbols: show attributes
   if lines.is_empty() {
-    let builtin_attrs = get_builtin_attributes_mask(sym);
+    let builtin_attrs = get_builtin_attributes(sym);
     if !builtin_attrs.is_empty() {
       let vals = builtin_attrs.to_vec().join(", ");
       lines.push(format!("Attributes[{printed}] = {{{vals}}}"));
@@ -15362,9 +15362,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
       crate::FUNC_OPTIONS_DELAYED.with(|m| m.borrow().contains(sym));
     let op = if is_user_stored {
       if user_delayed { ":=" } else { "=" }
-    } else if get_builtin_attributes_mask(sym)
-      .contains(Attributes::ReadProtected)
-    {
+    } else if get_builtin_attributes(sym).contains(Attributes::ReadProtected) {
       ":="
     } else {
       "="
@@ -15571,7 +15569,7 @@ pub fn full_definition_text(sym: &str) -> Option<String> {
     }
 
     if lines.is_empty() {
-      let builtin_attrs = get_builtin_attributes_mask(sym);
+      let builtin_attrs = get_builtin_attributes(sym);
       if !builtin_attrs.is_empty() {
         let vals = builtin_attrs.to_vec().join(", ");
         lines.push(format!("Attributes[{sym}] = {{{vals}}}"));
@@ -15692,7 +15690,7 @@ fn information_property(sym: &str, property: &str) -> Expr {
     return match property {
       "Usage" => Expr::String(info.description.to_string()),
       "Attributes" => Expr::List(
-        get_builtin_attributes_mask(sym)
+        get_builtin_attributes(sym)
           .to_vec()
           .into_iter()
           .map(|a| Expr::Identifier(a.to_string()))

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -958,8 +958,7 @@ fn evaluate_function_call_ast_inner(
   // dispatch — DownValues for the same head are still tried as usual.
   let head_has_hold_all_complete =
     crate::func_attrs_contains(name, Attributes::HoldAllComplete)
-      || get_builtin_attributes_mask(name)
-        .contains(Attributes::HoldAllComplete);
+      || get_builtin_attributes(name).contains(Attributes::HoldAllComplete);
   let overloads = crate::FUNC_DEFS.with(|m| {
     let defs = m.borrow();
     let raw = defs.get(name).cloned();

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1328,7 +1328,7 @@ pub fn dispatch_predicate_functions(
       // Check user-defined attributes first, then combine with built-in
       let user_attrs =
         crate::FUNC_ATTRS.with(|m| m.borrow().get(sym_name).cloned());
-      let builtin = get_builtin_attributes_mask(sym_name);
+      let builtin = get_builtin_attributes(sym_name);
       let removed = crate::FUNC_ATTRS_REMOVED
         .with(|m| m.borrow().get(sym_name).cloned())
         .unwrap_or_default();
@@ -1372,7 +1372,7 @@ pub fn dispatch_predicate_functions(
         return Some(Ok(Expr::String(sym_name[..=last].to_string())));
       }
       // Built-in symbols are in System` context
-      let builtin = get_builtin_attributes_mask(&sym_name);
+      let builtin = get_builtin_attributes(&sym_name);
       if !builtin.is_empty() {
         return Some(Ok(Expr::String("System`".to_string())));
       }
@@ -1706,7 +1706,7 @@ pub fn dispatch_predicate_functions(
         // Check if the symbol has been defined (OwnValues, DownValues, or is built-in)
         let has_own = crate::ENV.with(|e| e.borrow().contains_key(name));
         let has_down = crate::FUNC_DEFS.with(|m| m.borrow().contains_key(name));
-        let has_builtin_attrs = !get_builtin_attributes_mask(name).is_empty();
+        let has_builtin_attrs = !get_builtin_attributes(name).is_empty();
         if has_own || has_down || has_builtin_attrs {
           return Some(Ok(bool_expr(true)));
         }

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 
 /// Version of the Wolfram Language that Woxi aims to be compatible with,
@@ -1552,7 +1551,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
 /// SequenceHold semantics (Wolfram Language: HoldAllComplete = HoldAll
 /// + SequenceHold + ... ).
 pub(crate) fn has_sequence_hold(name: &str) -> bool {
-  let builtin = attributes::get_builtin_attributes_mask(name);
+  let builtin = get_builtin_attributes(name);
   builtin.contains(Attributes::SequenceHold)
     || crate::func_attrs_contains(name, Attributes::SequenceHold)
     || crate::func_attrs_contains(name, Attributes::HoldAllComplete)

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 use std::cell::RefCell;
 
@@ -659,7 +658,7 @@ fn try_ast_pattern_replace_impl(
 /// Check if a function has the OneIdentity attribute (builtin or user-defined).
 /// Check if a symbol has the Protected attribute (builtin or user-defined).
 pub fn is_symbol_protected(name: &str) -> bool {
-  let builtin = get_builtin_attributes_mask(name);
+  let builtin = get_builtin_attributes(name);
   let builtin_protected = builtin.contains(Attributes::Protected);
   // `Unprotect` records the removal in FUNC_ATTRS_REMOVED so the builtin's
   // baseline can be temporarily overridden without losing it.
@@ -671,7 +670,7 @@ pub fn is_symbol_protected(name: &str) -> bool {
 }
 
 fn has_one_identity(name: &str) -> bool {
-  let builtin = get_builtin_attributes_mask(name);
+  let builtin = get_builtin_attributes(name);
   if builtin.contains(Attributes::OneIdentity) {
     return true;
   }

--- a/src/evaluator/symbol_values.rs
+++ b/src/evaluator/symbol_values.rs
@@ -158,7 +158,7 @@ pub(crate) fn take_symbol_values(sym: &str) -> SymbolValues {
   // defaults have to be masked explicitly for `Attributes[sym]` to be `{}`.
   saved.attrs_removed =
     crate::FUNC_ATTRS_REMOVED.with(|m| m.borrow_mut().remove(sym));
-  let builtin = get_builtin_attributes_mask(sym);
+  let builtin = get_builtin_attributes(sym);
   if !builtin.is_empty() {
     crate::FUNC_ATTRS_REMOVED.with(|m| {
       let mut removed = m.borrow_mut();

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -199,7 +199,7 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       // user-set). When a slot is held, leave the argument literal and
       // skip the recursive N application.
       let attrs = {
-        let builtin = crate::evaluator::get_builtin_attributes_mask(name);
+        let builtin = crate::evaluator::get_builtin_attributes(name);
         let user = crate::FUNC_ATTRS
           .with(|m| m.borrow().get(name).cloned().unwrap_or_default());
         let mut combined = builtin;
@@ -1232,7 +1232,7 @@ fn n_eval_arbitrary_partial(
       // doesn't recurse into Out's slot and rewrite the index as a
       // BigFloat. (Out has NHoldFirst; the `0` slot must stay literal.)
       let attrs = {
-        let builtin = crate::evaluator::get_builtin_attributes_mask(name);
+        let builtin = crate::evaluator::get_builtin_attributes(name);
         let user = crate::FUNC_ATTRS
           .with(|m| m.borrow().get(name).cloned().unwrap_or_default());
         let mut combined = builtin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5448,8 +5448,7 @@ fn store_function_definition(
   let was_unprotected = func_attrs_removed_contains(&func_name, A::Protected);
   let is_builtin_protected = !is_n_value_assignment
     && !was_unprotected
-    && evaluator::get_builtin_attributes_mask(&func_name)
-      .contains(A::Protected);
+    && evaluator::get_builtin_attributes(&func_name).contains(A::Protected);
   let is_user_protected = func_attrs_contains(&func_name, A::Protected);
   if is_builtin_protected || is_user_protected {
     let (tag, ret) = if is_builtin_protected && !is_user_protected {

--- a/tests/miscellaneous_tests/attributes.rs
+++ b/tests/miscellaneous_tests/attributes.rs
@@ -6,7 +6,7 @@ mod tests {
     let names = woxi::evaluator::all_builtin_symbol_names();
     let mut failures: Vec<&str> = vec![];
     for name in names {
-      let mask = woxi::evaluator::get_builtin_attributes_mask(name);
+      let mask = woxi::evaluator::get_builtin_attributes(name);
       if !test(name, mask) {
         failures.push(name);
       }


### PR DESCRIPTION
Now that get_builtin_attributes is no longer used, we can rename get_builtin_attributes_mask to use it.  Also remove some unneeded use super::* to source files.