### PR TITLE
Accept OpenerView as a Manipulate control-panel item

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16746,7 +16746,9 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // swaps whole control panels as `sel` changes. `Item[Column[…], opts]`
       // is the same layout pattern wrapped in a grid-alignment `Item[…]`
       // (a Demonstration lining up its whole control panel inside an outer
-      // `Grid`), not a control itself.
+      // `Grid`), not a control itself. `OpenerView[{label, content}]` is the
+      // same pattern for a collapsible disclosure widget (e.g. a "circuit
+      // diagram" aside tucked below the sliders).
       Expr::FunctionCall { name, .. }
         if matches!(
           name.as_str(),
@@ -16760,6 +16762,7 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             | "PaneSelector"
             | "TabView"
             | "Item"
+            | "OpenerView"
         ) =>
       {
         out_args.push(spec.clone());

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -18614,6 +18614,25 @@ mod manipulate {
     assert!(result.result.starts_with("Manipulate["));
   }
 
+  #[test]
+  fn opener_view_arg_is_not_vsform() {
+    // A trailing `OpenerView[{label, content}]` argument is a common
+    // Demonstrations pattern for tucking an aside (e.g. a circuit diagram)
+    // below the sliders. It is a control-panel content item, not a
+    // malformed variable specification, so wolframscript shows it with no
+    // Manipulate::vsform message.
+    let result = woxi::interpret_with_stdout(
+      "Manipulate[x, {x, 0, 1}, OpenerView[{\"more\", Graphics[{}]}]]",
+    )
+    .unwrap();
+    assert!(
+      !result.warnings.iter().any(|w| w.contains("vsform")),
+      "no vsform expected, got {:?}",
+      result.warnings
+    );
+    assert!(result.result.starts_with("Manipulate["));
+  }
+
   /// Controls wrapped in a `Row[…]` layout (with loose labels, `Spacer`
   /// padding, and `Dynamic[Control[…]]` wrappers — the Doyle-spirals
   /// Demonstration idiom) extract in display order: the loose string

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -8078,6 +8078,24 @@ mod tests {
   }
 
   #[test]
+  fn stored_manipulate_with_opener_view_instantiates() {
+    // A trailing `OpenerView[{label, content}]` argument (a Demonstrations
+    // idiom for a collapsible aside below the sliders, e.g. a circuit
+    // diagram) must not stop the widget from instantiating.
+    let state = instantiate_stored_manipulate(
+      "Manipulate[x^2, {x, 0, 10}, OpenerView[{\"more\", Graphics[{}]}]]",
+      "",
+    )
+    .expect("the stored Manipulate must instantiate on load");
+    assert_eq!(state.controls.len(), 1);
+    assert!(
+      state.displays.iter().any(|d| d.contains("OpenerView")),
+      "expected an OpenerView display element, got {:?}",
+      state.displays
+    );
+  }
+
+  #[test]
   fn standalone_output_cells_get_editors() {
     // Output cells that do not follow an Input (e.g. the saved snapshot
     // images of a Demonstration notebook) must become editors; skipping


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration ("Parallel Plate Capacitors and RC Circuits") to check Woxi Studio's compatibility, per the recurring compatibility-check routine.
- Its `Manipulate[...]` uses a trailing `OpenerView[{"circuit diagram", Graphics[...]}]` argument — a common Demonstrations idiom for tucking a collapsible aside below the sliders.
- Woxi's `Manipulate` argument classifier only whitelisted `Row`/`Column`/`Grid`/`Control`/`Button`/`ButtonBar`/`Spacer`/`PaneSelector`/`TabView`/`Item` as valid non-variable-spec arguments, so the trailing `OpenerView[...]` fell through to the "malformed variable specification" branch and emitted a spurious `Manipulate::vsform` message that wolframscript would not produce.
- Fixed by adding `OpenerView` to that whitelist in `src/functions/graphics.rs`. (The separate Woxi Studio widget-instantiation path, `extract_manipulate_spec`, already handled `OpenerView` fine as a generic display element, so the widget itself was unaffected — only the message was wrong.)

## Test plan

- [x] Added `tests/interpreter_tests/graphics.rs::opener_view_arg_is_not_vsform` — minimal reproduction confirming no `Manipulate::vsform` message.
- [x] Added `woxi-studio/src/main.rs::stored_manipulate_with_opener_view_instantiates` — confirms the Woxi Studio widget instantiates with the `OpenerView` content preserved.
- [x] `make format`
- [x] `make test` — 27778 passed, 0 failed
- [x] `make test-studio` — 196 passed, 0 failed
- [x] Re-ran the downloaded Demonstration notebook through `woxi run` before/after: the spurious message is gone.

(No code from the notebook itself is included — the regression tests are minimal, independent reproductions of the underlying language pattern.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXu3Dep999zhUut6XAKydo)_