### PR TITLE
Support coupled-flux and chained-equality PDE boundary conditions

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -705,6 +705,54 @@ fn rewrite_pde_rhs(
   if failed.get() { None } else { Some(mapped) }
 }
 
+/// Rewrite every unknown's bare occurrence at the boundary point `x0`
+/// (`u_names[j][t_name, x0]`, in whichever argument order `swap` selects)
+/// into the placeholder identifier `NDSolve$U{j}` — how a Neumann boundary
+/// condition's right-hand side couples to the unknowns' own current
+/// boundary values, e.g. a Robin-type flux condition
+/// `Λ Exp[-α (a[0, t] - b[0, t])]` that depends on both species'
+/// concentrations at the electrode surface. The method-of-lines
+/// integrator (`try_solve_pde_system`'s `derivative` closure) evaluates
+/// the compiled result each step from the already-known grid values at
+/// that boundary. Returns `None` when some unknown appears at a point
+/// other than `x0`, or through a derivative — shapes this boundary solver
+/// doesn't attempt.
+fn rewrite_pde_bc_rhs(
+  expr: &Expr,
+  u_names: &[String],
+  t_name: &str,
+  x0: f64,
+  swap: bool,
+) -> Option<Expr> {
+  for (j, name) in u_names.iter().enumerate() {
+    if let Some((dt, dx, t_arg, x_arg)) = match_pde_term_roles(expr, name, swap)
+    {
+      if dt != 0
+        || dx != 0
+        || !matches!(&t_arg, Expr::Identifier(n) if n == t_name)
+        || !nval_to_f64(&x_arg)
+          .is_some_and(|v| (v - x0).abs() <= 1e-9 * x0.abs().max(1.0))
+      {
+        return None;
+      }
+      return Some(Expr::Identifier(format!("NDSolve$U{j}")));
+    }
+  }
+  let failed = std::cell::Cell::new(false);
+  let mapped = map_children(expr, &|c| {
+    if failed.get() {
+      return c.clone();
+    }
+    if let Some(r) = rewrite_pde_bc_rhs(c, u_names, t_name, x0, swap) {
+      r
+    } else {
+      failed.set(true);
+      c.clone()
+    }
+  });
+  if failed.get() { None } else { Some(mapped) }
+}
+
 /// `NDSolve[eqns, u, {v1, v1min, v1max}, {v2, v2min, v2max}]` — one or
 /// several coupled parabolic PDEs in one space dimension (a
 /// diffusion/reaction/convection shape), solved by the method of lines:
@@ -753,6 +801,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
     Expr::List(items) => items.to_vec(),
     other => vec![other.clone()],
   };
+  let eq_items = flatten_chained_pde_equalities(&eq_items);
   if eq_items.len() != 4 * u_names.len() {
     return Ok(None);
   }
@@ -767,6 +816,40 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
     }
   }
   Ok(None)
+}
+
+/// Expand a chained equality `e0 == e1 == ... == e_{k-1}` (`k > 2`
+/// operands, every operator `==`) into the `k - 1` pairwise equations
+/// `e_i == e_{k-1}` for `i` from `0` to `k - 2`. `NDSolve` demonstrations
+/// commonly use this shorthand to state an initial condition and a
+/// same-valued boundary condition in a single equation, e.g.
+/// `u[x, t0] == u[xmax, t] == c` for both `u[x, t0] == c` (the initial
+/// condition) and `u[xmax, t] == c` (a Dirichlet boundary condition).
+/// Transitivity makes every such pair a valid consequence of the chain, so
+/// this expansion is lossless. Equations that aren't a longer chain pass
+/// through unchanged.
+fn flatten_chained_pde_equalities(items: &[Expr]) -> Vec<Expr> {
+  let mut out = Vec::with_capacity(items.len());
+  for item in items {
+    if let Expr::Comparison {
+      operands,
+      operators,
+    } = item
+      && operands.len() > 2
+      && operators.iter().all(|op| *op == ComparisonOp::Equal)
+    {
+      let last = operands.len() - 1;
+      for operand in &operands[..last] {
+        out.push(Expr::Comparison {
+          operands: vec![operand.clone(), operands[last].clone()],
+          operators: vec![ComparisonOp::Equal],
+        });
+      }
+    } else {
+      out.push(item.clone());
+    }
+  }
+  out
 }
 
 /// One unknown's compiled evolution/initial/boundary functions.
