### PR TITLE
Let Longest/Shortest drive the search when behind another sequence pattern

### DIFF
--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -3098,6 +3098,130 @@ fn index_permutations(n: usize) -> Vec<Vec<usize>> {
   }
 }
 
+/// Head, `PatternTest` and `Repeated`-element checks for one candidate split of
+/// a sequence pattern, plus the binding for the pattern's own name. `None` when
+/// this window of arguments cannot be what the pattern matches.
+fn match_sequence_window(
+  seq: &SeqInfo,
+  window: &[Expr],
+) -> Option<Vec<(String, Expr)>> {
+  if let Some(ref h) = seq.head
+    && !window.iter().all(|a| get_expr_head(a) == *h)
+  {
+    return None;
+  }
+  if let Some(ref test) = seq.test
+    && !window.iter().all(|a| apply_pattern_test(test, a))
+  {
+    return None;
+  }
+  let mut bindings: Vec<(String, Expr)> = vec![];
+  if let Some(ref elem_pat) = seq.element_pattern {
+    for arg in window {
+      let b = match_pattern(arg, elem_pat)?;
+      if !merge_bindings(&mut bindings, b) {
+        return None;
+      }
+    }
+  }
+  if !seq.name.is_empty() {
+    let bound = match window.len() {
+      0 => call0("Sequence"),
+      1 => window[0].clone(),
+      _ => unevaluated("Sequence", window),
+    };
+    bindings.insert(0, (seq.name.clone(), bound));
+  }
+  Some(bindings)
+}
+
+/// Index of the first `Longest[…]` / `Shortest[…]` sequence pattern that an
+/// earlier sequence pattern would otherwise outrank.
+///
+/// Wolfram reads the wrapper as a preference on the *whole* match, not just on
+/// the split tried first at that one position: `{a___, Longest[x__Integer],
+/// b___}` picks the longest run of integers anywhere in the list, rather than
+/// the longest run that happens to start where a left-to-right `a___` stopped.
+/// So when such a pattern sits behind another sequence pattern it has to drive
+/// the search instead of being driven by its neighbours.
+fn ordering_sequence_index(pat_args: &[Expr]) -> Option<usize> {
+  let idx = pat_args.iter().position(|p| {
+    matches!(p, Expr::FunctionCall { name, args }
+      if (name == "Longest" || name == "Shortest") && args.len() == 1)
+      && get_sequence_info(p).is_some()
+  })?;
+  // With only fixed-width patterns in front of it the ordinary left-to-right
+  // walk already arrives with a single possible split, so nothing outranks it.
+  pat_args[..idx]
+    .iter()
+    .any(|p| get_sequence_info(p).is_some())
+    .then_some(idx)
+}
+
+/// Match `pat_args` with the sequence pattern at `idx` choosing first: its
+/// length is the primary key (longest or shortest, per its wrapper) and its
+/// starting offset the secondary one, with the patterns on either side matched
+/// against whatever each candidate window leaves them.
+fn match_args_driven_by_sequence(
+  expr_args: &[Expr],
+  pat_args: &[Expr],
+  idx: usize,
+) -> Option<Vec<(String, Expr)>> {
+  let seq = get_sequence_info(&pat_args[idx])?;
+  let (pre, post) = (&pat_args[..idx], &pat_args[idx + 1..]);
+  let pre_min = min_args_for_patterns(pre);
+  let post_min = min_args_for_patterns(post);
+  let budget = expr_args.len().checked_sub(pre_min + post_min)?;
+  let max_count = seq.max_count.unwrap_or(budget).min(budget);
+  if max_count < seq.min_count {
+    return None;
+  }
+
+  let counts: Box<dyn Iterator<Item = usize>> = if seq.greedy {
+    Box::new((seq.min_count..=max_count).rev())
+  } else {
+    Box::new(seq.min_count..=max_count)
+  };
+  for count in counts {
+    for start in pre_min..=(expr_args.len() - count - post_min) {
+      let Some(mut bindings) =
+        match_sequence_window(&seq, &expr_args[start..start + count])
+      else {
+        continue;
+      };
+      let Some(pre_bindings) =
+        match_args_with_sequences(&expr_args[..start], pre)
+      else {
+        continue;
+      };
+      if !merge_bindings(&mut bindings, pre_bindings) {
+        continue;
+      }
+      let Some(post_bindings) =
+        match_args_with_sequences(&expr_args[start + count..], post)
+      else {
+        continue;
+      };
+      if !merge_bindings(&mut bindings, post_bindings) {
+        continue;
+      }
+      if let Some(ref cond) = seq.condition {
+        let test_expr =
+          apply_bindings(cond, &bindings).unwrap_or(*cond.clone());
+        match evaluate_expr_to_expr(&test_expr) {
+          Ok(Expr::Identifier(ref s)) if s == "True" => {}
+          _ => continue,
+        }
+      }
+      if lhs_condition_definitely_fails(&bindings) {
+        continue;
+      }
+      return Some(bindings);
+    }
+  }
+  None
+}
+
 fn match_args_with_sequences(
   expr_args: &[Expr],
   pat_args: &[Expr],
@@ -3109,6 +3233,10 @@ fn match_args_with_sequences(
     } else {
       None
     };
+  }
+
+  if let Some(idx) = ordering_sequence_index(pat_args) {
+    return match_args_driven_by_sequence(expr_args, pat_args, idx);
   }
 
   let pat = &pat_args[0];
