### PR TITLE
Fix ToString dropping the precision marker only on a bare BigFloat

### DIFF
--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5556,24 +5556,7 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // significant figures, matching wolframscript: `ToString[N[Pi, 5]]` is
   // "3.1416" (not "3.1415") and `ToString[N[999/1000, 2]]` is "1.0".
   if let Expr::BigFloat(digits, prec) = &args[0] {
-    let trimmed = digits.trim();
-    let (sign, body) = if let Some(rest) = trimmed.strip_prefix('-') {
-      ("-", rest)
-    } else {
-      ("", trimmed)
-    };
-    let prec_digits = prec.round() as i64;
-    let s = if prec_digits > 0 {
-      format!(
-        "{}{}",
-        sign,
-        crate::round_significant(body, prec_digits as usize)
-      )
-    } else {
-      // Non-positive precision (e.g. an accuracy form): keep the digits.
-      format!("{sign}{body}")
-    };
-    return Ok(Expr::String(s));
+    return Ok(Expr::String(format_bigfloat_for_to_string(digits, *prec)));
   }
 
   // Default (no form or unrecognized form): OutputForm.
@@ -5614,13 +5597,45 @@ fn round_real_to_6_sig_digits(f: f64) -> f64 {
   format!("{f:.5e}").parse().unwrap_or(f)
 }
 
+/// Render an arbitrary-precision number the way `ToString` does: drop the
+/// `` `p `` precision marker and round (not truncate) the decimal expansion
+/// to `p` significant figures — matching wolframscript: `ToString[N[Pi, 5]]`
+/// is "3.1416" (not "3.1415") and `ToString[N[999/1000, 2]]` is "1.0".
+fn format_bigfloat_for_to_string(digits: &str, prec: f64) -> String {
+  let trimmed = digits.trim();
+  let (sign, body) = if let Some(rest) = trimmed.strip_prefix('-') {
+    ("-", rest)
+  } else {
+    ("", trimmed)
+  };
+  let prec_digits = prec.round() as i64;
+  if prec_digits > 0 {
+    format!(
+      "{}{}",
+      sign,
+      crate::round_significant(body, prec_digits as usize)
+    )
+  } else {
+    // Non-positive precision (e.g. an accuracy form): keep the digits.
+    format!("{sign}{body}")
+  }
+}
+
 /// Recursively replace each `Expr::Real(f)` in `expr` with its
 /// 6-sig-digit-rounded counterpart, so the default ToString path