@@ -816,6 +899,209 @@ fn try_solve_pde_system(
     bc_lo: PdeBc,
     bc_hi: PdeBc,
   }
+
+  /// Try to match `eq` as a linear flux-conservation boundary condition
+  /// shared between several unknowns at the same end of the space domain
+  /// — e.g. `D[a[x, t], x] + dBA D[b[x, t], x] == 0` at `x == 0`, the
+  /// no-accumulation condition tying two coupled species' fluxes at a
+  /// reacting interface — rather than a single unknown's own condition.
+  /// Requires one side of the equation to be identically zero, and every
+  /// unknown referenced besides `target` (at index `target_idx`, not yet
+  /// in `raw_specs`) to already have its own Neumann condition resolved at
+  /// this same end (`raw_specs[j].bc_lo`/`bc_hi`, one entry per unknown
+  /// processed so far). Solving the linear relation for `target`'s flux —
+  /// substituting each other referenced unknown's already-known flux
+  /// expression — yields `target`'s own (derived) Neumann condition.
+  /// Returns `None` when the equation isn't in this shape, or references
+  /// an unknown whose own condition at this end isn't resolved yet.
+  fn try_coupled_flux_bc(
+    eq: &Expr,
+    target_idx: usize,
+    u_names: &[String],
+    raw_specs: &[RawSpec],
+    t_name: &str,
+    x0: f64,
+    at_lo: bool,
+    swap: bool,
+  ) -> Option<PdeBc> {
+    fn is_zero_literal(e: &Expr) -> bool {
+      match e {
+        Expr::Integer(0) => true,
+        Expr::Real(v) => v.abs() < 1e-12,
+        _ => false,
+      }
+    }
+    fn is_one_literal(e: &Expr) -> bool {
+      matches!(e, Expr::Integer(1))
+    }
+    fn neg_expr(e: Expr) -> Expr {
+      if is_zero_literal(&e) {
+        return e;
+      }
+      Expr::UnaryOp {
+        op: UnaryOperator::Minus,
+        operand: Box::new(e),
+      }
+    }
+    fn add_expr(a: Expr, b: Expr) -> Expr {
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        left: Box::new(a),
+        right: Box::new(b),
+      }
+    }
+    fn mul_expr(coeff: Expr, e: Expr) -> Expr {
+      if is_one_literal(&coeff) {
+        return e;
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left: Box::new(coeff),
+        right: Box::new(e),
+      }
+    }
+    fn flatten_additive_signed(
+      expr: &Expr,
+      sign: f64,
+      out: &mut Vec<(f64, Expr)>,
+    ) {
+      match expr {
+        Expr::BinaryOp {
+          op: BinaryOperator::Plus,
+          left,
+          right,
+        } => {
+          flatten_additive_signed(left, sign, out);
+          flatten_additive_signed(right, sign, out);
+        }
+        Expr::BinaryOp {
+          op: BinaryOperator::Minus,
+          left,
+          right,
+        } => {
+          flatten_additive_signed(left, sign, out);
+          flatten_additive_signed(right, -sign, out);
+        }
+        Expr::UnaryOp {
+          op: UnaryOperator::Minus,
+          operand,
+        } => {
+          flatten_additive_signed(operand, -sign, out);
+        }
+        Expr::FunctionCall { name, args } if name == "Plus" => {
+          for a in args {
+            flatten_additive_signed(a, sign, out);
+          }
+        }
+        other => out.push((sign, other.clone())),
+      }
+    }
+    /// Match a single additive term as `coeff * D[u_name, x]` (any
+    /// factor order, coefficient 1 when the term is a bare derivative),
+    /// returning `(coeff, t_arg, x_arg)`.
+    fn match_flux_term(
+      term: &Expr,
+      u_name: &str,
+      swap: bool,
+    ) -> Option<(Expr, Expr, Expr)> {
+      let factors = flatten_times(term);
+      let mut deriv: Option<(Expr, Expr)> = None;
+      let mut coeff_factors = Vec::new();
+      for f in &factors {
+        if deriv.is_none()
+          && let Some((dt, dx, t_arg, x_arg)) =
+            match_pde_term_roles(f, u_name, swap)
+          && dt == 0
+          && dx == 1
+        {
+          deriv = Some((t_arg, x_arg));
+        } else {
+          coeff_factors.push(f.clone());
+        }
+      }
+      let (t_arg, x_arg) = deriv?;
+      let coeff = match coeff_factors.len() {
+        0 => Expr::Integer(1),
+        1 => coeff_factors.into_iter().next().unwrap(),
+        _ => Expr::FunctionCall {
+          name: "Times".to_string(),
+          args: coeff_factors.into(),
+        },
+      };
+      Some((coeff, t_arg, x_arg))
+    }
+
+    let (lhs, rhs) = as_equal_pair(eq)?;
+    let sum_side = if is_zero_literal(lhs) {
+      rhs
+    } else if is_zero_literal(rhs) {
+      lhs
+    } else {
+      return None;
+    };
+    let mut terms = Vec::new();
+    flatten_additive_signed(sum_side, 1.0, &mut terms);
+
+    let mut self_coeff: Option<Expr> = None;
+    let mut other_terms: Vec<Expr> = Vec::new();
+    for (sign, term) in &terms {
+      let mut matched = false;
+      for (j, name) in u_names.iter().enumerate() {
+        let Some((coeff, t_arg, x_arg)) = match_flux_term(term, name, swap)
+        else {
+          continue;
+        };
+        if !matches!(&t_arg, Expr::Identifier(n) if n == t_name)
+          || !nval_to_f64(&x_arg)
+            .is_some_and(|v| (v - x0).abs() <= 1e-9 * x0.abs().max(1.0))
+        {
+          return None;
+        }
+        let signed_coeff = if *sign > 0.0 { coeff } else { neg_expr(coeff) };
+        if j == target_idx {
+          if self_coeff.is_some() {
+            return None; // the target's own flux appears more than once.
+          }
+          self_coeff = Some(signed_coeff);
+        } else {
+          if j >= raw_specs.len() {
+            return None; // that unknown's own condition isn't resolved yet.
+          }
+          let other_bc = if at_lo {
+            &raw_specs[j].bc_lo
+          } else {
+            &raw_specs[j].bc_hi
+          };
+          let PdeBc::Neumann(other_flux_expr) = other_bc else {
+            return None; // a Dirichlet boundary has no flux to substitute.
+          };
+          other_terms.push(mul_expr(signed_coeff, other_flux_expr.clone()));
+        }
+        matched = true;
+        break;
+      }
+      if !matched {
+        return None; // an unrecognised remainder term — outside this shape.
+      }
+    }
+    let self_coeff = self_coeff?;
+    let numerator = other_terms
+      .into_iter()
+      .reduce(add_expr)
+      .unwrap_or(Expr::Integer(0));
+    let negated = neg_expr(numerator);
+    let derived = if is_one_literal(&self_coeff) {
+      negated
+    } else {
+      Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(negated),
+        right: Box::new(self_coeff),
+      }
+    };
+    Some(PdeBc::Neumann(derived))
+  }
+
   let mut raw_specs: Vec<RawSpec> = Vec::with_capacity(n);
   for name in u_names {
     let mut coeff_rhs: Option<(Expr, Expr)> = None;
@@ -857,6 +1143,38 @@ fn try_solve_pde_system(
       {
         bc_hi = Some(bc);
         claimed[idx] = true;
+        continue;
+      }
+      if bc_lo.is_none()
+        && let Some(bc) = try_coupled_flux_bc(
+          eq,
+          raw_specs.len(),
+          u_names,
+          &raw_specs,
+          &t_dom.name,
+          x_dom.min,
+          true,
+          swap,
+        )
+      {
+        bc_lo = Some(bc);
+        claimed[idx] = true;
+        continue;
+      }
+      if bc_hi.is_none()
+        && let Some(bc) = try_coupled_flux_bc(
+          eq,
+          raw_specs.len(),
+          u_names,
+          &raw_specs,
+          &t_dom.name,
+          x_dom.max,
+          false,
+          swap,
+        )
+      {
+        bc_hi = Some(bc);
+        claimed[idx] = true;
       }
     }
     let (Some((coeff, rhs)), Some(ic), Some(bc_lo), Some(bc_hi)) =
@@ -881,6 +1199,9 @@ fn try_solve_pde_system(
     .chain(["NDSolve$UX".to_string(), "NDSolve$UXX".to_string()])
     .chain([t_dom.name.clone(), x_dom.name.clone()])
     .collect();
+  let bc_rhs_vars: Vec<String> = std::iter::once(t_dom.name.clone())
+    .chain((0..n).map(|j| format!("NDSolve$U{j}")))
+    .collect();
 
   let mut unknowns: Vec<PdeUnknown> = Vec::with_capacity(n);
   for (i, spec) in raw_specs.into_iter().enumerate() {
@@ -898,20 +1219,28 @@ fn try_solve_pde_system(
         rhs,
         std::slice::from_ref(&t_dom.name),
       )),
-      PdeBc::Neumann(rhs) => PdeBoundaryFn::Neumann(NumFn::new(
-        rhs,
-        std::slice::from_ref(&t_dom.name),
-      )),
+      PdeBc::Neumann(rhs) => {
+        let Some(rewritten) =
+          rewrite_pde_bc_rhs(&rhs, u_names, &t_dom.name, x_dom.min, swap)
+        else {
+          return Ok(None);
+        };
+        PdeBoundaryFn::Neumann(NumFn::new(rewritten, &bc_rhs_vars))
+      }
     };
     let bc_hi = match spec.bc_hi {
       PdeBc::Dirichlet(rhs) => PdeBoundaryFn::Dirichlet(NumFn::new(
         rhs,
         std::slice::from_ref(&t_dom.name),
       )),
-      PdeBc::Neumann(rhs) => PdeBoundaryFn::Neumann(NumFn::new(
-        rhs,
-        std::slice::from_ref(&t_dom.name),
-      )),
+      PdeBc::Neumann(rhs) => {
+        let Some(rewritten) =
+          rewrite_pde_bc_rhs(&rhs, u_names, &t_dom.name, x_dom.max, swap)
+        else {
+          return Ok(None);
+        };
+        PdeBoundaryFn::Neumann(NumFn::new(rewritten, &bc_rhs_vars))
+      }
     };
     unknowns.push(PdeUnknown {
       coeff_fn,
@@ -1028,7 +1357,10 @@ fn try_solve_pde_system(
             let PdeBoundaryFn::Neumann(f) = &unknowns[i].bc_lo else {
               unreachable!("a Dirichlet lo boundary is never a free index")
             };
-            let flux = f.eval(&[t])?;
+            let bc_args: Vec<f64> = std::iter::once(t)
+              .chain((0..n).map(|k2| fulls[k2][gi]))
+              .collect();
+            let flux = f.eval(&bc_args)?;
             let ghost = fulls[i][1] - 2.0 * dx * flux;
             (
               (fulls[i][1] - ghost) / (2.0 * dx),
@@ -1038,7 +1370,10 @@ fn try_solve_pde_system(
             let PdeBoundaryFn::Neumann(f) = &unknowns[i].bc_hi else {
               unreachable!("a Dirichlet hi boundary is never a free index")
             };
-            let flux = f.eval(&[t])?;
+            let bc_args: Vec<f64> = std::iter::once(t)
+              .chain((0..n).map(|k2| fulls[k2][gi]))
+              .collect();
+            let flux = f.eval(&bc_args)?;
             let ghost = fulls[i][N_X - 2] + 2.0 * dx * flux;
             (
               (ghost - fulls[i][N_X - 2]) / (2.0 * dx),

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -8438,6 +8438,141 @@ mod ndsolve {
        solution: coupled={coupled_val}, standalone={alone_val}"
     );
   }
+
+  /// A chained equality `u[0, x] == u[t, 1] == c` — the shorthand a
+  /// `NDSolve` demonstration commonly uses to state an initial condition
+  /// and a same-valued Dirichlet boundary condition in one equation —
+  /// must expand into both conditions rather than leaving the whole
+  /// system unrecognised (three equation items don't fit any single
+  /// unknown's required four). With a zero-flux wall at the other end,
+  /// a uniform initial profile matching the shared boundary value is a
+  /// fixed point of the heat equation, so it must stay exactly at that
+  /// value everywhere.
+  #[test]
+  fn pde_chained_equality_states_initial_and_dirichlet_boundary_together() {
+    let result = interpret(
+      "sol = NDSolve[{D[u[t, x], t] == D[u[t, x], {x, 2}], \
+       u[0, x] == u[t, 1] == 1, \
+       (D[u[t, x], x] /. x -> 0) == 0}, u, {t, 0, 1}, {x, 0, 1}]; \
+       (u[t, x] /. sol[[1]]) /. {t -> 0.5, x -> 0}",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!((val - 1.0).abs() < 1e-6, "Expected 1., got {val}");
+  }
+
+  /// A Neumann boundary condition whose flux is a Robin-type formula
+  /// referencing the unknown's own plain value at that same boundary
+  /// (`u[t, 0]`, not just `t`) — the shape a convective or reaction-rate
+  /// boundary condition takes (`flux ∝ u - u_target`). A uniform initial
+  /// profile at the Dirichlet value doubles as the Robin condition's own
+  /// target, so the flux term vanishes identically and the whole system
+  /// is already a steady state: it must stay exactly there.
+  #[test]
+  fn pde_neumann_flux_references_the_unknowns_own_boundary_value() {
+    let result = interpret(
+      "sol = NDSolve[{D[u[t, x], t] == D[u[t, x], {x, 2}], \
+       u[0, x] == u[t, 1] == 2, \
+       (D[u[t, x], x] /. x -> 0) == 3 (u[t, 0] - 2)}, \
+       u, {t, 0, 1}, {x, 0, 1}]; \
+       (u[t, x] /. sol[[1]]) /. {t -> 0.6, x -> 0.3}",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!((val - 2.0).abs() < 1e-6, "Expected 2., got {val}");
+  }
+
+  /// The same Robin-type flux away from its fixed point: with the
+  /// boundary relaxing toward a target above its uniform start, the
+  /// unknown's value at that wall must climb monotonically toward the
+  /// target over time, while staying inside the physical range the
+  /// target and the far Dirichlet value bound it to, and a point deep in
+  /// the domain — not yet reached by diffusion from the wall — must
+  /// still read far closer to its own (lower) initial value.
+  #[test]
+  fn pde_neumann_flux_drives_the_boundary_toward_its_target_over_time() {
+    let result = interpret(
+      "sol = NDSolve[{D[u[t, x], t] == D[u[t, x], {x, 2}], \
+       u[0, x] == u[t, 1] == 0, \
+       (D[u[t, x], x] /. x -> 0) == 2 (u[t, 0] - 1)}, \
+       u, {t, 0, 0.3}, {x, 0, 1}]; \
+       N[{u[t, x] /. sol[[1]] /. {t -> 0.1, x -> 0}, \
+          u[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0}, \
+          u[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0.9}}]",
+    )
+    .unwrap();
+    let vals: Vec<f64> = result
+      .trim_start_matches('{')
+      .trim_end_matches('}')
+      .split(',')
+      .map(|s| s.trim().parse().expect("should be a number"))
+      .collect();
+    let [early_wall, late_wall, late_far] = vals[..] else {
+      panic!("expected three values, got: {result}");
+    };
+    assert!(
+      (0.0..=1.0).contains(&early_wall) && (0.0..=1.0).contains(&late_wall),
+      "the wall's value must stay within the range set by its target and \
+       its own start: early={early_wall}, late={late_wall}"
+    );
+    assert!(
+      late_wall > early_wall,
+      "the wall should keep climbing toward its Robin target over time: \
+       early={early_wall}, late={late_wall}"
+    );
+    assert!(
+      late_far < early_wall,
+      "a point far from the wall shouldn't yet have caught up to where \
+       the wall itself was earlier: late_far={late_far}, early_wall={early_wall}"
+    );
+  }
+
+  /// Two coupled unknowns whose boundary condition at one end isn't
+  /// either one's own — it's a shared flux-conservation law spanning
+  /// both, `(D[p, x] + D[q, x]) /. x -> 0 == 0` (no net accumulation at
+  /// a reacting interface), alongside `p`'s own Robin condition that
+  /// consumes `q`'s boundary value. With equal diffusivities and
+  /// boundary/initial values for `p` and `q` that sum to the same
+  /// constant at every one of the *other* three conditions (the shared
+  /// interface's own flux being conserved, not fixed, contributes
+  /// nothing extra), `p + q` itself satisfies the heat equation with a
+  /// uniform initial profile, a zero-flux wall, and a Dirichlet value
+  /// all equal to that constant — so it must stay exactly there
+  /// everywhere, for both ends of the domain.
+  #[test]
+  fn pde_coupled_flux_conservation_boundary_splits_a_conserved_total() {
+    let result = interpret(
+      "sol = NDSolve[{D[p[t, x], t] == D[p[t, x], {x, 2}], \
+       p[0, x] == p[t, 1] == 1, \
+       (D[p[t, x], x] /. x -> 0) == 0.5 (p[t, 0] - q[t, 0]), \
+       D[q[t, x], t] == D[q[t, x], {x, 2}], \
+       q[0, x] == q[t, 1] == 0, \
+       ((D[p[t, x], x] + D[q[t, x], x]) /. x -> 0) == 0}, \
+       {p, q}, {t, 0, 0.3}, {x, 0, 1}]; \
+       N[{p[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0}, \
+          q[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0}, \
+          p[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0.6}, \
+          q[t, x] /. sol[[1]] /. {t -> 0.3, x -> 0.6}}]",
+    )
+    .unwrap();
+    let vals: Vec<f64> = result
+      .trim_start_matches('{')
+      .trim_end_matches('}')
+      .split(',')
+      .map(|s| s.trim().parse().expect("should be a number"))
+      .collect();
+    let [p_wall, q_wall, p_mid, q_mid] = vals[..] else {
+      panic!("expected four values, got: {result}");
+    };
+    assert!(
+      (p_wall + q_wall - 1.0).abs() < 1e-6,
+      "p + q must stay conserved at the shared wall: p={p_wall}, q={q_wall}"
+    );
+    assert!(
+      (p_mid + q_mid - 1.0).abs() < 1e-6,
+      "p + q must stay conserved away from the wall too: p={p_mid}, q={q_mid}"
+    );
+  }
 }
 
 mod sinh_cosh {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -17490,6 +17490,99 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`ctrl$$ = 1, $CellContext`P$$ = 760}
     );
   }
 
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook (an
+  /// electrochemistry Manipulate simulating two diffusing, interconverting
+  /// species reacting at one wall) against Woxi Studio's Manipulate
+  /// pipeline. Its shape: an `NDSolve` system of two coupled 1D parabolic
+  /// PDEs (`Method -> "MethodOfLines"`) whose initial condition and
+  /// same-valued Dirichlet boundary condition are stated together as one
+  /// chained equality (`u[x, 0] == u[xmax, t] == c`); a Robin-type Neumann
+  /// flux condition on the first species that references both species'
+  /// own plain boundary values (not just the time variable); and, on the
+  /// second species, a boundary condition that isn't either species' own —
+  /// a shared flux-conservation law spanning both (`(D[a, x] + k D[b, x])
+  /// /. x -> 0 == 0`, no net accumulation at the reacting interface).
+  /// `ParametricPlot`, `FindMinimum`/`FindMaximum`, and a labeled `Slider`
+  /// drive the rendered curve.
+  ///
+  /// None of these three PDE shapes were previously recognised at all —
+  /// the chained equality left the equation count short of what a
+  /// single-unknown role needs, the Robin flux's own-value references had
+  /// no compiled variable to bind to, and the shared boundary condition
+  /// matched no single unknown's boundary role — so the whole `NDSolve`
+  /// call fell through unevaluated. This is a self-authored,
+  /// construct-equivalent example (a made-up "two-species interface
+  /// exchange" scenario) — not the notebook's own code, data, or wording,
+  /// which is copyrighted.
+  #[test]
+  fn interface_exchange_manipulate_solves_a_coupled_pde_with_a_shared_flux_condition()
+   {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[ \
+         sol = NDSolve[{ \
+           D[p[t, x], t] == D[p[t, x], {x, 2}], \
+           p[0, x] == p[t, 1] == 1, \
+           (D[p[t, x], x] /. x -> 0) == k (p[t, 0] - q[t, 0]), \
+           D[q[t, x], t] == D[q[t, x], {x, 2}], \
+           q[0, x] == q[t, 1] == 0, \
+           ((D[p[t, x], x] + D[q[t, x], x]) /. x -> 0) == 0 \
+          }, {p, q}, {t, 0, 0.3}, {x, 0, 1}]; \
+         ParametricPlot[ \
+           {{x, p[t, x] /. sol[[1]] /. t -> 0.3}, \
+            {x, q[t, x] /. sol[[1]] /. t -> 0.3}}, \
+           {x, 0, 1}, PlotRange -> {0, 1}, Frame -> True], \
+         {{k, 0.5, \"exchange rate\"}, 0.1, 2, 0.1, Appearance -> \"Labeled\"}]",
+    )
+    .expect("the Manipulate source must parse and evaluate");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the Manipulate must build a widget");
+
+    assert!(
+      state.error.is_none(),
+      "the coupled PDE solve must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the ParametricPlot of both species must draw"
+    );
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the pieces must render")
+    };
+    let slow_exchange_view = render(&state);
+
+    // Raising the exchange rate must re-solve the coupled system and
+    // change the rendered curves.
+    match &mut state.controls[..] {
+      [manipulate::ControlState::Continuous { current, .. }] => {
+        *current = 1.8;
+      }
+      other => {
+        panic!("expected k as a single Continuous control, got {other:?}")
+      }
+    }
+    state.reevaluate();
+    assert!(state.error.is_none());
+    assert!(state.graphics_handle.is_some());
+    assert_ne!(
+      slow_exchange_view,
+      render(&state),
+      "raising the exchange rate must change the re-solved curves"
+    );
+  }
+
   /// End-to-end regression for the shape of the "Leverage Ratios"
   /// Wolfram Demonstration: a `Setter` whose choice rules are
   /// `key -> Tooltip[displayValue, hoverText]` (so the button shows the
@@ -18363,11 +18456,30 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
       other => panic!("expected a single Setter control, got {other:?}"),
     }
 
-    let initial_text = widget.text_output.clone();
     assert!(
-      initial_text.is_some() || widget.graphics_handle.is_some(),
+      widget.text_output.is_some() || widget.graphics_handle.is_some(),
       "the totals table must render as text or a picture"
     );
+
+    // The totals table renders as a picture (`Text@Style[Grid[...], 16]`
+    // wrapped in a `Pane`), so `text_output` never carries it — re-render
+    // the body directly to inspect the actual SVG, the same technique the
+    // other demonstration regressions use.
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the totals table must render as a picture")
+    };
+    let initial_view = render(&widget);
 
     // Stepping the Setter to a larger table size must change the
     // rendered totals.
@@ -18383,7 +18495,8 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
       widget.error
     );
     assert_ne!(
-      widget.text_output, initial_text,
+      render(&widget),
+      initial_view,
       "switching the table size must change the rendered totals"
     );
   }


### PR DESCRIPTION
## Summary

Checked a randomly-sampled Wolfram Demonstrations Project notebook (an electrochemistry Manipulate — cyclic voltammetry with two diffusing, interconverting species reacting at one electrode wall) against Woxi Studio's `NDSolve`/Manipulate pipeline. Its PDE system used three shapes the method-of-lines `NDSolve` branch didn't recognize at all, so the whole call fell through unevaluated:

- **Chained equality shorthand** — `u[x, 0] == u[xmax, t] == c`, stating an initial condition and a same-valued Dirichlet boundary condition in one equation — left the equation count short of what a single unknown's four roles (evolution, IC, BC-lo, BC-hi) need. It now expands into both conditions before role-matching, since transitivity makes the expansion lossless.
- **Robin-type Neumann flux** — a boundary condition's right-hand side referencing an unknown's own plain value at that same boundary (`u[t, 0]`), not just the time variable. The compiled flux function now also takes each unknown's current boundary value as an argument.
- **Shared flux-conservation boundary condition** — a condition that isn't any single unknown's own, but a linear combination of several unknowns' fluxes (`(D[a, x] + k D[b, x]) /. x -> 0 == 0`, no net accumulation at a reacting interface). This is now solved for whichever unknown doesn't yet have its own resolved flux, by substituting the other unknowns' already-resolved flux expressions.

Also fixes a pre-existing bug found while running the full `woxi-studio` suite: `demonstration_setter_grid_totals_manipulate_switches_table_size` asserted on `text_output`, which stays `None` for this notebook since its totals table renders as a picture, not text — so the assertion trivially held regardless of the actual rendered output. It now re-renders the body and compares the SVG, the same technique other demonstration regressions already use.

All test/example code in this PR is self-authored and construct-equivalent — not the notebook's own code, data, or wording, which is copyrighted.

## Test plan
- [x] Added 4 new unit tests in `tests/interpreter_tests/calculus.rs` covering chained-equality IC+BC, self/other-referencing Robin flux, and coupled flux-conservation (verified via an exact conservation invariant, `p + q == 1` everywhere).
- [x] Added an end-to-end `woxi-studio` Manipulate regression test combining all three PDE shapes with a slider-driven re-solve.
- [x] Fixed and re-verified the pre-existing `demonstration_setter_grid_totals_manipulate_switches_table_size` failure (confirmed present on `main` before this change, via `git stash`).
- [x] `cargo nextest run` (default workspace): 27792 passed, 0 failed.
- [x] `cargo nextest run -p woxi-studio`: 196 passed, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings`: clean.
- [x] `make format` applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAEwMV64BAxf3uAJgeiEC1)_