### PR TITLE
Fix numeric Eigensystem/Eigenvectors for repeated eigenvalues

### DIFF
--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -4445,18 +4445,49 @@ fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> crate::syntax::Expr {
   let eigenvalues = numeric_eigenvalues(&f_matrix, n);
 
   let mut eigenvectors = Vec::new();
+  // Normalized eigenvectors already emitted for the run of eigenvalues equal
+  // to the one currently being processed (eigenvalues are sorted, so a
+  // repeated eigenvalue's occurrences are adjacent). `(A - λI)` is identical
+  // across the whole run, so its null space is too — without tracking what
+  // has already been handed out, every occurrence would independently pick
+  // the same first free-column vector out of that shared null space instead
+  // of a genuinely different one spanning the rest of the eigenspace.
+  let mut group_lambda: Option<f64> = None;
+  let mut group_prev: Vec<Vec<f64>> = Vec::new();
   for &lambda in &eigenvalues {
+    if group_lambda.is_none_or(|g| (g - lambda).abs() > 1e-9) {
+      group_lambda = Some(lambda);
+      group_prev.clear();
+    }
+
     // Build (A - λI)
     let mut m = f_matrix.clone();
     for i in 0..n {
       m[i][i] -= lambda;
     }
 
-    // Find null space via Gaussian elimination
-    let mut vec = numeric_null_vector(&m, n);
+    // Find a null space vector independent from any already used for this
+    // same eigenvalue: Gram-Schmidt each free-column basis vector against
+    // the ones already emitted in this group and take the first that still
+    // has a non-negligible component left afterward.
+    let mut vec = numeric_null_space_basis(&m, n)
+      .into_iter()
+      .map(|mut candidate| {
+        for prev in &group_prev {
+          let dot: f64 = candidate.iter().zip(prev).map(|(a, b)| a * b).sum();
+          for (c, p) in candidate.iter_mut().zip(prev) {
+            *c -= dot * p;
+          }
+        }
+        candidate
+      })
+      .find(|candidate| {
+        candidate.iter().map(|x| x * x).sum::<f64>().sqrt() > 1e-9
+      })
+      .unwrap_or_else(|| vec![0.0; n]);
 
-    // The fixed pivot tolerance inside `numeric_null_vector` is tuned for
-    // well-conditioned small matrices; for a larger matrix (or one with
+    // The fixed pivot tolerance inside `numeric_null_space_basis` is tuned
+    // for well-conditioned small matrices; for a larger matrix (or one with
     // several eigenvalues close enough together to leave only a small gap
     // between them) the residual along the true null direction can sit
     // above that tolerance, so no column gets recognized as free and the
@@ -4467,8 +4498,14 @@ fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> crate::syntax::Expr {
     // of iterations are enough since the shift already sits at the
     // converged eigenvalue.
     if vec.iter().all(|x| x.abs() < 1e-15)
-      && let Some(v) = inverse_iteration_eigenvector(&f_matrix, lambda, n)
+      && let Some(mut v) = inverse_iteration_eigenvector(&f_matrix, lambda, n)
     {
+      for prev in &group_prev {
+        let dot: f64 = v.iter().zip(prev).map(|(a, b)| a * b).sum();
+        for (c, p) in v.iter_mut().zip(prev) {
+          *c -= dot * p;
+        }
+      }
       vec = v;
     }
 
@@ -4488,6 +4525,7 @@ fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> crate::syntax::Expr {
           *v = -*v;
         }
       }
+      group_prev.push(normalized.clone());
       let normalized_exprs: Vec<Expr> =
         normalized.into_iter().map(Expr::Real).collect();
       eigenvectors.push(Expr::List(normalized_exprs.into()));
@@ -4707,7 +4745,7 @@ fn qr_eigenvalues(h: &mut [Vec<f64>], n: usize) -> Vec<f64> {
 /// would make its own pivoting degenerate) while staying far smaller than
 /// the gap to any other eigenvalue, so it still converges to `λ`'s own
 /// eigenvector in a couple of iterations — including when `λ` sits close to
-/// another eigenvalue, which is exactly the case `numeric_null_vector`'s
+/// another eigenvalue, which is exactly the case `numeric_null_space_basis`'s
 /// fixed pivot tolerance can miss for larger or near-degenerate matrices.
 fn inverse_iteration_eigenvector(
   a: &[Vec<f64>],
@@ -4736,8 +4774,14 @@ fn inverse_iteration_eigenvector(
   result
 }
 
-/// Find a null space vector for a numeric matrix via Gaussian elimination.
-fn numeric_null_vector(m: &[Vec<f64>], n: usize) -> Vec<f64> {
+/// Every basis vector of a numeric matrix's null space, one per free
+/// column, via Gaussian elimination with partial pivoting. A repeated
+/// eigenvalue's shifted matrix `(A - λI)` has a null space of dimension
+/// equal to the eigenvalue's multiplicity; returning every free-column
+/// vector (instead of only the first) lets the caller hand each occurrence
+/// of the repeated eigenvalue a genuinely independent eigenvector instead
+/// of the same one every time.
+fn numeric_null_space_basis(m: &[Vec<f64>], n: usize) -> Vec<Vec<f64>> {
   let mut aug: Vec<Vec<f64>> = m.to_vec();
   let mut pivot_cols = Vec::new();
   let mut pivot_row = 0;
@@ -4781,21 +4825,20 @@ fn numeric_null_vector(m: &[Vec<f64>], n: usize) -> Vec<f64> {
 
   // Find free columns
   let pivot_col_set: Vec<usize> = pivot_cols.iter().map(|&(_, c)| c).collect();
-  let mut free_cols: Vec<usize> =
+  let free_cols: Vec<usize> =
     (0..n).filter(|c| !pivot_col_set.contains(c)).collect();
 
-  if free_cols.is_empty() {
-    return vec![0.0; n];
-  }
-
-  // Build null vector from first free column
-  let free_col = free_cols.remove(0);
-  let mut vec = vec![0.0; n];
-  vec[free_col] = 1.0;
-  for &(row, col) in &pivot_cols {
-    vec[col] = -aug[row][free_col];
-  }
-  vec
+  free_cols
+    .into_iter()
+    .map(|free_col| {
+      let mut vec = vec![0.0; n];
+      vec[free_col] = 1.0;
+      for &(row, col) in &pivot_cols {
+        vec[col] = -aug[row][free_col];
+      }
+      vec
+    })
+    .collect()
 }
 
 /// RowReduce[matrix] - Gaussian elimination to reduced row echelon form

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -4506,7 +4506,21 @@ fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> crate::syntax::Expr {
           *c -= dot * p;
         }
       }
-      vec = v;
+      // A defective matrix's repeated eigenvalue has a null space smaller
+      // than its multiplicity, so inverse iteration — deterministic given
+      // the same shifted matrix and starting vector — converges to the
+      // same direction already recorded in `group_prev` for every
+      // occurrence. Once that's subtracted out here, what's left is only
+      // the tiny residual from `inverse_iteration_eigenvector`'s shift
+      // regularization, not a genuine second eigenvector; require the same
+      // significance the null-space search above does, so a defective
+      // occurrence falls through to the zero-vector convention below
+      // (matching wolframscript, e.g. `Eigenvectors[{{1, 1}, {0, 1}}]` ==
+      // `{{1, 0}, {0, 0}}`) instead of fabricating an unrelated vector.
+      let v_norm: f64 = v.iter().map(|x| x * x).sum::<f64>().sqrt();
+      if v_norm > 1e-9 {
+        vec = v;
+      }
     }
 
     // Normalize to unit length

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -5477,6 +5477,44 @@ mod cases {
       r#"{1., 1., 1., 1., 1., 1., 1.}"#,
     );
   }
+  // A repeated numeric eigenvalue's shifted matrix (A - λI) has a null
+  // space spanning the whole eigenspace, so every occurrence of that
+  // eigenvalue independently landed on the same first free-column vector
+  // out of that shared null space instead of a second, independent one —
+  // e.g. Eigensystem[N[IdentityMatrix[2]]] returned the same vector twice
+  // rather than an orthonormal basis. This surfaced in a Wolfram
+  // Demonstrations Project notebook whose Manipulate computes the ellipse
+  // where a plane cuts a cylinder via Eigensystem of a symmetric 2x2
+  // matrix: whenever the plane's normal and the cylinder's axis lined up,
+  // that matrix became a scaled identity and the "ellipse" collapsed onto
+  // a single line instead of a circle.
+  #[test]
+  fn eigensystem_float_identity_2x2_distinct_eigenvectors() {
+    assert_case(
+      r#"Eigensystem[N[IdentityMatrix[2]]]"#,
+      r#"{{1., 1.}, {{-1., 0.}, {0., -1.}}}"#,
+    );
+  }
+  #[test]
+  fn eigenvectors_float_identity_3x3_distinct_eigenvectors() {
+    assert_case(
+      r#"Eigenvectors[N[IdentityMatrix[3]]]"#,
+      r#"{{1., 0., 0.}, {0., 1., 0.}, {0., 0., 1.}}"#,
+    );
+  }
+  // Same bug, but on a non-identity symmetric matrix (eigenvalues 4, 1, 1):
+  // the two eigenvectors sharing the repeated eigenvalue 1 must come out
+  // independent (nonzero norm, mutually orthogonal), not the same vector.
+  #[test]
+  fn eigenvectors_float_repeated_eigenvalue_orthogonal() {
+    assert_case(
+      r#"Round[
+        With[{vs = Eigenvectors[{{2., 1., 1.}, {1., 2., 1.}, {1., 1., 2.}}]},
+          {vs[[2]] . vs[[3]], Norm[vs[[2]]], Norm[vs[[3]]]}],
+        0.0001]"#,
+      r#"{0., 1., 1.}"#,
+    );
+  }
   #[test]
   fn inverse_1() {
     assert_case(

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -5515,6 +5515,20 @@ mod cases {
       r#"{0., 1., 1.}"#,
     );
   }
+  // A *defective* (non-diagonalizable) float matrix's repeated eigenvalue
+  // has a null space smaller than its multiplicity: the Gram-Schmidt fix
+  // above must not fabricate a second eigenvector out of the inverse-
+  // iteration fallback's shift residual once the real eigenvector is
+  // subtracted out — it should fall back to the zero vector, matching the
+  // exact-integer path's existing convention (see `defective_matrix`
+  // above: `Eigenvectors[{{1, 1}, {0, 1}}]` == `{{1, 0}, {0, 0}}`).
+  #[test]
+  fn eigenvectors_float_defective_repeated_eigenvalue() {
+    assert_case(
+      r#"Eigenvectors[{{2., 1.}, {0., 2.}}]"#,
+      r#"{{-1., 0.}, {0., 0.}}"#,
+    );
+  }
   #[test]
   fn inverse_1() {
     assert_case(


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration ("Intersection of a Plane and Cylinder") and checked it against Woxi Studio's Manipulate pipeline (`cargo run -p woxi-studio --example dump_manipulate`). The Manipulate built and rendered, but the red intersection curve/disk between the plane and cylinder was geometrically wrong whenever the plane's normal lined up with the cylinder's axis.
- Root cause: the demonstration computes that intersection via `Eigensystem` of a symmetric 2×2 matrix that becomes a scaled identity in that alignment. `numeric_eigenvectors` independently found the null space vector for each eigenvalue occurrence via `numeric_null_vector`, which always returns the *first* free-column vector — so a repeated eigenvalue's shifted matrix `(A - λI)`, whose null space spans the whole eigenspace, produced the *same* vector for every occurrence instead of an orthonormal basis (e.g. `Eigensystem[N[IdentityMatrix[2]]]` returned `{{-1.,0.},{-1.,0.}}`, not two independent vectors).
- Fixed by extracting `numeric_null_vector` into `numeric_null_space_basis` (every free-column basis vector, not just the first), and having `numeric_eigenvectors` Gram-Schmidt each candidate against the vectors already emitted for the same eigenvalue so every occurrence of a repeated eigenvalue gets a genuinely independent, orthonormal vector.
- No code from the notebook itself is included in the repo (per project guidelines); the fix and regression tests are expressed against plain matrices (`IdentityMatrix`, a simple symmetric matrix with eigenvalues 4, 1, 1) that reproduce the same underlying bug.

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/linear_algebra.rs` covering `Eigensystem[N[IdentityMatrix[2]]]`, `Eigenvectors[N[IdentityMatrix[3]]]`, and orthogonality/independence for a repeated eigenvalue on a non-identity symmetric matrix.
- [x] `make test` — all 27,728 tests pass.
- [x] `make format`.
- [x] Manually re-rendered the demonstration's Manipulate at default control values before/after the fix and confirmed the intersection circle now renders correctly (previously collapsed to a degenerate line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ78db9M3ApSJsCjFa4pn5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ78db9M3ApSJsCjFa4pn5)_