@@ -3310,105 +3438,36 @@ fn match_args_with_sequences(
       (seq.min_count..=max_count).collect()
     };
     for count in counts {
-      let seq_args = &expr_args[..count];
-
-      // Check head constraints for all elements
-      if let Some(ref h) = seq.head
-        && !seq_args.iter().all(|a| get_expr_head(a) == *h)
-      {
+      let Some(mut bindings) = match_sequence_window(&seq, &expr_args[..count])
+      else {
         continue;
-      }
-
-      // Check PatternTest for all elements
-      if let Some(ref test) = seq.test
-        && !seq_args.iter().all(|a| apply_pattern_test(test, a))
-      {
-        continue;
-      }
-
-      // Check element pattern for Repeated/RepeatedNull
-      if let Some(ref elem_pat) = seq.element_pattern {
-        let mut all_match = true;
-        let mut elem_bindings: Vec<(String, Expr)> = vec![];
-        for arg in seq_args {
-          if let Some(b) = match_pattern(arg, elem_pat) {
-            if !merge_bindings(&mut elem_bindings, b) {
-              all_match = false;
-              break;
-            }
-          } else {
-            all_match = false;
-            break;
-          }
-        }
-        if !all_match {
-          continue;
-        }
-        // Recursively match the rest
-        if let Some(rest_bindings) =
-          match_args_with_sequences(&expr_args[count..], rest_pats)
-          && merge_bindings(&mut elem_bindings, rest_bindings)
-        {
-          // Add binding for this sequence name (if any)
-          if !seq.name.is_empty() {
-            let bound_value = if count == 0 {
-              call0("Sequence")
-            } else if count == 1 {
-              seq_args[0].clone()
-            } else {
-              unevaluated("Sequence", seq_args)
-            };
-            elem_bindings.insert(0, (seq.name.clone(), bound_value));
-          }
-          // Check Condition if present
-          if let Some(ref cond) = seq.condition {
-            let test_expr =
-              apply_bindings(cond, &elem_bindings).unwrap_or(*cond.clone());
-            match evaluate_expr_to_expr(&test_expr) {
-              Ok(Expr::Identifier(ref s)) if s == "True" => {}
-              _ => continue,
-            }
-          }
-          // Outer LHS Condition (`pat /; cond` or `Condition[pat, test]`):
-          // backtrack to the next sequence split when the candidate
-          // bindings make the condition definitively False.
-          if lhs_condition_definitely_fails(&elem_bindings) {
-            continue;
-          }
-          return Some(elem_bindings);
-        }
-        continue;
-      }
+      };
 
       // Recursively match the rest
-      if let Some(mut rest_bindings) =
+      let Some(rest_bindings) =
         match_args_with_sequences(&expr_args[count..], rest_pats)
-      {
-        // Add binding for this sequence
-        if !seq.name.is_empty() {
-          let bound_value = if count == 0 {
-            call0("Sequence")
-          } else if count == 1 {
-            seq_args[0].clone()
-          } else {
-            unevaluated("Sequence", seq_args)
-          };
-          rest_bindings.insert(0, (seq.name.clone(), bound_value));
-        }
-        // Check Condition if present
-        if let Some(ref cond) = seq.condition {
-          let test_expr =
-            apply_bindings(cond, &rest_bindings).unwrap_or(*cond.clone());
-          match evaluate_expr_to_expr(&test_expr) {
-            Ok(Expr::Identifier(ref s)) if s == "True" => {}
-            _ => continue,
-          }
-        }
-        if lhs_condition_definitely_fails(&rest_bindings) {
-          continue;
-        }
-        return Some(rest_bindings);
+      else {
+        continue;
+      };
+      if !merge_bindings(&mut bindings, rest_bindings) {
+        continue;
       }
+      // Check Condition if present
+      if let Some(ref cond) = seq.condition {
+        let test_expr =
+          apply_bindings(cond, &bindings).unwrap_or(*cond.clone());
+        match evaluate_expr_to_expr(&test_expr) {
+          Ok(Expr::Identifier(ref s)) if s == "True" => {}
+          _ => continue,
+        }
+      }
+      // Outer LHS Condition (`pat /; cond` or `Condition[pat, test]`):
+      // backtrack to the next sequence split when the candidate bindings
+      // make the condition definitively False.
+      if lhs_condition_definitely_fails(&bindings) {
+        continue;
+      }
+      return Some(bindings);
     }
     None
   } else {

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -4506,6 +4506,51 @@ mod longest_shortest_and_orderless_sequences {
     );
   }
 
