### PR TITLE
Implement GraphData with a self-contained named-graph dataset

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -620,7 +620,7 @@ Specularity,Specifies the specular highlight of 3D surfaces,✅,pure,6.0,576
 Minimize,Global symbolic minimization of a function over variables with optional constraints and an optional Reals or Integers domain,✅,pure,5.0,577
 Begin,Switches $Context so names read afterwards belong to that context,✅,effectful,1.0,578
 RepeatedTiming,Time expression evaluation with repeated sampling,✅,effectful,10.1,579
-GraphData,,🚫,,6.0,580
+GraphData,Self-contained named-graph knowledge base backing GraphData[] (known names) GraphData[name] (the Graph[...] object) and GraphData[name property] (VertexCount/EdgeCount/VertexList/EdgeList/EdgeRules/AdjacencyMatrix/Image/Name) -- not the full Wolfram Knowledgebase graph atlas,✅,pure,6.0,580
 FileNameJoin,Join file path components,✅,pure,7.0,582
 ToFileName,Join directory path components into a file name string,✅,pure,1.0,
 InverseFunction,Represents the inverse of a function or geometric transform,✅,pure,2.0,584

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -1985,6 +1985,9 @@ fn evaluate_function_call_ast_inner(
     "CountryData" => {
       return crate::functions::country_data::country_data_ast(args);
     }
+    "GraphData" => {
+      return crate::functions::graph_data::graph_data_ast(args);
+    }
     "ExternalIdentifier" => {
       return crate::functions::wikidata_ast::external_identifier_ast(args);
     }

--- a/src/functions/graph_data.rs
+++ b/src/functions/graph_data.rs
@@ -1,0 +1,303 @@
+//! Minimal built-in named-graph knowledge base.
+//!
+//! Woxi has no connection to the Wolfram Knowledgebase's graph atlas (which
+//! enumerates thousands of graphs), but a self-contained, deterministic set
+//! of common named and parametrized graphs is easy to bundle. This backs
+//! `GraphData[]` (every known name), `GraphData[name]` (the `Graph[...]`
+//! object), and `GraphData[name, "property"]`.
+//!
+//! Names follow Wolfram's usual convention (`"PetersenGraph"`,
+//! `"CompleteGraphK5"`, `"CycleGraphC6"`, …) but this is not meant to match
+//! the Wolfram Knowledgebase's full enumeration to the last entry — it gives
+//! Woxi a reproducible graph dataset covering the common named graphs and
+//! small parametrized families (complete, cycle, path, star, wheel,
+//! complete bipartite).
+
+#[allow(unused_imports)]
+use super::*;
+
+struct NamedGraph {
+  name: String,
+  n: usize,
+  /// 1-based vertex labels.
+  edges: Vec<(usize, usize)>,
+}
+
+fn special_graphs() -> Vec<NamedGraph> {
+  let mut octahedral_edges = Vec::new();
+  for i in 1..=6 {
+    for j in (i + 1)..=6 {
+      let antipodal = (i, j) == (1, 2) || (i, j) == (3, 4) || (i, j) == (5, 6);
+      if !antipodal {
+        octahedral_edges.push((i, j));
+      }
+    }
+  }
+  vec![
+    NamedGraph {
+      name: "PetersenGraph".to_string(),
+      n: 10,
+      edges: vec![
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        (5, 1),
+        (6, 8),
+        (8, 10),
+        (10, 7),
+        (7, 9),
+        (9, 6),
+        (1, 6),
+        (2, 7),
+        (3, 8),
+        (4, 9),
+        (5, 10),
+      ],
+    },
+    NamedGraph {
+      name: "BullGraph".to_string(),
+      n: 5,
+      edges: vec![(1, 2), (2, 3), (1, 3), (1, 4), (2, 5)],
+    },
+    NamedGraph {
+      name: "DiamondGraph".to_string(),
+      n: 4,
+      edges: vec![(1, 2), (1, 3), (1, 4), (2, 3), (2, 4)],
+    },
+    NamedGraph {
+      name: "HouseGraph".to_string(),
+      n: 5,
+      edges: vec![(1, 2), (2, 3), (3, 4), (4, 1), (1, 5), (2, 5)],
+    },
+    NamedGraph {
+      name: "ButterflyGraph".to_string(),
+      n: 5,
+      edges: vec![(1, 2), (1, 3), (2, 3), (3, 4), (3, 5), (4, 5)],
+    },
+    NamedGraph {
+      name: "TetrahedralGraph".to_string(),
+      n: 4,
+      edges: vec![(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)],
+    },
+    NamedGraph {
+      name: "CubicalGraph".to_string(),
+      n: 8,
+      edges: vec![
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 1),
+        (5, 6),
+        (6, 7),
+        (7, 8),
+        (8, 5),
+        (1, 5),
+        (2, 6),
+        (3, 7),
+        (4, 8),
+      ],
+    },
+    NamedGraph {
+      name: "OctahedralGraph".to_string(),
+      n: 6,
+      edges: octahedral_edges,
+    },
+  ]
+}
+
+fn complete_graphs() -> Vec<NamedGraph> {
+  (3..=7)
+    .map(|n| {
+      let mut edges = Vec::new();
+      for i in 1..=n {
+        for j in (i + 1)..=n {
+          edges.push((i, j));
+        }
+      }
+      NamedGraph {
+        name: format!("CompleteGraphK{n}"),
+        n,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn cycle_graphs() -> Vec<NamedGraph> {
+  (3..=15)
+    .map(|n| {
+      let mut edges: Vec<(usize, usize)> = (1..n).map(|i| (i, i + 1)).collect();
+      edges.push((n, 1));
+      NamedGraph {
+        name: format!("CycleGraphC{n}"),
+        n,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn path_graphs() -> Vec<NamedGraph> {
+  (2..=15)
+    .map(|n| {
+      let edges: Vec<(usize, usize)> = (1..n).map(|i| (i, i + 1)).collect();
+      NamedGraph {
+        name: format!("PathGraphP{n}"),
+        n,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn star_graphs() -> Vec<NamedGraph> {
+  (3..=15)
+    .map(|n| {
+      let edges: Vec<(usize, usize)> = (2..=n).map(|i| (1, i)).collect();
+      NamedGraph {
+        name: format!("StarGraphS{n}"),
+        n,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn wheel_graphs() -> Vec<NamedGraph> {
+  // Hub is vertex 1; the rim (vertices 2..=n) forms a cycle, and every rim
+  // vertex has a spoke back to the hub.
+  (4..=10)
+    .map(|n| {
+      let mut edges: Vec<(usize, usize)> = (2..n).map(|i| (i, i + 1)).collect();
+      edges.push((n, 2));
+      edges.extend((2..=n).map(|i| (1, i)));
+      NamedGraph {
+        name: format!("WheelGraphW{n}"),
+        n,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn complete_bipartite_graphs() -> Vec<NamedGraph> {
+  const SIZES: &[(usize, usize)] = &[
+    (2, 3),
+    (2, 4),
+    (2, 5),
+    (2, 6),
+    (2, 7),
+    (3, 3),
+    (3, 4),
+    (3, 5),
+    (3, 6),
+    (4, 4),
+  ];
+  SIZES
+    .iter()
+    .map(|&(m, k)| {
+      let mut edges = Vec::new();
+      for i in 1..=m {
+        for j in (m + 1)..=(m + k) {
+          edges.push((i, j));
+        }
+      }
+      NamedGraph {
+        name: format!("CompleteBipartiteGraphK{m}{k}"),
+        n: m + k,
+        edges,
+      }
+    })
+    .collect()
+}
+
+fn all_graphs() -> Vec<NamedGraph> {
+  let mut graphs = Vec::new();
+  graphs.extend(special_graphs());
+  graphs.extend(complete_graphs());
+  graphs.extend(cycle_graphs());
+  graphs.extend(path_graphs());
+  graphs.extend(star_graphs());
+  graphs.extend(wheel_graphs());
+  graphs.extend(complete_bipartite_graphs());
+  graphs
+}
+
+fn lookup(name: &str) -> Option<NamedGraph> {
+  all_graphs().into_iter().find(|g| g.name == name)
+}
+
+fn missing_not_available() -> Expr {
+  call1("Missing", Expr::String("NotAvailable".to_string()))
+}
+
+/// The `Graph[vertices, edges]` object for a named graph, matching the
+/// `Graph[List[...], List[UndirectedEdge[...] ...]]` shape every other
+/// graph function (`VertexCount`, `EdgeRules`, `GraphPlot`, …) expects.
+fn graph_expr(g: &NamedGraph) -> Expr {
+  let verts: Vec<Expr> = (1..=g.n as i128).map(Expr::Integer).collect();
+  let edges: Vec<Expr> = g
+    .edges
+    .iter()
+    .map(|&(a, b)| {
+      call(
+        "UndirectedEdge",
+        vec![Expr::Integer(a as i128), Expr::Integer(b as i128)],
+      )
+    })
+    .collect();
+  call(
+    "Graph",
+    vec![Expr::List(verts.into()), Expr::List(edges.into())],
+  )
+}
+
+/// A property spec may be given as a string (`"VertexCount"`) or, as some
+/// older Demonstrations do, a bare symbol (`Image`).
+fn property_name(e: &Expr) -> Option<String> {
+  match e {
+    Expr::String(s) => Some(s.clone()),
+    Expr::Identifier(s) => Some(s.clone()),
+    _ => None,
+  }
+}
+
+fn graph_property(
+  g: &NamedGraph,
+  prop: &str,
+) -> Result<Expr, InterpreterError> {
+  match prop {
+    "VertexCount" | "EdgeCount" | "VertexList" | "EdgeList" | "EdgeRules"
+    | "AdjacencyMatrix" => {
+      crate::evaluator::evaluate_expr_to_expr(&call1(prop, graph_expr(g)))
+    }
+    "Image" | "Icon" | "Plot" | "Graph" => Ok(graph_expr(g)),
+    "Name" | "StandardName" => Ok(Expr::String(g.name.clone())),
+    _ => Ok(missing_not_available()),
+  }
+}
+
+pub fn graph_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  match args {
+    [] => {
+      let names: Vec<Expr> = all_graphs()
+        .into_iter()
+        .map(|g| Expr::String(g.name))
+        .collect();
+      Ok(Expr::List(names.into()))
+    }
+    [Expr::String(name)] => match lookup(name) {
+      Some(g) => Ok(graph_expr(&g)),
+      None => Ok(missing_not_available()),
+    },
+    [Expr::String(name), prop] => match lookup(name) {
+      Some(g) => match property_name(prop) {
+        Some(p) => graph_property(&g, &p),
+        None => Ok(unevaluated("GraphData", args)),
+      },
+      None => Ok(missing_not_available()),
+    },
+    _ => Ok(unevaluated("GraphData", args)),
+  }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -42,6 +42,7 @@ pub mod geo_math;
 pub mod geographics;
 pub mod geometric_test_ast;
 pub mod graph;
+pub mod graph_data;
 pub mod graphics;
 pub mod graphicsbox;
 pub mod groebner_ast;

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -7242,3 +7242,135 @@ mod topological_sort {
     assert!(result.starts_with("TopologicalSort["));
   }
 }
+
+// GraphData backs itself with a self-contained, curated set of named and
+// parametrized graphs (see src/functions/graph_data.rs) rather than the
+// full Wolfram Knowledgebase graph atlas.
+mod graph_data {
+  use super::*;
+
+  #[test]
+  fn no_args_lists_known_names() {
+    assert_eq!(
+      interpret("MemberQ[GraphData[], \"PetersenGraph\"]").unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret("MemberQ[GraphData[], \"CompleteGraphK4\"]").unwrap(),
+      "True"
+    );
+    let count = interpret("Length[GraphData[]]").unwrap();
+    assert!(
+      count.parse::<i64>().unwrap() > 50,
+      "expected a sizeable curated set, got {count}"
+    );
+  }
+
+  #[test]
+  fn no_args_has_no_duplicate_names() {
+    assert_eq!(
+      interpret("Length[GraphData[]] == Length[Union[GraphData[]]]").unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn named_graph_returns_graph_object() {
+    assert_eq!(
+      interpret("Head[GraphData[\"PetersenGraph\"]]").unwrap(),
+      "Graph"
+    );
+  }
+
+  #[test]
+  fn vertex_and_edge_count_properties() {
+    assert_eq!(
+      interpret("GraphData[\"PetersenGraph\", \"VertexCount\"]").unwrap(),
+      "10"
+    );
+    assert_eq!(
+      interpret("GraphData[\"PetersenGraph\", \"EdgeCount\"]").unwrap(),
+      "15"
+    );
+    assert_eq!(
+      interpret("GraphData[\"CompleteGraphK4\", \"VertexCount\"]").unwrap(),
+      "4"
+    );
+    assert_eq!(
+      interpret("GraphData[\"CompleteGraphK4\", \"EdgeCount\"]").unwrap(),
+      "6"
+    );
+    assert_eq!(
+      interpret("GraphData[\"CycleGraphC6\", \"VertexCount\"]").unwrap(),
+      "6"
+    );
+    assert_eq!(
+      interpret("GraphData[\"CycleGraphC6\", \"EdgeCount\"]").unwrap(),
+      "6"
+    );
+  }
+
+  #[test]
+  fn edge_count_matches_vertex_count_and_edge_rules_for_every_graph() {
+    // Every curated graph's VertexCount/EdgeCount/EdgeRules stay consistent
+    // with the underlying Graph[...] object.
+    let result = interpret(
+      "AllTrue[GraphData[], (GraphData[#, \"EdgeCount\"] == \
+       Length[GraphData[#, \"EdgeRules\"]] && \
+       VertexCount[GraphData[#]] == GraphData[#, \"VertexCount\"] && \
+       EdgeCount[GraphData[#]] == GraphData[#, \"EdgeCount\"]) &]",
+    )
+    .unwrap();
+    assert_eq!(result, "True");
+  }
+
+  #[test]
+  fn edge_rules_are_rules_between_vertices() {
+    assert_eq!(
+      interpret("GraphData[\"CompleteGraphK4\", \"EdgeRules\"]").unwrap(),
+      "{1 -> 2, 1 -> 3, 1 -> 4, 2 -> 3, 2 -> 4, 3 -> 4}"
+    );
+  }
+
+  #[test]
+  fn unknown_name_gives_missing() {
+    assert_eq!(
+      interpret("GraphData[\"NotARealGraphName\"]").unwrap(),
+      "Missing[NotAvailable]"
+    );
+    assert_eq!(
+      interpret("GraphData[\"NotARealGraphName\", \"VertexCount\"]").unwrap(),
+      "Missing[NotAvailable]"
+    );
+  }
+
+  #[test]
+  fn unknown_property_gives_missing() {
+    assert_eq!(
+      interpret("GraphData[\"PetersenGraph\", \"NotAProperty\"]").unwrap(),
+      "Missing[NotAvailable]"
+    );
+  }
+
+  #[test]
+  fn bare_symbol_property_is_accepted_like_a_string() {
+    // Some older Demonstrations pass the property as a bare symbol
+    // (e.g. `GraphData[name, Image]`) instead of a string.
+    assert_eq!(
+      interpret("Head[GraphData[\"PetersenGraph\", Image]]").unwrap(),
+      "Graph"
+    );
+  }
+
+  #[test]
+  fn select_by_edge_count_matches_direct_filtering() {
+    // Mirrors the `Select[GraphData[], Inequality[4, LessEqual, ..., Less,
+    // 20] &]` pattern used to pick small graphs for a substitution system.
+    let result = interpret(
+      "Length[Select[GraphData[], \
+       4 <= GraphData[#, \"EdgeCount\"] < 20 &]] > 0",
+    )
+    .unwrap();
+    assert_eq!(result, "True");
+  }
+}


### PR DESCRIPTION
## Summary

- A randomly-fetched Wolfram Demonstration notebook ("Automata Generative Networks 2") failed to fully evaluate in Woxi Studio because it calls `GraphData[]` (list all named graphs) and `GraphData[name, "property"]` (query `VertexCount`/`EdgeCount`/`EdgeRules`/etc.), which Woxi reported as not yet implemented — this stopped the notebook's `Manipulate` from ever seeding its initial state.
- Adds `src/functions/graph_data.rs`: a self-contained, deterministic named-graph dataset (special named graphs — Petersen, Bull, Diamond, House, Butterfly, Tetrahedral, Cubical, Octahedral — plus the complete/cycle/path/star/wheel/complete-bipartite parametrized families), following the same "curated knowledge base, not the full Wolfram Knowledgebase" approach already used by `CountryData`/`ElementData`.
- Wires up `GraphData[]`, `GraphData[name]`, and `GraphData[name, property]` in the evaluator dispatch, delegating `VertexCount`/`EdgeCount`/`VertexList`/`EdgeList`/`EdgeRules`/`AdjacencyMatrix` to the existing `Graph[...]` property implementations (via `evaluate_expr_to_expr`) rather than re-implementing them.
- Updates `functions.csv` to mark `GraphData` as implemented.

## Verification

- The notebook now evaluates end-to-end in Woxi Studio (`All cells evaluated`, 293/293 cells) instead of erroring on `GraphData`, and its cellular-automaton `ArrayPlot` — which is built from the `GraphData`-derived substitution graph — renders correctly with real graph-derived data.
- `make test` — all 27,736 tests pass.
- `make format` — clean.

## Test plan

- [x] `cargo test --test interpreter_tests graph_data` — new unit tests for `GraphData[]`, per-name lookup, `VertexCount`/`EdgeCount`/`EdgeRules` consistency, unknown name/property → `Missing[NotAvailable]`, bare-symbol property spec, and `Select`-by-`EdgeCount` filtering (mirrors the notebook's own usage pattern)
- [x] `make test` (full suite)
- [x] `make format`
- [x] Manually opened the fetched Demonstration notebook in Woxi Studio and confirmed it evaluates without the previous "not yet implemented" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013zs3zZPKKSxQxZpotgpBxT)_