### PR TITLE
Parse geometric/pictograph/astronomical symbol characters as identifiers

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -914,6 +914,59 @@ fn is_symbol_letter(c: char) -> bool {
   c.is_alphabetic()
     || ('\u{F6B2}'..='\u{F6CB}').contains(&c)
     || ('\u{F770}'..='\u{F789}').contains(&c)
+    || is_letterlike_symbol_char(c)
+}
+
+/// Geometric shapes, pictographs, musical accidentals and astronomical
+/// symbols that Wolfram treats as ordinary letterlike symbol names — e.g.
+/// `Head[\[FilledSquare]]` is `Symbol`, not a syntax error — even though
+/// Unicode files them under `So`/`Sm` rather than `L`. Mirrors
+/// `LetterlikeSymbolChar` in wolfram.pest, which accepts the same
+/// characters when they appear as the bare glyph rather than the `\[Name]`
+/// escape.
+fn is_letterlike_symbol_char(c: char) -> bool {
+  matches!(
+    c,
+    '\u{2220}'
+      | '\u{25A0}'
+      | '\u{25A1}'
+      | '\u{25FC}'
+      | '\u{25FB}'
+      | '\u{25AA}'
+      | '\u{25AB}'
+      | '\u{25CF}'
+      | '\u{25CB}'
+      | '\u{F750}'
+      | '\u{25E6}'
+      | '\u{25C6}'
+      | '\u{25C7}'
+      | '\u{25B2}'
+      | '\u{25B3}'
+      | '\u{25BC}'
+      | '\u{25BD}'
+      | '\u{25C0}'
+      | '\u{25B6}'
+      | '\u{F528}'
+      | '\u{F527}'
+      | '\u{F725}'
+      | '\u{2713}'
+      | '\u{231A}'
+      | '\u{2605}'
+      | '\u{2736}'
+      | '\u{266F}'
+      | '\u{266D}'
+      | '\u{266E}'
+      | '\u{2609}'
+      | '\u{263F}'
+      | '\u{2640}'
+      | '\u{F3DF}'
+      | '\u{2642}'
+      | '\u{2643}'
+      | '\u{2644}'
+      | '\u{26E2}'
+      | '\u{2646}'
+      | '\u{2647}'
+  )
 }
 
 /// Extract all child `Expr` nodes from a variant, leaving it childless.

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -148,7 +148,26 @@ PatternName = @{ (ASCII_ALPHA | LETTER | PrivateUseLetter) ~ (ASCII_ALPHANUMERIC
 // Excludes operator named chars (\[Element], \[NotElement], \[ReverseElement], \[DirectedEdge], \[UndirectedEdge],
 // \[Rule], \[RuleDelayed], \[Equal], \[NotEqual], \[LessEqual], \[GreaterEqual], …)
 // which must be parsed as infix operators, not as identifiers in implicit multiplication.
-NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]" | "\\[Rule]" | "\\[RuleDelayed]" | "\\[Equal]" | "\\[NotEqual]" | "\\[LessEqual]" | "\\[GreaterEqual]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" }
+// Geometric shapes, pictographs, musical accidentals and astronomical
+// symbols that Wolfram treats as ordinary (letterlike) symbol names —
+// e.g. `Head[\[FilledSquare]]` is `Symbol`, not a syntax error. Unicode
+// files them under `So`/`Sm` rather than `L`, so — like PrivateUseLetter
+// above — they need to be named explicitly. A notebook's box form stores
+// these as the bare character (not the `\[Name]` escape), and a
+// Demonstration commonly uses `\[FilledSquare]`/`\[EmptySquare]` etc. as
+// grid-cell markers. Mirrors the "Geometric and miscellaneous symbols"
+// section of `named_char_to_unicode` in syntax.rs.
+LetterlikeSymbolChar = _{
+  "\u{2220}" | "\u{25A0}" | "\u{25A1}" | "\u{25FC}" | "\u{25FB}" | "\u{25AA}" | "\u{25AB}"
+  | "\u{25CF}" | "\u{25CB}" | "\u{F750}" | "\u{25E6}" | "\u{25C6}" | "\u{25C7}"
+  | "\u{25B2}" | "\u{25B3}" | "\u{25BC}" | "\u{25BD}" | "\u{25C0}" | "\u{25B6}"
+  | "\u{F528}" | "\u{F527}" | "\u{F725}" | "\u{2713}" | "\u{231A}" | "\u{2605}" | "\u{2736}"
+  | "\u{266F}" | "\u{266D}" | "\u{266E}"
+  | "\u{2609}" | "\u{263F}" | "\u{2640}" | "\u{F3DF}" | "\u{2642}" | "\u{2643}" | "\u{2644}"
+  | "\u{26E2}" | "\u{2646}" | "\u{2647}"
+}
+
+NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]" | "\\[Rule]" | "\\[RuleDelayed]" | "\\[Equal]" | "\\[NotEqual]" | "\\[LessEqual]" | "\\[GreaterEqual]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" | LetterlikeSymbolChar }
 // Adjacent `\[Name]` segments (or named char + identifier chars)
 // concatenate into a single identifier — `\[CapitalGamma]\[Beta]` → `Γβ`,
 // `\[Angle]XYZ` → `∠XYZ`, `i\[Ellipsis]j` (when `i` then `\[Ellipsis]j`

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -9029,6 +9029,53 @@ mod unicode_operators {
   }
 }
 
