### PR TITLE
Fix SubscriptBox conversion for bare display-glyph subscripts

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -790,14 +790,29 @@ fn extract_typeset_box(s: &str) -> Option<String> {
       "SubscriptBox" if args.len() == 2 => {
         let sub = conv(&args[1]);
         let base = conv(&args[0]);
-        match part_spec_inside_double_brackets(&sub) {
-          Some(spec) => format_part_access(&base, spec),
-          // Prefix subscript, as above — keep an explicit empty string so
-          // the result still parses.
-          None if draws_nothing(&base) => {
+        if let Some(spec) = part_spec_inside_double_brackets(&sub) {
+          format_part_access(&base, spec)
+        } else {
+          // The subscript is usually a real index (`Subscript[p, 0]`
+          // stays evaluable, keeping `p` and `0` bare), but a
+          // typeset annotation like `\!\(\*SubscriptBox[\(0\),
+          // \(+\)]\)` (the "0⁺" of a one-sided limit) has no meaning
+          // as code on its own — `Subscript[0, +]` would not parse.
+          // Quote such a subscript as a string literal instead, the
+          // same fallback `OverscriptBox`/`UnderscriptBox` use for
+          // their bare mark below.
+          let sub = if crate::parse_to_expr(&sub).is_ok() {
+            sub
+          } else {
+            format!("\"{}\"", escape_string(&sub))
+          };
+          // Prefix subscript, as above — keep an explicit empty string
+          // so the result still parses.
+          if draws_nothing(&base) {
             format!("Subscript[\"\", {sub}]")
+          } else {
+            format!("Subscript[{base}, {sub}]")
           }
-          None => format!("Subscript[{base}, {sub}]"),
         }
       }
       // `SubsuperscriptBox[a, b, c]` → `Subscript[a, b]^c`.
@@ -3696,6 +3711,24 @@ Cell["Chapter 2", "Chapter"]
     // An ordinary subscript is still `Subscript`.
     let s = r#"BoxData[SubscriptBox["c", "1"]]"#;
     assert_eq!(extract_cell_content(s), "Subscript[c, 1]");
+  }
+
+  /// A subscript can also be a bare display glyph rather than a real index
+  /// — a Demonstrations control label typeset "0" with a subscript "+" (the
+  /// one-sided-limit notation "0⁺") as `SubscriptBox["0", "+"]`. Regression:
+  /// it came back as `Subscript[0, +]`, which does not parse (`+` alone is
+  /// not a complete expression), so the reconstructed source fell back to
+  /// showing the raw box syntax instead of typesetting anything.
+  #[test]
+  fn test_subscript_with_bare_operator_glyph_is_quoted() {
+    let s = r#"BoxData[SubscriptBox["0", "+"]]"#;
+    assert_eq!(extract_cell_content(s), "Subscript[0, \"+\"]");
+    // A real indexed variable keeps its identifier/number subscript bare.
+    let s = r#"BoxData[SubscriptBox["p", "0"]]"#;
+    assert_eq!(extract_cell_content(s), "Subscript[p, 0]");
+    // A compound index expression still parses as one, so it stays bare.
+    let s = r#"BoxData[SubscriptBox["x", RowBox[{"i", "+", "1"}]]]"#;
+    assert_eq!(extract_cell_content(s), "Subscript[x, i+1]");
   }
 
   /// `OverscriptBox`/`UnderscriptBox` become the evaluable `Overscript`/

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -10041,6 +10041,46 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn setter_choice_label_typesets_a_bare_subscript_glyph() {
+    // Regression: a Setter whose per-choice label is a `Column` mixing plain
+    // lines with a `Row` that ends in an inline `\!\(\*SubscriptBox[…]\)`
+    // (a one-sided-limit annotation, "lag = 0⁺" — the shape a Demonstrations
+    // control used, independently written here rather than copied from any
+    // specific one) came back showing the raw box source `SubscriptBox[0,
+    // +]` instead of the "0⁺" it typesets, because reconstructing the boxed
+    // expression as `Subscript[0, +]` does not parse (`+` alone is not a
+    // complete expression).
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[x, \
+       {{x, 1, \"kind\"}, \
+        {1 -> Column[{\"first\", \
+           Row[{\"at \", \"lag = \\!\\(\\*SubscriptBox[\\(0\\), \\(+\\)]\\)\"}]}], \
+         2 -> Column[{\"second\", \"plain\"}]}, \
+        ControlType -> Setter}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the subscript-labelled Setter must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete { value_labels, .. } => {
+        assert_eq!(
+          value_labels,
+          &[
+            "first\nat lag = 0₊".to_string(),
+            "second\nplain".to_string()
+          ]
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  #[test]
   fn popup_menu_traditional_form_labels_render_as_typeset_svg() {
     // Regression: a PopupMenu choice label wrapped in `TraditionalForm[…]`
     // (the "pick a formula" idiom several Demonstrations use, independently


### PR DESCRIPTION
## Summary

- Investigated Woxi Studio's support for a randomly-selected Wolfram Demonstration ("Estimators of a Noisy Centered Ornstein-Uhlenbeck Process and Its Noise Variance"). Parsing, cell reconstruction, and evaluation of the notebook's `Manipulate[...]` all worked, but one `Setter` control's choice label rendered the raw box source `SubscriptBox[0, +]` instead of typesetting "0⁺".
- Root cause: `SubscriptBox[a, b]` reconstructs to the evaluable form `Subscript[a, b]`, keeping `b` bare so a real index like `Subscript[p, 0]` stays symbolic. But some subscripts are pure display glyphs with no meaning as code on their own (e.g. a one-sided-limit annotation using a bare `+`), and `Subscript[0, +]` doesn't parse — `+` alone isn't a complete expression. The reconstruction failed silently and fell back to showing the raw box source.
- Fix: when the subscript argument doesn't parse as a standalone expression, quote it as a string literal instead of leaving it bare — mirroring the existing fallback `OverscriptBox`/`UnderscriptBox` already use for their mark argument. A real index (identifier, number, or compound expression like `i+1`) still parses fine and stays bare, unaffected.

## Test plan

- [x] Added a unit test in `src/notebook.rs` covering the bare-glyph case, a plain indexed subscript, and a compound-expression subscript.
- [x] Added an end-to-end regression test in `woxi-studio/src/main.rs` building a `Manipulate` Setter whose choice label mixes plain text with the inline `SubscriptBox` annotation, asserting it typesets to "0₊".
- [x] `make test` — 27727 tests passed.
- [x] `make test-studio` — 193 tests passed.
- [x] `make format` (plus `cargo fmt -p woxi-studio` / `cargo clippy -p woxi-studio --fix`) — no further changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013EbvQ2EpMuPrLbV3vwuUkX)_