### PR TITLE
Fix Part index dropped after a function-call's Part in implicit multiplication

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4174,15 +4174,14 @@ fn parse_function_call_extended(pair: &Pair<Rule>) -> Expr {
       while i < inners.len() {
         if inners[i].as_rule() == Rule::PartIndexSuffix {
           if let Some(base) = factors.pop() {
-            let mut result = base;
-            for idx_pair in inners[i].clone().into_inner() {
-              let index = pair_to_expr(idx_pair);
-              result = Expr::Part {
-                expr: Box::new(result),
-                index: Box::new(index),
-              };
-            }
-            factors.push(result);
+            // Delegate to the shared Part-suffix handler rather than
+            // walking `PartIndexGroup` pairs by hand: `PartIndexGroup`'s
+            // span is the whole bracketed group (`[[1]]`), not the index
+            // expression, so feeding it straight to `pair_to_expr` fell
+            // through to the "unknown rule" fallback and stored the raw
+            // bracket text as the index instead of the parsed `1` — see
+            // `apply_part_index_suffix`.
+            factors.push(apply_part_index_suffix(base, inners[i].clone()));
           }
         } else if inners[i].as_rule() == Rule::ImplicitPowerSuffix {
           if let Some(base) = factors.pop() {

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -11568,6 +11568,41 @@ mod alternating_part_and_call_suffixes {
       "{1, 3}"
     );
   }
+
+  /// Regression: a `Part` extraction on a function call (`f[x][[i]]`),
+  /// immediately followed by implicit multiplication against a factor that
+  /// itself ends in a `Part` extraction (`g[[j]]`), lost the second
+  /// factor's index. The grammar puts both factors under
+  /// `FunctionCallExtended`'s `FunctionCallImplicitSuffix`, and the AST
+  /// builder for that suffix fed each `PartIndexGroup` pair (the `[[j]]`
+  /// span, delimiters included) straight to the generic expression
+  /// converter instead of extracting its index — falling through to the
+  /// "unknown rule" fallback, which stored the raw bracket text as the
+  /// index and left it to be re-parsed as if it were a whole program on
+  /// its own. That re-parse always fails (`[[j]]` is not a valid
+  /// standalone expression), surfacing as a parse error on code that had
+  /// already parsed successfully.
+  #[test]
+  fn a_call_s_part_may_multiply_another_part() {
+    assert_eq!(
+      interpret("f[x_] := {x, x + 1}; g = {10, 20}; f[1][[1]] g[[2]]").unwrap(),
+      "20"
+    );
+    // The second factor's index need not be a bare integer literal either.
+    assert_eq!(
+      interpret(
+        "f[x_] := {x, x + 1}; g = {10, 20, 30}; n = 3; f[1][[2]] g[[n]]"
+      )
+      .unwrap(),
+      "60"
+    );
+    // A plain (non-function-call) first factor already worked; keep it
+    // covered alongside the call-based case above.
+    assert_eq!(
+      interpret("g = {10, 20}; h = {1, 2}; h[[1]] g[[2]]").unwrap(),
+      "20"
+    );
+  }
 }
 
 /// `+=`, `-=`, `*=` and `/=` also take a function-call target — the shape a


### PR DESCRIPTION
## Summary

Found while checking Woxi Studio's support for a random Wolfram Demonstrations Project notebook (title: "Evolutes of Some Basic Curves"): a helper-function body written as `f[x][[i]] g[x][[j]]` — implicit multiplication between a `Part` extraction on a function call and another `Part`-indexed factor — was reported by Woxi Studio as a parse error, even though the cell had already parsed successfully once.

- **Root cause**: `FunctionCallExtended`'s implicit-multiplication suffix (the grammar node that covers `f[x][[i]] g[x][[j]]` as one unit) built the second factor's `Part` index by feeding each `PartIndexGroup` pair straight to the generic expression converter. A `PartIndexGroup`'s span is the *whole* bracketed group (`[[j]]`), not the index expression inside it, so the converter fell through to its "unknown rule" fallback and stored the raw bracket text — brackets included — as the index, to be re-parsed later as if it were a standalone program. That re-parse always fails, since `[[j]]` alone isn't a valid top-level expression, which is what surfaced as a parse error on code that had already parsed fine.
- **Fix**: the same suffix-parsing closure already had sibling cases (power, factorial, `Repeated`) built correctly, and the ordinary (non-function-call) implicit-multiplication rule handled its own `Part` suffix correctly too, via a shared `apply_part_index_suffix` helper — this one case just hadn't been kept in sync. Delegate to that helper instead of duplicating (and getting wrong) the same logic.

## Verification

- Extracted the notebook's box-form cells through `box_source_to_expression`/`parse_notebook` and evaluated the resulting source with `cargo run -- eval`; all three input cells (curve/derivative helpers, osculating-circle formulas, and the full `Manipulate[...]` call) now evaluate correctly, including `ExportString[..., "SVG"]` producing valid graphics for the `Show`/`ParametricPlot`/`ListPlot`/`Manipulate` pipeline.
- `parse_notebook` parses the full 709KB notebook file without error.
- Added a regression test in `tests/interpreter_tests/syntax.rs` using independently written minimal expressions that isolate the grammar/AST bug (not copied from the demonstration).
- `make test` (27,635 tests via `cargo nextest`) passes.
- `make format` runs cleanly with no additional changes.

Note: `wolframscript` was not available in this environment, so exact-output parity with Wolfram couldn't be re-verified here beyond the existing test suite's own comparisons; the fixed behavior (`f[1][[1]] g[[2]]` evaluating instead of raising a spurious parse error) matches standard Wolfram Language `Part`/implicit-multiplication semantics.

## Test plan

- [x] `make test`
- [x] `make format`
- [x] Manually evaluated all 3 real cells from the source notebook end-to-end, including SVG export of the `Manipulate` graphics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHLUgjkQb4rd94psbipcpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHLUgjkQb4rd94psbipcpc)_