### PR TITLE
Resolve list-pattern Part[] accessors before they reach held arguments

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14795,6 +14795,56 @@ fn substitute_into_scoping_construct(
   }
 }
 
+/// Statically resolve a `Part[…]` chain built by list-pattern lowering
+/// (`build_list_pattern_match`/`collect_element_bindings` in
+/// `evaluator::assignment`) down to the literal element it names, using
+/// `bindings` to look up the synthetic `_lp{i}` base parameter those
+/// functions introduce for an anonymous list-pattern argument (`f[{x_,
+/// y_}] := …`).
+///
+/// A rule's pattern variables bind to the actual matched sub-expressions in
+/// Wolfram — `x_` in that example becomes whatever `x` matched, a plain
+/// value, never a `Part[…]` access. Woxi represents that binding
+/// internally as `Part[_lp0, 1]` so the leaf pattern can be recovered once
+/// the whole list argument is known, but that internal encoding must not
+/// leak into the substituted body: left as `Part[…]`, a held argument
+/// position (`Plot`'s iterator spec, `Hold`, …) would see the accessor
+/// instead of the symbol/value it stands for. Resolving it here — before
+/// the body is even substituted — closes that seam.
+///
+/// Returns `None` for anything that isn't one of these synthetic chains;
+/// in particular a `Part[…]` the user actually wrote is left alone so it
+/// keeps evaluating (or staying held) exactly like today.
+fn resolve_synthetic_list_part(
+  expr: &Expr,
+  bindings: &[(&str, &Expr)],
+) -> Option<Expr> {
+  match expr {
+    Expr::Identifier(name) if name.starts_with("_lp") => bindings
+      .iter()
+      .find(|&&(var_name, _)| var_name == name)
+      .map(|&(_, value)| value.clone()),
+    Expr::FunctionCall { name, args } if name == "Part" && args.len() == 2 => {
+      let base = resolve_synthetic_list_part(&args[0], bindings)?;
+      let Expr::List(items) = &base else {
+        return None;
+      };
+      let Expr::Integer(n) = &args[1] else {
+        return None;
+      };
+      let idx = if *n >= 1 {
+        (*n - 1) as usize
+      } else if *n < 0 {
+        usize::try_from(items.len() as i128 + *n).ok()?
+      } else {
+        return None;
+      };
+      items.get(idx).cloned()
+    }
+    _ => None,
+  }
+}
+
 fn substitute_variables_impl(
   expr: &Expr,
   bindings: &[(&str, &Expr)],
@@ -14818,6 +14868,18 @@ fn substitute_variables_impl(
         .map(|e| substitute_variables_impl(e, bindings, template))
         .collect(),
     ),
+    Expr::FunctionCall { name, args } if name == "Part" && args.len() == 2 => {
+      match resolve_synthetic_list_part(expr, bindings) {
+        Some(resolved) => resolved,
+        None => Expr::FunctionCall {
+          name: name.clone(),
+          args: args
+            .iter()
+            .map(|e| substitute_variables_impl(e, bindings, template))
+            .collect(),
+        },
+      }
+    }
     Expr::FunctionCall { name, args } => {
       // Capture-avoiding substitution into an unevaluated
       // `Function[{params}, body]` FunctionCall. Function has HoldAll, so

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -4965,6 +4965,72 @@ mod call_patterns_nested_in_a_list_pattern {
   }
 }
 
+/// A leaf variable destructured out of a list-pattern argument
+/// (`f[{x_, y_}] := …`) binds to the actual matched value, the same as any
+/// other pattern variable. Woxi represents that binding internally as a
+/// `Part[…]` access into the whole matched list, resolved once the list
+/// argument is known — but a rule's bound values are never that accessor
+/// in real Wolfram, so the internal encoding must not leak into a body
+/// position that holds its arguments (an iterator spec, `Hold`, …): it has
+/// to resolve to the plain matched value there too.
+mod list_pattern_bindings_survive_hold_contexts {
+  use super::*;
+
+  #[test]
+  fn a_destructured_variable_plots_as_a_plain_iterator_symbol() {
+    // Before the fix, `x` stayed `Part[_lp0, 1]` inside `Plot`'s held
+    // iterator-spec argument, so `Plot` rejected it with
+    // "iterator variable must be a symbol" instead of drawing the curve.
+    assert_eq!(
+      interpret(
+        "lpp1[{x_, x1_, x2_}] := Head[Plot[Sin[x], {x, x1, x2}]]; \
+         lpp1[{z, 0, 1}]"
+      )
+      .unwrap(),
+      "Graphics"
+    );
+  }
+
+  #[test]
+  fn a_destructured_variable_stays_a_plain_symbol_under_hold() {
+    assert_eq!(
+      interpret("lpp2[{x_, x1_, x2_}] := Hold[{x, x1, x2}]; lpp2[{z, 0, 1}]")
+        .unwrap(),
+      "Hold[{z, 0, 1}]"
+    );
+    // `x` resolves to the plain symbol `z` before `Hold` ever sees it, so
+    // `Head[x]`/`Head[Unevaluated[x]]` stay unevaluated calls on `z` — not
+    // on some `Part[…]` accessor.
+    assert_eq!(
+      interpret(
+        "lpp3[{x_, x1_, x2_}] := Hold[Head[x], Head[Unevaluated[x]]]; \
+         lpp3[{z, 0, 1}]"
+      )
+      .unwrap(),
+      "Hold[Head[z], Head[Unevaluated[z]]]"
+    );
+  }
+
+  #[test]
+  fn nested_list_pattern_variables_also_resolve_under_hold() {
+    assert_eq!(
+      interpret("lpp4[{{a_, b_}, c_}] := Hold[a, b, c]; lpp4[{{1, 2}, 3}]")
+        .unwrap(),
+      "Hold[1, 2, 3]"
+    );
+  }
+
+  #[test]
+  fn a_literal_part_of_a_literal_list_still_stays_held() {
+    // A genuine `Part[…]` the user wrote (not synthesized by list-pattern
+    // destructuring) must keep its ordinary Hold behaviour.
+    assert_eq!(
+      interpret("Hold[{1, 2, 3}[[2]]]").unwrap(),
+      "Hold[{1, 2, 3}[[2]]]"
+    );
+  }
+}
+
 mod literal_left_hand_side {
   use super::*;
 


### PR DESCRIPTION
## Summary

- Found via a random Wolfram Demonstration ("Oxidation of Naphthalene in a Tubular Flow Reactor") that Woxi Studio failed to render: its `Manipulate` body defines a local helper via a destructured list-pattern argument (`f[{x_, x1_, x2_}] := ...`) and passes one of the destructured leaves as `Plot`'s iterator variable.
- Root cause: Woxi lowers each leaf of an anonymous list-pattern argument to a `Part[_lp0, idx]` access into the whole matched list, baked into the stored rule body at definition time and resolved once the argument value is known at call time. Left as `Part[...]`, that internal encoding survived into any *held* argument position downstream (`Plot`'s iterator spec, `Hold`, ...) instead of resolving to the plain matched value — so Woxi rejected the call with `Plot: iterator variable must be a symbol` where real Wolfram just draws the curve.
- Fix: resolve these synthetic `Part[...]` chains during body substitution, before the substituted body is even evaluated — matching how Wolfram binds pattern variables directly to their matched values rather than through an accessor. A `Part[...]` the user actually wrote (e.g. `Hold[{1, 2, 3}[[2]]]`) is left untouched, verified by a regression test.
- Re-ran the notebook's `Manipulate` through Woxi Studio's `dump_manipulate` diagnostic afterward: it now builds and renders the interactive widget without error.

No verbatim code from the (copyrighted) demonstration notebook is included; the added tests use independently written, structurally analogous examples.

## Test plan

- [x] `make test` — all 27,792 unit tests pass, no regressions
- [x] `make format`
- [x] Added regression tests in `tests/interpreter_tests/patterns.rs::list_pattern_bindings_survive_hold_contexts` covering: a destructured variable used as `Plot`'s iterator symbol, a destructured variable staying a plain symbol under `Hold`, nested list-pattern destructuring under `Hold`, and confirming a genuine user-written `Part[...]` still stays held
- [x] Re-verified the source Wolfram Demonstration notebook (downloaded from `demonstrations.wolfram.com`) now builds and renders in Woxi Studio via the `dump_manipulate` example, with no evaluation error


---
_Generated by [Claude Code](https://claude.ai/code/session_019dkSZ4Cr9tDEDzjUJLHoBo)_