### PR TITLE
Fix severe NDSolve slowdown for Interpolation-driven right-hand sides

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -2832,6 +2832,18 @@ enum NExpr {
     template: Expr,
     refs: Vec<(String, usize)>,
   },
+  /// A call `InterpolatingFunction[domain, data, order…][arg]` — e.g. a
+  /// lookup table built with `Interpolation[…]` and referenced from an
+  /// ODE's right-hand side. Goes straight to
+  /// `evaluate_interpolating_function` instead of through `External`'s
+  /// full symbolic round trip (re-resolving the call generically on every
+  /// one of the tens of thousands of RK4 stages a solve takes), while
+  /// still calling that same function so the interpolation math itself is
+  /// not duplicated.
+  Interp1D {
+    func_args: Vec<Expr>,
+    arg: Box<Self>,
+  },
 }
 
 impl NExpr {
@@ -2864,6 +2876,13 @@ impl NExpr {
           );
         }
         crate::evaluator::evaluate_expr_to_expr(&substituted)
+          .ok()
+          .and_then(|r| expr_to_f64(&r).ok())
+          .unwrap_or(f64::NAN)
+      }
+      Self::Interp1D { func_args, arg } => {
+        let x = arg.eval(vars);
+        evaluate_interpolating_function(func_args, &[Expr::Real(x)])
           .ok()
           .and_then(|r| expr_to_f64(&r).ok())
           .unwrap_or(f64::NAN)
@@ -2902,6 +2921,46 @@ fn compile_external_leaf(expr: &Expr, var_names: &[String]) -> NExpr {
     template: expr.clone(),
     refs,
   }
+}
+
+/// If `expr` is a call `InterpolatingFunction[domain, data, …][arg]` — a
+/// lookup table built by `Interpolation[…]`/`ListInterpolation[…]` or an
+/// NDSolve result, already resolved to its value by the time equations
+/// reach this compiler — compile it as an `NExpr::Interp1D` leaf so a
+/// residual that looks the table up stays out of `External`'s full
+/// symbolic dispatch on every RK4 stage. Returns `None` for anything else:
+/// a 2-D grid interpolation (its call takes a `{x, y}` pair, not this
+/// leaf's single scalar) or a call whose head isn't `InterpolatingFunction`.
+fn compile_interp1d_call(
+  func: &Expr,
+  args: &[Expr],
+  var_names: &[String],
+) -> Option<NExpr> {
+  if args.len() != 1 {
+    return None;
+  }
+  let Expr::FunctionCall {
+    name: interp_name,
+    args: func_args,
+  } = func
+  else {
+    return None;
+  };
+  if interp_name != "InterpolatingFunction"
+    || !(2..=4).contains(&func_args.len())
+  {
+    return None;
+  }
+  // The 2-D grid form carries `{orderRow, orderCol}` as its third
+  // argument; a plain 1-D table has a single integer order (or none).
+  if matches!(func_args.get(2), Some(Expr::List(_))) {
+    return None;
+  }
+  let arg = compile_numeric(&args[0], var_names)?;
+  Some(NExpr::Interp1D {
+    func_args: func_args.to_vec(),
+    arg: Box::new(arg),
+  })
 }
 
 /// Compile an expression over the given variable names to an `NExpr`.
@@ -3031,6 +3090,16 @@ fn compile_numeric(expr: &Expr, var_names: &[String]) -> Option<NExpr> {
         // bailing the whole residual out to the symbolic path.
         _ => Some(compile_external_leaf(expr, var_names)),
       }
+    }
+    // `xy = Interpolation[…]; …xy[y[t]]…` — by the time an ODE's
+    // right-hand side reaches this compiler, the symbol `xy` has already
+    // been resolved to its value, leaving `InterpolatingFunction[…][arg]`
+    // as a `CurriedCall` rather than a plain named call. Recognizing it
+    // here keeps a table lookup out of `External`'s full generic dispatch
+    // on every one of the tens of thousands of RK4 stages a solve takes.
+    Expr::CurriedCall { func, args } => {
+      compile_interp1d_call(func, args, var_names)
+        .or_else(|| Some(compile_external_leaf(expr, var_names)))
     }
     other => Some(compile_external_leaf(other, var_names)),
   }

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7948,6 +7948,38 @@ mod ndsolve {
   }
 
   #[test]
