### PR TITLE
Fix a HoldFirst structural pattern running its held Set as a side effect

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -869,11 +869,59 @@ fn replace_placeholders_with_patterns(
   }
 }
 
+/// Whether `expr` calls an assignment-family function (`Set`, `SetDelayed`,
+/// `AddTo`, …) anywhere in its tree. `normalize_structural_pattern` evaluates
+/// a placeholder-substituted copy of the pattern to canonicalize benign
+/// arithmetic identities (`1/x_` → `x_^-1`); running that same evaluation on
+/// a pattern like `f[a_ = b_]` (the `HoldFirst` "let"-binding idiom used by
+/// held-argument code) would actually perform the placeholder assignment and
+/// collapse `Set[placeholder_a, placeholder_b]` down to just its right-hand
+/// side, permanently losing the left pattern variable (`a_`) from the stored
+/// pattern. Skip canonicalization for such patterns instead — they have no
+/// arithmetic normal form to look for.
+fn contains_mutating_head(expr: &Expr) -> bool {
+  match expr {
+    Expr::FunctionCall { name, args } => {
+      matches!(
+        name.as_str(),
+        "Set"
+          | "SetDelayed"
+          | "UpSet"
+          | "UpSetDelayed"
+          | "TagSet"
+          | "TagSetDelayed"
+          | "TagUnset"
+          | "Unset"
+          | "AddTo"
+          | "SubtractFrom"
+          | "TimesBy"
+          | "DivideBy"
+          | "Increment"
+          | "Decrement"
+          | "PreIncrement"
+          | "PreDecrement"
+      ) || args.iter().any(contains_mutating_head)
+    }
+    Expr::BinaryOp { left, right, .. } => {
+      contains_mutating_head(left) || contains_mutating_head(right)
+    }
+    Expr::UnaryOp { operand, .. } => contains_mutating_head(operand),
+    Expr::List(items) => items.iter().any(contains_mutating_head),
+    Expr::CurriedCall { func, args } => {
+      contains_mutating_head(func) || args.iter().any(contains_mutating_head)
+    }
+    Expr::Part { expr, index } => {
+      contains_mutating_head(expr) || contains_mutating_head(index)
+    }
+    _ => false,
+  }
+}
+
 /// Normalize a structural pattern by evaluating it with placeholder variables.
 /// E.g., `1/x_` (BinaryOp Divide) → `Power[x_, -1]` (canonical form).
 fn normalize_structural_pattern(pattern: &Expr) -> Expr {
   let vars = collect_pattern_vars(pattern);
-  if vars.is_empty() {
+  if vars.is_empty() || contains_mutating_head(pattern) {
     return pattern.clone();
   }
   let with_placeholders = replace_patterns_with_placeholders(pattern, &vars);
@@ -2954,6 +3002,28 @@ pub fn set_delayed_ast(
         // Supports a trailing BlankSequence (`__`) or BlankNullSequence (`___`)
         // element, which relaxes the length check and (for named sequence
         // elements) binds the sequence variable to the matching tail.
+        Expr::List(patterns) if patterns.iter().any(contains_mutating_head) => {
+          // An element like `x_ = expr_` (the `HoldFirst` "let"-binding
+          // idiom, e.g. `myLet[{x_ = expr_}, x_] := expr`) must never be
+          // decomposed via `build_list_pattern_match`'s Part accessors:
+          // reconstructing `Part[{x = expr}, 1]` and evaluating it like
+          // ordinary code would actually perform the assignment. Route it
+          // through the structural-pattern matcher instead — it binds `x`
+          // and `expr` by walking the held argument's structure, never
+          // evaluating it.
+          let param_name = format!("__sp{i}");
+          conditions.push(Some(call(
+            "__StructuralPattern__",
+            vec![
+              Expr::Identifier(param_name.clone()),
+              Expr::List(patterns.clone()),
+            ],
+          )));
+          params.push(param_name);
+          defaults.push(None);
+          heads.push(None);
+          blank_types.push(1);
+        }
         Expr::List(patterns) => {
           let param_name = format!("_lp{i}");
           // The combined condition checks the list length and that each
@@ -3057,7 +3127,24 @@ pub fn set_delayed_ast(
             }
             // `Pattern[name, {p1, p2, ...}]` — named list pattern.
             // Bind `name` to the entire list (via the param itself) AND
-            // destructure inner elements.
+            // destructure inner elements. An element containing a mutating
+            // head (`x_ = expr_`) skips the Part-accessor decomposition for
+            // the same reason as the unnamed list-pattern case above.
+            Expr::List(patterns)
+              if patterns.iter().any(contains_mutating_head) =>
+            {
+              conditions.push(Some(call(
+                "__StructuralPattern__",
+                vec![
+                  Expr::Identifier(pname.clone()),
+                  Expr::List(patterns.clone()),
+                ],
+              )));
+              params.push(pname);
+              defaults.push(None);
+              heads.push(None);
+              blank_types.push(1);
+            }
             Expr::List(patterns) => {
               let (combined_cond, bindings) =
                 build_list_pattern_match(patterns, &pname);

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -359,6 +359,73 @@ mod set_delayed {
       clear_state();
       assert_eq!(interpret("f[a_ + b_] := a * b; f[3]").unwrap(), "f[3]");
     }
+
+    // Regression: a downvalue pattern that peers into a `Set` inside a
+    // `HoldFirst` argument (`f[a_ = b_] := ...`, the shape a `let`-style
+    // local-binding idiom uses) used to run the held assignment for real
+    // while *canonicalizing* the stored pattern for dispatch — replacing
+    // pattern variables with placeholder symbols and evaluating the result
+    // to look for an arithmetic normal form (as `1/x_` does for `x_^-1`).
+    // Evaluating `Set[placeholder_a, placeholder_b]` actually performs the
+    // assignment and collapses to just its right-hand side, permanently
+    // losing the left variable from the stored pattern. The lost slot then
+    // fell back to matching the *whole* argument, so the real call's raw,
+    // still-unevaluated `Set` ended up spliced into the (unheld) function
+    // body, where it fired for real once the body was evaluated.
+    #[test]
+    fn set_pattern_argument_does_not_run_the_held_assignment() {
+      clear_state();
+      assert_eq!(
+        interpret(
+          "Clear[g, uu]; SetAttributes[g, HoldFirst]; \
+           g[a_ = b_] := {a, b}; g[uu = 42]"
+        )
+        .unwrap(),
+        "{uu, 42}"
+      );
+      assert_eq!(interpret("uu").unwrap(), "uu");
+    }
+
+    // Same regression as above, but for the list-wrapped shape
+    // (`f[{a_ = b_}, ...] := ...`) an actual `let`-style `HoldFirst` binding
+    // uses. This argument goes through a separate list-pattern Part-accessor
+    // path that reconstructs `Part[{x = expr}, 1]` and evaluates it like
+    // ordinary code, running the assignment the same way.
+    #[test]
+    fn list_wrapped_set_pattern_does_not_run_the_held_assignment() {
+      clear_state();
+      assert_eq!(
+        interpret(
+          "Clear[myLet, uu]; Attributes[myLet] = {HoldFirst}; \
+           myLet[{a_ = b_}, a_] := b; myLet[{uu = 42}, uu]"
+        )
+        .unwrap(),
+        "42"
+      );
+      assert_eq!(interpret("uu").unwrap(), "uu");
+    }
+
+    // End-to-end version of the two regressions above: a Church-encoding
+    // style Demonstration builds a `let` binding out of a `HoldFirst`
+    // function and a curried infix combinator (`(lambda[x_] . body_)[arg_]
+    // := let[{x = arg}, body]`). Applying the identity combinator to a value
+    // used to leave the combinator's own bound variable permanently
+    // assigned to that value as a side effect of the two bugs above.
+    #[test]
+    fn curried_let_combinator_does_not_leak_its_bound_variable() {
+      clear_state();
+      assert_eq!(
+        interpret(
+          r#"Clear[myLet, lam, vv]; Attributes[myLet] = {HoldFirst};
+myLet[{a_ = b_}, a_] := b;
+(lam[a_] \[CenterDot] body_)[arg_] := myLet[{a = arg}, body];
+(lam[vv] \[CenterDot] vv)[42]"#
+        )
+        .unwrap(),
+        "42"
+      );
+      assert_eq!(interpret("vv").unwrap(), "vv");
+    }
   }
 }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -8047,6 +8047,61 @@ mod tests {
     );
   }
 
+  /// A Demonstration-style local-binding helper: a `HoldFirst` function
+  /// pattern-matching a `{x_ = val_}` argument, which several Wolfram
+  /// Demonstrations use to build a `let`-style local binding (`Module`/
+  /// `With` don't work point-free inside a curried combinator). Woxi used
+  /// to actually run the held assignment as a side effect while
+  /// canonicalizing the stored pattern for dispatch, permanently binding
+  /// the pattern's left variable to whatever value the Manipulate's control
+  /// last passed in — so clicking the Setter leaked state across
+  /// re-evaluations instead of staying purely local to each one.
+  #[test]
+  fn held_let_binding_pattern_works_inside_a_live_manipulate() {
+    let expr = woxi::interpret_to_expr(
+      r#"Clear[bindLocal, base, opChoice, nn];
+Attributes[bindLocal] = {HoldFirst};
+bindLocal[{x_ = val_}, x_] := val;
+Manipulate[
+  If[opChoice == "double", 2, 1] * bindLocal[{nn = base}, nn],
+  {{base, 3, "start"}, 0, 10, 1, ControlType -> Setter},
+  {{opChoice, "increment"}, {"increment", "double"}}
+]"#,
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("Manipulate builds a widget");
+    assert!(
+      state.error.is_none(),
+      "manipulate body errored: {:?}",
+      state.error
+    );
+    assert_eq!(state.text_output.as_deref(), Some("3"));
+
+    // Flip the Setter to "double" and re-evaluate, as clicking it would.
+    let choice_idx = state
+      .controls
+      .iter()
+      .position(|c| c.name() == "opChoice")
+      .unwrap();
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[choice_idx]
+    {
+      *current_index = 1;
+    }
+    state.request_reeval(choice_idx);
+    state.run_scheduled_reeval();
+    assert!(
+      state.error.is_none(),
+      "manipulate body errored after Setter click: {:?}",
+      state.error
+    );
+    assert_eq!(state.text_output.as_deref(), Some("6"));
+
+    // The pattern's bound variable must never leak into global scope.
+    assert_eq!(woxi::interpret("nn").unwrap(), "nn");
+  }
+
   #[test]
   fn dynamic_box_dump_is_recognized() {
     // The saved box form of a live Manipulate (what Mathematica writes


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration ("Arithmetic in Lambda Calculus") from the Wolfram Cloud and checked it against Woxi Studio, per the routine's task.
- The Demonstration builds a `let`-style local binding out of a `HoldFirst` function that pattern-matches a `{x_ = expr_}` argument, then uses a curried infix combinator to apply Church-numeral-style functions. Interacting with the notebook's `Manipulate` Setter controls leaked the combinator's bound variable into global scope, corrupting later evaluations.
- Root cause: two independent bugs in how Woxi stores a downvalue whose pattern peers into a `Set` inside a held argument:
  1. `f[a_ = b_] := ...` — the structural-pattern storage path canonicalizes patterns by substituting placeholder symbols and *evaluating* the result to look for an arithmetic normal form (e.g. `1/x_` → `x_^-1`). Evaluating `Set[placeholder_a, placeholder_b]` actually performs the assignment and collapses to just its right-hand side, permanently losing the left pattern variable from the stored pattern.
  2. `f[{a_ = b_}, ...] := ...` (the list-wrapped shape the `let` idiom actually uses) — a separate Part-accessor decomposition path reconstructs `Part[{x = expr}, 1]` and evaluates it like ordinary code, which also runs the assignment.
- Both call sites now route a pattern containing an assignment-family head (`Set`, `SetDelayed`, `AddTo`, …) through the existing structural-pattern matcher instead, which binds variables by walking the held argument's structure without evaluating it.

## Test plan

- [x] Added 3 regression tests in `tests/interpreter_tests/function_definitions.rs` (`structural_patterns` module) covering the bare pattern, the list-wrapped pattern, and the end-to-end curried combinator idiom.
- [x] Added a Woxi Studio regression test (`held_let_binding_pattern_works_inside_a_live_manipulate`) that builds a live `Manipulate` with a Setter control using this idiom and verifies both correct re-evaluation across a control change and that no global variable leaks.
- [x] `cargo test --release` (core interpreter): 25659 + 246 + 45 + 1262 + 576 passed, 0 failed.
- [x] `cargo test --release -p woxi-studio`: 196 passed, 0 failed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DP2FGt5Ne4N4KWarkdmCZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP2FGt5Ne4N4KWarkdmCZT)_