+// Wolfram treats geometric-shape, pictograph, astronomical and musical
+// glyphs as ordinary (letterlike) symbol names, even though Unicode files
+// them under `So`/`Sm` rather than `L` — `Head[■]` is `Symbol`, not a
+// syntax error. A Demonstration's box form stores these as the bare
+// character rather than the `\[Name]` escape (e.g. a grid-cell marker),
+// so the raw glyph must parse as an identifier on its own.
+mod letterlike_symbol_characters {
+  use super::*;
+
+  #[test]
+  fn geometric_shape_is_a_symbol() {
+    assert_eq!(interpret("Head[■]").unwrap(), "Symbol");
+    assert_eq!(interpret("Head[□]").unwrap(), "Symbol");
+    assert_eq!(interpret("Head[●]").unwrap(), "Symbol");
+    assert_eq!(interpret("Head[○]").unwrap(), "Symbol");
+    assert_eq!(interpret("Head[◆]").unwrap(), "Symbol");
+    assert_eq!(interpret("Head[▲]").unwrap(), "Symbol");
+  }
+
+  #[test]
+  fn geometric_shape_used_as_array_fill_value() {
+    assert_eq!(interpret("ConstantArray[■, 3]").unwrap(), "{■, ■, ■}");
+  }
+
+  #[test]
+  fn geometric_shape_raw_char_matches_named_escape() {
+    assert_eq!(interpret("■ === \\[FilledSquare]").unwrap(), "True");
+  }
+
+  #[test]
+  fn astronomical_and_musical_symbols_are_symbols() {
+    assert_eq!(interpret("Head[♄]").unwrap(), "Symbol"); // Saturn
+    assert_eq!(interpret("Head[♯]").unwrap(), "Symbol"); // Sharp
+    assert_eq!(interpret("Head[☉]").unwrap(), "Symbol"); // Sun
+  }
+
+  #[test]
+  fn geometric_shape_inside_nested_function_call() {
+    // The bare glyph must survive being nested inside further function
+    // calls and control flow, not just as a lone top-level expression.
+    assert_eq!(
+      interpret("If[True, ConstantArray[■, 2], ConstantArray[□, 2]]").unwrap(),
+      "{■, ■}"
+    );
+  }
+}
+
 // Regression tests for `&` (Function) precedence. `&` has very low precedence
 // in Wolfram — it binds looser than any infix operator. Inner-term rules must
 // not consume the `&` greedily when there are preceding operators, otherwise


### PR DESCRIPTION
## Summary

- Weekly check: fetched a random Demonstration from the Wolfram Cloud resource API and tested it against Woxi Studio's notebook pipeline (`cargo run -p woxi-studio --example test_notebook` / `dump_manipulate`). The Demonstration's single `Manipulate` cell uses `■` (`\[FilledSquare]`) as a raw Unicode character to draw a grid of squares — this failed to parse.
- Wolfram treats glyphs like `■` as ordinary letterlike symbol names (`Head[■]` is `Symbol`), even though Unicode files them under `So`/`Sm` rather than `L`. Woxi's grammar only special-cased a handful of such characters (π, ∞, °, …), missing the broader "geometric shapes / pictographs / musical accidentals / astronomical symbols" class that `named_char_to_unicode` (in `src/syntax.rs`) already maps from `\[Name]` escapes.
- Extends the raw-character whitelist in `src/wolfram.pest` (new `LetterlikeSymbolChar` rule) and the matching `is_symbol_letter` check in `src/syntax.rs` with that same character set, so the bare glyph and its `\[Name]` escape now parse identically.
- After the fix, the downloaded Demonstration's `Manipulate` builds correctly in Woxi Studio (sliders for `n`/`d`, a toggle for `resize`, and a correctly rendered grid of `■` characters showing the factorization). The notebook itself is not checked in since it is copyrighted material; the added tests exercise the same underlying construct with originally-authored snippets.

## Test plan

- [x] Added `letterlike_symbol_characters` test module in `tests/interpreter_tests/syntax.rs` covering: bare shapes evaluate to `Symbol`, work as `ConstantArray` fill values, match their `\[Name]` escape form (`■ === \[FilledSquare]`), astronomical/musical symbols, and nesting inside `If`/`ConstantArray`.
- [x] `make test` — all 27,728 tests pass, no regressions.
- [x] `make format`.
- [x] Manually verified via `cargo run -p woxi-studio --example dump_manipulate` that the fetched Demonstration's `Manipulate` now builds its widget and renders correct SVG output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvH4UM6Rxw6kwm2YedrUUC)_