+  fn ndsolve_rhs_calling_an_interpolating_function_stays_fast() {
+    // Regression: a right-hand side that looks a value up in a table built
+    // with `Interpolation[…]` (`xy = Interpolation[…]; y'[t] == -xy[y[t]]`,
+    // a common way to drive an ODE off precomputed data, e.g. a physical
+    // property curve) used to fall out of the residual compiler's
+    // closed-form arithmetic subset entirely: every RK4 stage re-resolved
+    // the call through the full generic evaluator instead of the compiled
+    // numeric tree, turning a solve that should take well under a second
+    // into one that took minutes. With the table set to the identity
+    // function, `y' = -y` from `y(0) = 1` has the closed form `y = e^-t`.
+    let start = std::time::Instant::now();
+    let result = interpret(
+      "xy = Interpolation[Table[{i, N[i]}, {i, -50, 50}], \
+       InterpolationOrder -> 1]; \
+       sol = NDSolve[{y'[t] == -xy[y[t]], y[0] == 1}, y, {t, 0, 5}]; \
+       y[3.0] /. sol[[1]]",
+    )
+    .unwrap();
+    assert!(
+      start.elapsed().as_secs() < 5,
+      "an Interpolation-driven residual must use the compiled numeric \
+       path, not fall back to the full evaluator on every RK4 stage"
+    );
+    let val: f64 = result.parse().expect("should be a number");
+    let expected = (-3.0_f64).exp();
+    assert!(
+      (val - expected).abs() < 1e-4,
+      "Expected {expected}, got {val}"
+    );
+  }
+
+  #[test]
   fn interior_initial_point_integrates_both_directions() {
     // The initial condition sits inside the domain: y' = y, y(1) = 1 on
     // {t, 0, 2} → y(t) = E^(t-1) on both sides of t = 1.


### PR DESCRIPTION
## Summary

- While checking whether Woxi Studio could open a random Wolfram Demonstrations Project notebook (a batch-distillation `Manipulate` simulation), found that opening it hung for over 14 minutes instead of completing near-instantly.
- Root cause: `NDSolve`'s residual compiler (`compile_numeric` in `src/functions/ode_ast.rs`) had no fast path for a right-hand side that looks a value up in a table built with `Interpolation[...]` (a common pattern: `xy = Interpolation[...]; y'[t] == -xy[y[t]]`). By the time an equation reaches the compiler, the symbol has already resolved to `InterpolatingFunction[...][arg]` — a `CurriedCall` the compiler didn't recognize — so every RK4 stage fell back to `NExpr::External`, re-resolving the call through the full generic evaluator instead of the compiled numeric tree.
- Added `NExpr::Interp1D`, which recognizes this `CurriedCall` shape and calls the existing `evaluate_interpolating_function` directly (reusing its interpolation math, not duplicating it) instead of round-tripping through the general evaluator.
- A synthetic reproduction (8 coupled ODEs, RHS calling a 100-point interpolation table) went from ~20s to ~0.8s; the real Demonstration's `Manipulate` widget went from ~854s to under a second in Woxi Studio.

## Test plan

- [x] Added `ndsolve_rhs_calling_an_interpolating_function_stays_fast` in `tests/interpreter_tests/calculus.rs`, checking both correctness (against the closed-form solution) and a wall-clock bound so a future regression is caught.
- [x] `make test` — all 27,727 tests pass.
- [x] `make test-studio` — all 192 tests pass (finished in 54s total, vs. the single problematic case previously taking 854s on its own).
- [x] `make format-check` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AuwWuQqU6gCxwqXfkvVoRk)_