+  // `{a___, Longest[x__Integer], b___} -> {x}` is the standard idiom for
+  // pulling the longest run of a kind of element out of a list (e.g. the
+  // longest run of heads in a coin-toss sequence, once heads have been
+  // replaced by 1 and tails are anything else). `Longest` wrapping a
+  // sequence pattern that sits *behind* another sequence pattern (`a___`)
+  // has to pick the split that makes its own match longest overall, not
+  // just the longest run starting wherever `a___`'s default (shortest)
+  // split happens to land — otherwise it finds only the first run instead
+  // of the true longest one.
+  #[test]
+  fn longest_behind_a_sequence_pattern_finds_the_longest_run_anywhere() {
+    assert_eq!(
+      interpret(
+        r#"{1, 1, "gap", 1, "gap", "gap", 1, 1, 1} /. {a___, Longest[x__Integer], b___} -> {x}"#
+      )
+      .unwrap(),
+      "{1, 1, 1}"
+    );
+    // Shortest still returns the first (leftmost) run when driven the same
+    // way.
+    assert_eq!(
+      interpret(
+        r#"{"gap", "gap", 1, "gap", 1, 1, 1, "gap"} /. {a___, Shortest[x__Integer], b___} -> {x}"#
+      )
+      .unwrap(),
+      "{1}"
+    );
+    // A tie between two runs of the same maximal length picks the leftmost.
+    assert_eq!(
+      interpret(
+        r#"{1, 1, "gap", 1, 1, "gap", "gap"} /. {a___, Longest[x__Integer], b___} -> {x}"#
+      )
+      .unwrap(),
+      "{1, 1}"
+    );
+    // No run at all leaves the list unchanged (the rule doesn't match).
+    assert_eq!(
+      interpret(
+        r#"{"gap", "gap", "gap"} /. {a___, Longest[x__Integer], b___} -> {x}"#
+      )
+      .unwrap(),
+      "{gap, gap, gap}"
+    );
+  }
+
   // OrderlessPatternSequence matches the block of arguments at its position
   // in any order — so the elements it takes stay contiguous.
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21883,4 +21883,92 @@ SaveDefinitions -> True]";
       "Show[Graphics[...], RegionPlot[...]] should render as a picture"
     );
   }
