### PR TITLE
Render UpEquilibrium/ReverseUpEquilibrium named characters for a Demonstration's electron-configuration diagram

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -4839,7 +4839,7 @@ TitsGroupT,,,,8.0,5013
 TraceBackward,,,,2.0,5013
 TransferFunctionFactor,,🚫,,8.0,5013
 UndoOptions,,🚫,,10.0,5013
-UpEquilibrium,,,,3.0,5013
+UpEquilibrium,Same-spin-pair upward harpoon notation symbol,✅,none,3.0,5013
 ValidationLength,,🚫,,7.0,5013
 ValuePreprocessingFunction,,,,11.2,5013
 VerticalBar,,,,3.0,5013
@@ -5149,7 +5149,7 @@ QuantityVariableIdentifier,,,,10.0,5390
 RemoteBatchSubmit,,🚫,,12.2,5390
 RemoveUsers,,🚫,,10.0,5390
 ReverseEquilibrium,,,,3.0,5390
-ReverseUpEquilibrium,,,,3.0,5390
+ReverseUpEquilibrium,Reversed same-spin-pair upward harpoon notation symbol,✅,none,3.0,5390
 RightArrowLeftArrow,,,,3.0,5390
 RightDownTeeVector,,,,3.0,5390
 RightDownVector,,,,3.0,5390

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -3771,7 +3771,8 @@ Cell["Chapter 2", "Chapter"]
   fn test_up_equilibrium_named_character_renders_as_unicode() {
     let s = r#"BoxData[RowBox[{"f", "[", "\"\<\[UpEquilibrium]\>\"", "]"}]]"#;
     assert_eq!(extract_cell_content(s), "f[\"\u{296E}\"]");
-    let s = r#"BoxData[RowBox[{"f", "[", "\"\<\[ReverseUpEquilibrium]\>\"", "]"}]]"#;
+    let s =
+      r#"BoxData[RowBox[{"f", "[", "\"\<\[ReverseUpEquilibrium]\>\"", "]"}]]"#;
     assert_eq!(extract_cell_content(s), "f[\"\u{296F}\"]");
   }
 

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -3762,6 +3762,19 @@ Cell["Chapter 2", "Chapter"]
     assert_eq!(extract_cell_content(s), "T'=a \u{00B7} T \u{00B7} a");
   }
 
+  /// `\[UpEquilibrium]` (⥮) and `\[ReverseUpEquilibrium]` (⥯) are the
+  /// same-spin-pair glyphs a Demonstrations electron-configuration diagram
+  /// draws its spin arrows with. They were missing from the named-character
+  /// table, so a labelled cell fell back to printing the literal escape
+  /// `\[UpEquilibrium]` instead of the glyph.
+  #[test]
+  fn test_up_equilibrium_named_character_renders_as_unicode() {
+    let s = r#"BoxData[RowBox[{"f", "[", "\"\<\[UpEquilibrium]\>\"", "]"}]]"#;
+    assert_eq!(extract_cell_content(s), "f[\"\u{296E}\"]");
+    let s = r#"BoxData[RowBox[{"f", "[", "\"\<\[ReverseUpEquilibrium]\>\"", "]"}]]"#;
+    assert_eq!(extract_cell_content(s), "f[\"\u{296F}\"]");
+  }
+
   #[test]
   fn test_extract_cell_content_template_box_quantity() {
     // `TemplateBox[{value, displayed, name, unit_id}, "QuantityPrefix"]` is

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -430,6 +430,8 @@ pub fn named_char_to_unicode(name: &str) -> Option<&'static str> {
     "DoubleLongLeftRightArrow" => "\u{27FA}",
     "Equilibrium" => "\u{21CC}",
     "ReverseEquilibrium" => "\u{21CB}",
+    "UpEquilibrium" => "\u{296E}",
+    "ReverseUpEquilibrium" => "\u{296F}",
     "LeftTeeArrow" => "\u{21A4}",
     "RightTeeArrow" => "\u{21A6}",
     "UpTeeArrow" => "\u{21A5}",


### PR DESCRIPTION
## Summary

- Following the scheduled routine that fetches a random Wolfram Demonstration and checks whether Woxi Studio fully supports it, this run downloaded **"Electron Configurations and Atomic Radii for the Elements"**.
- All 245 cells evaluated cleanly (`make test` / the `test_notebook` harness reported 0 errors), but the notebook's electron-configuration orbital diagram — which labels paired electrons with `\[UpEquilibrium]` (⥮), styled in per-shell colors — rendered as overlapping garbled text in Woxi Studio instead of the arrow-pair glyph.
- Root cause: `\[UpEquilibrium]` (and its `\[ReverseUpEquilibrium]` counterpart) were missing from `named_char_to_unicode` in `src/syntax.rs`, so the notebook parser's fallback printed the literal escape string `\[UpEquilibrium]` — much wider than a single glyph — causing many labels to overlap each other and the neighboring orbital names.
- Added both named characters (`U+296E` / `U+296F`) to the character table and a regression test in `src/notebook.rs`. Also filled in the previously-empty `functions.csv` rows for both.

## Verification

- Opened the downloaded demonstration notebook in Woxi Studio under Xvfb, ran all cells ("All cells evaluated | 245 cells"), and dragged the atomic-number slider through several values.
- Before the fix: the orbital diagram showed overlapping garbled text at higher atomic numbers (more paired orbitals).
- After the fix: the diagram renders correctly — up/down spin-pair arrows in the right colors, no overlap — matching expected chemistry (e.g. Iridium, Z=77: `[Xe] 4f¹⁴ 5d⁷ 6s²` with 3 unpaired 5d electrons per Hund's rule).
- `make test`: 27,724 tests passed, 0 failed.
- `make format`: clean, no additional changes.

Note: no code from the (copyrighted) Demonstration notebook itself is included in this PR — the regression test uses a minimal, independently-authored box expression exercising the same named-character escape.

## Test plan

- [x] `make test` passes (27,724/27,724)
- [x] `make format` produces no diff
- [x] Manually verified in Woxi Studio (screenshots, not included) that the Demonstration's orbital diagram renders correctly across multiple atomic numbers


---
_Generated by [Claude Code](https://claude.ai/code/session_016CFgG1PsApcpgfeNXDbzZj)_