-/// emits e.g. `15.8406` for the f64 value `15.840646417884168`.
-/// Leaves BigFloat, Integer, and symbolic Expr nodes intact.
+/// emits e.g. `15.8406` for the f64 value `15.840646417884168`. Each
+/// `Expr::BigFloat` is rendered the same way a top-level BigFloat argument
+/// to `ToString` is (backtick marker dropped, rounded to its precision) —
+/// otherwise a BigFloat nested inside a List or FunctionCall would print
+/// its raw InputForm digits with the marker still attached, e.g.
+/// `ToString[{N[Pi, 5]}]` would wrongly be "{3.1415926535897932385`5.}"
+/// instead of "{3.1416}".
 fn truncate_machine_reals_for_to_string(expr: &Expr) -> Expr {
   match expr {
     Expr::Real(f) => Expr::Real(round_real_to_6_sig_digits(*f)),
+    Expr::BigFloat(digits, prec) => {
+      Expr::Raw(format_bigfloat_for_to_string(digits, *prec))
+    }
     Expr::List(items) => Expr::List(
       items
         .iter()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -385,6 +385,28 @@ Cell[BoxData[RowBox[{"Print[\"hi\"]", "\n", "x = 5"}]], "Code"]
 }
 
 #[test]
+fn run_notebook_manipulate_epilog_label_has_no_precision_marker() {
+  // Regression for a Wolfram Demonstrations Project notebook pattern: a
+  // Manipulate body computes a value with `NIntegrate`, then builds a
+  // `Plot` `Epilog` label via `ToString[SetPrecision[expr, n]]`. The label
+  // text must be the plain rounded decimal (matching wolframscript), not
+  // the raw InputForm digits with a `` `n `` precision marker still
+  // attached.
+  let nb = concat!(
+    "Notebook[{\n",
+    "Cell[BoxData[\"Print[ToString[SetPrecision[Tanh[1], 3]]]\"], \"Input\"]\n",
+    "}]\n"
+  );
+  let dir = std::env::temp_dir();
+  let path = dir.join("woxi_cli_test_manipulate_epilog_label.nb");
+  std::fs::write(&path, nb).expect("write temp notebook");
+  let (stdout, stderr, ok) = run_file(&path);
+  let _ = std::fs::remove_file(&path);
+  assert!(ok, "woxi run notebook failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "Tanh[1.00]");
+}
+
+#[test]
 fn run_notebook_notebook_directory_resolves_to_file_dir() {
   // Regression: `NotebookDirectory[]` must resolve to the `.nb` file's
   // own directory when run via `woxi run` (so Export paths etc. work),

--- a/tests/interpreter_tests/string.rs
+++ b/tests/interpreter_tests/string.rs
@@ -9539,6 +9539,32 @@ mod to_string_bigfloat {
     assert_eq!(interpret("ToString[N[999/1000, 2]]").unwrap(), "1.0");
     assert_eq!(interpret("ToString[N[19999/2000, 3]]").unwrap(), "10.0");
   }
+
+  // A BigFloat nested inside a List, FunctionCall, or arithmetic op gets the
+  // same marker-dropping/rounding treatment as a bare top-level BigFloat
+  // argument — previously only the top-level case was handled, so a nested
+  // BigFloat printed its raw InputForm digits with the `` `p `` marker still
+  // attached (e.g. `Tanh[1.`3.]` instead of `Tanh[1.00]`, surfaced by a
+  // Wolfram Demonstration's Manipulate body: `ToString[SetPrecision[Tanh[mL]/
+  // mL, 3]]` inside a Plot Epilog label).
+  #[test]
+  fn to_string_bigfloat_nested_in_list_strips_marker() {
+    assert_eq!(interpret("ToString[{N[Pi, 5]}]").unwrap(), "{3.1416}");
+  }
+
+  #[test]
+  fn to_string_bigfloat_nested_in_function_call_strips_marker() {
+    assert_eq!(interpret("ToString[f[N[Pi, 5]]]").unwrap(), "f[3.1416]");
+    assert_eq!(
+      interpret("ToString[SetPrecision[Tanh[1], 3]]").unwrap(),
+      "Tanh[1.00]"
+    );
+  }
+
+  #[test]
+  fn to_string_bigfloat_nested_in_binary_op_strips_marker() {
+    assert_eq!(interpret("ToString[N[Pi, 5] + x]").unwrap(), "3.1416 + x");
+  }
 }
 
 mod cases {


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook ("Surface Kinetics with Pore Diffusion Resistance"), I found that its `Manipulate` body renders a `Plot` `Epilog` label with `ToString[SetPrecision[Tanh[mL]/mL, 3]]`, which produced `"Tanh[1.\`3.]"` instead of `"Tanh[1.00]"`.

- `ToString[SetPrecision[expr, n]]` already correctly rounded a **top-level** arbitrary-precision real to `n` significant figures and dropped its `` `n `` precision marker (e.g. `ToString[N[Pi, 5]]` → `"3.1416"`).
- The same arbitrary-precision real **nested** inside a `List`, `FunctionCall`, or `BinaryOp` kept its raw InputForm digits with the marker still attached (e.g. `ToString[{N[Pi, 5]}]` wrongly gave `"{3.1415926535897932385\`5.}"` instead of `"{3.1416}"`).

This extracts the top-level rounding logic into `format_bigfloat_for_to_string` and reuses it in `truncate_machine_reals_for_to_string`'s recursive expression walk, so a nested `BigFloat` is rendered the same way regardless of where it appears in the expression tree.

With the fix, the downloaded notebook's `Manipulate`/`NIntegrate`/`FindRoot`/`Plot`-with-`Epilog` body evaluates and renders (`ExportString[..., "SVG"]`) correctly end-to-end, so no notebook-parsing changes were needed — the notebook itself was not copied into the repo (copyrighted content), only a minimal reproduction of the failing expression pattern.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/string.rs` for `ToString` on a `BigFloat` nested in a list, function call, and binary op.
- [x] Added a CLI regression test in `tests/cli_tests.rs` running a minimal `.nb` notebook through `woxi run` that reproduces the Demonstration's exact failure pattern.
- [x] `make test` — all 27,729 tests pass.
- [x] `make format`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AkQkB8P87RqcmitJQutEcE)_