### PR TITLE
Support legacy PieCharts`PieChart in demonstration Manipulates

### DIFF
--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -638,6 +638,37 @@ fn load_needed_context(ctx: &str) -> Result<(), InterpreterError> {
   Ok(())
 }
 
+/// Rewrite a legacy `PieCharts\`` option to the option `PieChart` accepts
+/// today, so `PieCharts\`PieChart` can be normalized to a plain `PieChart`
+/// call (see the qualified-name normalization below) without its options
+/// being left unevaluated under their old, unrecognized names.
+fn normalize_piecharts_option(arg: &Expr) -> Expr {
+  match arg {
+    Expr::Rule {
+      pattern,
+      replacement,
+    } => {
+      let renamed = match pattern.as_ref() {
+        Expr::Identifier(id) if id == "PieCharts`PieStyle" => {
+          Some("ChartStyle")
+        }
+        Expr::Identifier(id) if id == "PieCharts`PieLabels" => {
+          Some("ChartLabels")
+        }
+        _ => None,
+      };
+      match renamed {
+        Some(new_name) => Expr::Rule {
+          pattern: Box::new(Expr::Identifier(new_name.to_string())),
+          replacement: replacement.clone(),
+        },
+        None => arg.clone(),
+      }
+    }
+    other => other.clone(),
+  }
+}
+
 fn evaluate_function_call_ast_inner(
   name: &str,
   args: &[Expr],
@@ -649,9 +680,25 @@ fn evaluate_function_call_ast_inner(
   // one flat namespace (see `is_standard_distribution_context`), so a
   // qualified call to one of these is normalized to its modern name before
   // dispatch rather than reimplementing the legacy function separately.
+  let original_name = name;
   let name = match name {
     "VectorFieldPlots`ListVectorFieldPlot" => "ListVectorPlot",
+    "PieCharts`PieChart" => "PieChart",
     other => other,
+  };
+
+  // `PieCharts`PieChart` renamed its options relative to the modern
+  // `PieChart` (`PieStyle` -> `ChartStyle`, `PieLabels` -> `ChartLabels`);
+  // translate them alongside the head so old demonstrations still render.
+  let normalized_pie_args;
+  let args: &[Expr] = if original_name == "PieCharts`PieChart" {
+    normalized_pie_args = args
+      .iter()
+      .map(normalize_piecharts_option)
+      .collect::<Vec<_>>();
+    &normalized_pie_args
+  } else {
+    args
   };
 
   // Every graph query/analysis function below documents its first argument

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -643,28 +643,36 @@ fn load_needed_context(ctx: &str) -> Result<(), InterpreterError> {
 /// call (see the qualified-name normalization below) without its options
 /// being left unevaluated under their old, unrecognized names.
 fn normalize_piecharts_option(arg: &Expr) -> Expr {
+  fn renamed_option(pattern: &Expr) -> Option<&'static str> {
+    match pattern {
+      Expr::Identifier(id) if id == "PieCharts`PieStyle" => Some("ChartStyle"),
+      Expr::Identifier(id) if id == "PieCharts`PieLabels" => {
+        Some("ChartLabels")
+      }
+      _ => None,
+    }
+  }
   match arg {
     Expr::Rule {
       pattern,
       replacement,
-    } => {
-      let renamed = match pattern.as_ref() {
-        Expr::Identifier(id) if id == "PieCharts`PieStyle" => {
-          Some("ChartStyle")
-        }
-        Expr::Identifier(id) if id == "PieCharts`PieLabels" => {
-          Some("ChartLabels")
-        }
-        _ => None,
-      };
-      match renamed {
-        Some(new_name) => Expr::Rule {
-          pattern: Box::new(Expr::Identifier(new_name.to_string())),
-          replacement: replacement.clone(),
-        },
-        None => arg.clone(),
-      }
-    }
+    } => match renamed_option(pattern) {
+      Some(new_name) => Expr::Rule {
+        pattern: Box::new(Expr::Identifier(new_name.to_string())),
+        replacement: replacement.clone(),
+      },
+      None => arg.clone(),
+    },
+    Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } => match renamed_option(pattern) {
+      Some(new_name) => Expr::RuleDelayed {
+        pattern: Box::new(Expr::Identifier(new_name.to_string())),
+        replacement: replacement.clone(),
+      },
+      None => arg.clone(),
+    },
     other => other.clone(),
   }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -10900,6 +10900,20 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    // `Manipulate` bodies set chart options from control variables with
+    // `:>` (RuleDelayed) rather than `->`, so the legacy-option rename must
+    // handle both rule forms the same way `option_name_value` already does
+    // for modern `PieChart` options.
+    #[test]
+    fn legacy_pie_chart_style_option_with_rule_delayed() {
+      assert_eq!(
+        export_svg(
+          "PieCharts`PieChart[{1, 1, 1}, PieCharts`PieStyle :> {Red, Green, Blue}]"
+        ),
+        export_svg("PieChart[{1, 1, 1}, ChartStyle -> {Red, Green, Blue}]")
+      );
+    }
+
     #[test]
     fn stream_plot_basic() {
       insta::assert_snapshot!(export_svg(

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -10855,6 +10855,51 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    // Demonstrations predating the modern `PieChart` load the legacy
+    // `PieCharts`` package and call its qualified `PieChart`, whose
+    // `PieStyle`/`PieLabels` options were renamed to `ChartStyle`/
+    // `ChartLabels` — so both the head and its options must be normalized
+    // for the picture to come out the same.
+    #[test]
+    fn legacy_pie_chart_matches_pie_chart() {
+      assert_eq!(
+        export_svg("PieCharts`PieChart[{1, 1, 1}]"),
+        export_svg("PieChart[{1, 1, 1}]")
+      );
+    }
+
+    #[test]
+    fn legacy_pie_chart_style_option_matches_chart_style() {
+      assert_eq!(
+        export_svg(
+          "PieCharts`PieChart[{1, 1, 1}, PieCharts`PieStyle -> {Red, Green, Blue}]"
+        ),
+        export_svg("PieChart[{1, 1, 1}, ChartStyle -> {Red, Green, Blue}]")
+      );
+    }
+
+    #[test]
+    fn legacy_pie_chart_labels_option_matches_chart_labels() {
+      assert_eq!(
+        export_svg(
+          "PieCharts`PieChart[{1, 1, 1}, PieCharts`PieLabels -> {\"a\", \"b\", \"c\"}]"
+        ),
+        export_svg("PieChart[{1, 1, 1}, ChartLabels -> {\"a\", \"b\", \"c\"}]")
+      );
+    }
+
+    #[test]
+    fn legacy_pie_chart_style_and_labels_together() {
+      assert_eq!(
+        export_svg(
+          "PieCharts`PieChart[{1, 1, 1}, PieCharts`PieStyle -> {Red, Green, Blue}, PieCharts`PieLabels -> {\"a\", \"b\", \"c\"}]"
+        ),
+        export_svg(
+          "PieChart[{1, 1, 1}, ChartStyle -> {Red, Green, Blue}, ChartLabels -> {\"a\", \"b\", \"c\"}]"
+        )
+      );
+    }
+
     #[test]
     fn stream_plot_basic() {
       insta::assert_snapshot!(export_svg(


### PR DESCRIPTION
## Summary

As part of a scheduled compatibility check, I downloaded a random Wolfram Demonstration ("Multiplying Probabilities") and tested it against Woxi Studio's notebook loader/`Manipulate` renderer.

The demonstration's `Manipulate` body calls a helper that in turn calls `PieCharts\`PieChart` after `Get["PieCharts\`"]` — the legacy pie-chart package that shipped with Mathematica before `Statistics\`` / the modern `PieChart` existed. Woxi has no package system, so `PieCharts\`` is treated as one of the standard-distribution contexts whose `Get`/`Needs` is a no-op — but the qualified `PieCharts\`PieChart` call itself was never mapped to anything, so it stayed unevaluated instead of drawing a chart, and the demonstration's Manipulate couldn't render its graphics.

This mirrors an existing pattern already in the codebase (`VectorFieldPlots\`ListVectorFieldPlot` → `ListVectorPlot`): normalize the legacy qualified call to its modern equivalent rather than reimplementing the legacy function separately.

- `PieCharts\`PieChart[...]` is normalized to `PieChart[...]`.
- Its options are translated to their modern names: `PieCharts\`PieStyle` → `ChartStyle`, `PieCharts\`PieLabels` → `ChartLabels`.

No content from the downloaded (copyrighted) demonstration notebook is included here — the change and its tests are written against the public, documented behavior of the legacy `PieCharts` package and the modern `PieChart` function.

## Test plan

- [x] Added 4 regression tests in `tests/interpreter_tests/graphics.rs` asserting `PieCharts\`PieChart[...]` (with and without `PieStyle`/`PieLabels`) renders identically to the equivalent modern `PieChart[...]` call.
- [x] `make test` (27,781 tests via `cargo nextest`) passes.
- [x] `make format` run.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qCm3g87z5z34vA3wCNyWw)_