### PR TITLE
Fix invisible GridBox bracket markers corrupting notebook source

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1884,7 +1884,7 @@ fn unescape_string_inner(s: &str, code: bool) -> String {
           {
             result.push_str(&crate::syntax::substitute_private_use_glyphs(
               &ch.to_string(),
-            ))
+            ));
           } else {
             result.push('\\');
             result.push(':');

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1866,6 +1866,31 @@ fn unescape_string_inner(s: &str, code: bool) -> String {
         Some('>') => {
           // \> is a Wolfram string delimiter in box expressions – skip
         }
+        Some(':') => {
+          // `\:XXXX` is Wolfram's ASCII-safe hex escape for an arbitrary
+          // character. Box source uses it for characters that have no
+          // `\[Name]`, e.g. the pair of invisible bracket markers a
+          // FrontEnd wraps a `GridBox` matrix literal in
+          // (`RowBox[{"(", "\:f3a2", GridBox[…], "\:f3a2", ")"}]`).
+          // Substitute the same safe textual stand-in a `\[Name]` escape
+          // would draw as: the raw private-use code point isn't valid
+          // Wolfram Language source (unlike the handful of private-use
+          // operators, e.g. Rule's U+F522, that the parser does accept
+          // literally), so an unmapped invisible marker must become
+          // nothing rather than get inserted into the cell's code.
+          let hex: String = chars.by_ref().take(4).collect();
+          if let Some(ch) =
+            u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32)
+          {
+            result.push_str(&crate::syntax::substitute_private_use_glyphs(
+              &ch.to_string(),
+            ))
+          } else {
+            result.push('\\');
+            result.push(':');
+            result.push_str(&hex);
+          }
+        }
         Some('[') => {
           // Wolfram named character like \[Alpha] / \[CloseCurlyQuote].
           // Translate to Unicode when known; otherwise keep \[Name].
@@ -4995,5 +5020,36 @@ Cell[BoxData[\n\
     assert_eq!(strip_line_continuations("ab\\\\\ncd"), "ab\\\\\ncd");
     assert_eq!(strip_line_continuations("ab\\\r\ncd"), "abcd");
     assert_eq!(strip_line_continuations("plain\ntext"), "plain\ntext");
+  }
+
+  #[test]
+  fn test_input_cell_matrix_wrapped_in_invisible_gridbox_brackets() {
+    // The FrontEnd wraps a matrix literal that's an argument to a
+    // function call in a pair of invisible `\:f3a2` bracket markers
+    // alongside the visible `(` `)` — this is how a Wolfram Demonstrations
+    // Project notebook's Initialization code typesets e.g.
+    // `arrowHead = {Line[({{1, 2}, {3, 4}})]}` (independently written, not
+    // copied from any specific Demonstration). The markers carry no
+    // lexical meaning and must not leak into the reconstructed source.
+    let nb = r#"Notebook[{
+Cell[BoxData[RowBox[{"arrowHead", "=", RowBox[{"{", RowBox[{"Line", "[", RowBox[{"(", "\:f3a2", GridBox[{{"1", "2"}, {"3", "4"}}], "\:f3a2", ")"}], "]"}], "}"}]}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.style, CellStyle::Input);
+        assert_eq!(cell.content, "arrowHead={Line[({{1, 2}, {3, 4}})]}");
+        assert!(
+          !cell.content.contains('\u{f3a2}'),
+          "the invisible bracket marker must not appear in the reconstructed \
+           source: {:?}",
+          cell.content
+        );
+        crate::interpret(&cell.content).expect(
+          "the reconstructed source must be valid, evaluable Wolfram Language",
+        );
+      }
+      CellEntry::Group(_) => panic!("Expected single cell"),
+    }
   }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -700,6 +700,7 @@ fn private_use_glyph(c: char) -> Option<&'static str> {
     | '\u{F765}'                          // InvisibleComma
     | '\u{F76D}'                          // InvisibleApplication
     | '\u{F3A0}'                          // Null
+    | '\u{F3A2}'                          // invisible GridBox matrix bracket
     | '\u{F3B3}' | '\u{F3B4}'             // Invisible…ScriptBase
     | '\u{F3BA}' | '\u{F3BB}' | '\u{F3BC}' => "", // SpanFrom…
     _ => return None,


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook ("Turing Machine Causal Networks"), I found that its Initialization code failed to evaluate correctly, producing a cascade of `Rest::normal` / `First::normal` / `Part::partw` errors.

Root cause: the notebook's FrontEnd-generated box source wraps a matrix literal that's a function argument in a pair of invisible `\:f3a2` bracket markers alongside the visible parens, e.g.:

```
RowBox[{"(", "\:f3a2", GridBox[{...}], "\:f3a2", ")"}]
```

`notebook.rs` had no handling at all for `\:XXXX`-style hex character escapes in box source. The fallback path pushed the literal 6-character text `\:f3a2` straight into the reconstructed InputForm source, which is not valid Wolfram Language syntax. That broke parsing of the enclosing assignment, leaving the target symbol unbound, which then produced the cascade of downstream errors anywhere that symbol was used.

## Changes

- `src/notebook.rs`: decode `\:XXXX` hex escapes in `unescape_string_inner`, routing the resulting character through the existing private-use-glyph substitution table (the same safe-textual-form logic already used for `\[Name]` escapes).
- `src/syntax.rs`: register U+F3A2 in the no-glyph substitution table (alongside `Null`/`InvisibleSpace`) so it drops out of reconstructed source instead of leaking into it.
- Added a regression test (`test_input_cell_matrix_wrapped_in_invisible_gridbox_brackets`) with an independently-written example reproducing the same box-source pattern (not copied from the Demonstration itself), asserting the cell's reconstructed content is valid, evaluable Wolfram Language.

With this fix, the notebook's Initialization code parses and evaluates cleanly. One separate, unrelated limitation remains: one Initialization cell calls `Uncompress` on a real Wolfram-generated `Compress` string, and Woxi's `Uncompress` only supports the base64 encoding its own `Compress` produces, not Wolfram's actual (undocumented, seemingly ~90+ character alphabet) encoding — this is a distinct, deeper gap I did not attempt to fix here since I couldn't find a reliable reference for the exact algorithm and didn't want to guess at a proprietary binary format.

## Test plan

- [x] `make test` — all 27727 unit tests pass
- [x] `make format`
- [x] New regression test covers the fix directly
- [x] Verified against the actual downloaded Demonstration notebook: the `Rest`/`First`/`Part` error cascade is gone after this fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpXKZQbmF7e4gi5DUBCEWh)_