### PR TITLE
Run Manipulate's Initialization before earlier variable-spec bounds

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16666,6 +16666,25 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     out_args.push(body.clone());
   }
 
+  // `Initialization :> {...}` may define helper symbols (e.g. `func = {...}`)
+  // that a variable spec's bound references (e.g. `{{n, 4, "function"}, 1,
+  // Length[func], 1}`). Wolfram runs Initialization when the DynamicModule
+  // is set up, before any control bound is resolved, regardless of where
+  // the option appears among the argument list. Run it first here too, so
+  // the speculative bound evaluation below sees `func` already defined
+  // instead of evaluating `Length[func]` against an undefined symbol.
+  let already_initialized = args.iter().skip(1).any(|spec| {
+    if let Expr::Rule { pattern, replacement } | Expr::RuleDelayed { pattern, replacement } =
+      spec
+      && matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Initialization")
+    {
+      let _ = evaluate_expr_to_expr(replacement);
+      true
+    } else {
+      false
+    }
+  });
+
   for spec in args.iter().skip(1) {
     match spec {
       Expr::List(items) if !items.is_empty() => {
@@ -16691,8 +16710,11 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Mathematica's behavior of running Initialization at notebook
         // evaluation time. Evaluate its body in the current (global)
         // scope so SetDelayed definitions register before the Manipulate
-        // expression itself is returned.
-        if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Initialization")
+        // expression itself is returned. Already run above (before any
+        // variable spec bound was resolved) when `already_initialized` is
+        // set, so it isn't re-run here.
+        if !already_initialized
+          && matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Initialization")
         {
           let _ = evaluate_expr_to_expr(replacement);
         }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -18159,6 +18159,30 @@ mod manipulate {
     assert_eq!(result, "10");
   }
 
+  /// Regression: a variable spec's bound (`Length[func]`) that references a
+  /// symbol only `Initialization :> …` defines must still resolve, even
+  /// though the spec appears earlier in the argument list than the
+  /// `Initialization` option. Wolfram runs `Initialization` when the
+  /// DynamicModule is set up — before any control bound is resolved —
+  /// regardless of where the option is written among the arguments.
+  /// Previously the speculative bound evaluation ran left to right and hit
+  /// `Length[func]` before `func` had been defined, evaluating it against
+  /// an undefined symbol (`Length[func] -> 0`) instead of leaving it
+  /// symbolic for a later retry.
+  #[test]
+  fn bound_referencing_initialization_symbol_resolves_regardless_of_order() {
+    let result = interpret(
+      "Manipulate[func[[n]], {{n, 1, \"which\"}, 1, Length[func], 1}, \
+       Initialization :> (func = {a, b, c, d})]",
+    )
+    .unwrap();
+    assert_eq!(
+      result,
+      "Manipulate[func[[n]], {{n, 1, which}, 1, 4, 1}, \
+       Initialization :> (func = {a, b, c, d})]"
+    );
+  }
+
   #[test]
   fn tracked_symbols_option_is_not_vsform() {
     // Rule (`->`) options like TrackedSymbols also pass through cleanly.


### PR DESCRIPTION
## Summary
- Woxi Studio was checked against a random Wolfram Demonstration ("Function Explorer 3D"), whose `Manipulate` specifies its function-picker slider as `{{n, 4, "function"}, 1, Length[func], 1}`, with `func` only defined later in the same call's `Initialization :> {...}` option.
- `manipulate_ast` processed variable specs left to right, so it speculatively evaluated `Length[func]` before `Initialization` had run, against an undefined `func` (`Length` of a bare symbol is `0`) instead of the intended function count (`56`).
- Wolfram runs `Initialization` when the `DynamicModule` is set up, before any control bound is resolved, regardless of where the option sits among the arguments. Fixed by scanning for `Initialization` first and running it before the speculative bound evaluation, so a later-listed helper is already defined when an earlier bound references it.
- No code from the Demonstration notebook itself was copied — the fix targets the general `Manipulate`/`Initialization` ordering behavior, with a from-scratch regression test.

## Test plan
- [x] `make test` (27,724 tests passed)
- [x] `make test-studio` (191 tests passed)
- [x] `make format`
- [x] Manually verified the downloaded "Function Explorer 3D" notebook now reports the correct `Length[func] -> 56` bound instead of `0`


---
_Generated by [Claude Code](https://claude.ai/code/session_01E2v7xhA2g5uRr5jz6eV4NU)_