+
+  /// End-to-end regression for the shape of Demonstration that reports
+  /// run-length statistics on a random binary sequence: five standalone
+  /// (ungrouped) Input cells define a `BlockRandom`/`SeedRandom`-seeded
+  /// `RandomChoice` draw whose two outcomes are a `Style`-wrapped string and
+  /// a plain string, then count-based and longest-run helpers built on top
+  /// of it, and a `Manipulate` with two `Appearance -> "Labeled"` sliders
+  /// displays the results. The longest-run helpers use the standard
+  /// `list /. mark -> 1 /. {a___, Longest[x__Integer], b___} -> {x}` idiom,
+  /// which only returns the true longest run when `Longest` is allowed to
+  /// pick where `a___`/`b___` split rather than being stuck with whatever
+  /// split a left-to-right walk lands on first. Independently written, not
+  /// copied from any specific Wolfram Demonstration.
+  #[test]
+  fn run_length_statistics_notebook_opens_with_its_widget() {
+    let nb_src = r#"Notebook[{
+Cell[BoxData["draws[n_, s_] := BlockRandom[SeedRandom[s]; RandomChoice[{Style[\"W  \", RGBColor[0, 0.6, 0]], \"L  \"}, n]]"], "Input"],
+Cell[BoxData["wins[n_, s_] := Count[draws[n, s], Style[\"W  \", RGBColor[0, 0.6, 0]]]"], "Input"],
+Cell[BoxData["losses[n_, s_] := Count[draws[n, s], \"L  \"]"], "Input"],
+Cell[BoxData["winStreak[n_, s_] := Sign[wins[n, s]] Length[draws[n, s] /. Style[\"W  \", RGBColor[0, 0.6, 0]] -> 1 /. {a___, Longest[x__Integer], b___} -> {x}]"], "Input"],
+Cell[BoxData["loseStreak[n_, s_] := Sign[losses[n, s]] Length[draws[n, s] /. \"L  \" -> 1 /. {a___, Longest[y__Integer], b___} -> {y}]"], "Input"],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[Graphics[{Text[Style[wins[n, s], 18, Bold, RGBColor[0, 0.6, 0]], {-300, 200}], Text[Style[\" wins\", 18, Bold], {-230, 200}], Text[Style[\"longest win streak: \", 18, Bold], {80, 200}], Text[Style[winStreak[n, s], 18, Bold, RGBColor[0, 0.6, 0]], {260, 200}], Text[Style[losses[n, s], 18, Bold], {-300, 150}], Text[Style[\" losses\", 18, Bold], {-230, 150}], Text[Style[\"longest loss streak: \", 18, Bold], {80, 150}], Text[Style[loseStreak[n, s], 18, Bold], {260, 150}]}, ImageSize -> {500, 350}], {{n, 30, \"number of trials\"}, 5, 400, 1, Appearance -> \"Labeled\"}, {{s, 5, \"random seed\"}, 1, 400, 1, Appearance -> \"Labeled\"}, SaveDefinitions -> True, AutorunSequencing -> {1}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 30, $CellContext`s$$ = 5}, \"…\"]"], "Output"]
+}, Open]]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+
+    // `SaveDefinitions -> True` and `AutorunSequencing -> {1}` are
+    // Manipulate options, not controls.
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: n_name,
+          current: n_current,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: s_name,
+          current: s_current,
+          ..
+        },
+      ] => {
+        assert_eq!(n_name, "n");
+        assert_eq!(s_name, "s");
+        assert_eq!((*n_current, *s_current), (30.0, 5.0));
+      }
+      other => panic!("expected two labelled sliders, got {other:?}"),
+    }
+
+    // The earlier standalone Input cells (the helper definitions) already
+    // ran into global state while the notebook loaded, exactly as
+    // `wins`/`losses`/`winStreak`/`loseStreak` would after Mathematica
+    // evaluates a Demonstration's initialization cells — so they're callable
+    // directly here, scoped only by the widget's current control values.
+    //
+    // For 30 draws seeded with 5, the sequence has 15 wins, 15 losses, a
+    // longest win streak of 5 and a longest loss streak of 3 — checked
+    // independently against `woxi eval` on the same from-scratch helpers.
+    // Before `Longest` was made to pick its own split point instead of
+    // deferring to `a___`'s default leftmost/shortest one, `winStreak`
+    // returned 2 (the first win run) instead of 5 (the true longest one).
+    let bindings: Vec<(String, String)> = widget
+      .controls
+      .iter()
+      .map(|c| (c.name().to_string(), c.current_code()))
+      .collect();
+    let stats = woxi::with_scoped_globals(&bindings, || {
+      woxi::interpret_with_stdout(
+        "{wins[n, s], losses[n, s], winStreak[n, s], loseStreak[n, s]}",
+      )
+    })
+    .expect("the run-length helpers must evaluate");
+    assert_eq!(
+      stats.result, "{15, 15, 5, 3}",
+      "wins, losses, longest win streak, longest loss streak"
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Woxi Studio was checked against a random Wolfram Demonstration ("Consecutive Heads or Tails"), whose longest-run-length statistics use the standard idiom `list /. mark -> 1 /. {a___, Longest[x__Integer], b___} -> {x}`.
- Woxi's sequence-pattern matcher processed patterns strictly left to right, so `a___` (defaulting to its shortest split) picked its length first and `Longest[x__Integer]` could only ever see the run starting right after wherever `a___` stopped — returning the *first* run of the wanted kind instead of the true *longest* one anywhere in the list.
- Wolfram treats `Longest`/`Shortest` as a preference on the whole match: when such a wrapped sequence pattern sits behind another sequence pattern, it now drives the search itself (longest/shortest count first, then earliest start among ties), matching the patterns on either side against whatever each candidate window leaves them.
- No code from the Demonstration notebook itself was copied — the fix targets the general `Longest`/`Shortest` ordering behavior, with from-scratch regression tests in both the interpreter (`tests/interpreter_tests/patterns.rs`) and Woxi Studio (`woxi-studio/src/main.rs`), the latter modeling the Demonstration's shape (renamed variables/text, different colors and numbers) rather than reproducing it.

## Test plan
- [x] `make test` (27,727 tests passed)
- [x] `make test-studio` (193 tests passed)
- [x] `make format`
- [x] Manually verified `{1, 1, "T", 1, "T", "T", 1, 1, 1} /. {a___, Longest[x__Integer], b___} -> {x}` now returns `{1, 1, 1}` instead of `{1, 1}`, matching the expected longest-run semantics
- [x] All pre-existing `Longest`/`Shortest` test expectations (simple two-pattern splits, `MatchQ`, transparency around non-sequence patterns, definition-parameter wrapping) unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01G1Piz1Urwrh6C2WjEWge77)_