### PR TITLE
Fall back to embedded pure function for serialized CompiledFunction dumps

### DIFF
--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1872,6 +1872,43 @@ pub fn apply_curried_call(
     Expr::FunctionCall {
       name,
       args: func_args,
+    } if name == "CompiledFunction" => {
+      // A `CompiledFunction[…]` restored from a saved notebook (e.g. a
+      // Demonstration's `SaveDefinitions -> True` dump) carries Mathematica's
+      // full serialized form — id tuple, argument patterns, type/constant
+      // tables, raw bytecode, the uncompiled pure function, and a trailing
+      // evaluation flag — not the 2-argument `[specs, body]` shape woxi's own
+      // `Compile` produces above. woxi has no bytecode VM to run the middle
+      // arguments, but real Mathematica always embeds an uncompiled
+      // `Function[…]` alongside the bytecode as a correctness fallback (it's
+      // what runs when the compiled code can't handle an argument); applying
+      // that instead gives the same result the bytecode would. Without this,
+      // the call falls through to the generic case below and returns
+      // unevaluated — which then never collapses to a number and blows up
+      // any surrounding computation that reruns it (e.g. a Manipulate whose
+      // body composes it dozens of times).
+      // `CompiledFunction` holds its arguments (like `Compile`), so an
+      // embedded `Function[…]` is still the literal, unevaluated
+      // `FunctionCall` AST here, not the `NamedFunction`/`Function` value
+      // `Function[…]` evaluates to — evaluate it first to get something
+      // `apply_curried_call` can invoke.
+      match func_args.iter().find(|a| {
+        matches!(a, Expr::NamedFunction { .. } | Expr::Function { .. })
+          || matches!(a, Expr::FunctionCall { name, .. } if name == "Function")
+      }) {
+        Some(pure_fn) => {
+          let pure_fn = evaluate_expr_to_expr(pure_fn)?;
+          apply_curried_call(&pure_fn, args)
+        }
+        None => Ok(Expr::CurriedCall {
+          func: Box::new(func.clone()),
+          args: args.to_vec(),
+        }),
+      }
+    }
+    Expr::FunctionCall {
+      name,
+      args: func_args,
     } => {
       // Property access on a canonical music object, e.g.
       // MusicNote[<|…|>]["Pitch"] or MusicChord[<|…|>]["PitchList"].

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -817,6 +817,50 @@ mod compile {
     );
     assert_eq!(interpret("Head[cf]").unwrap(), "CompiledFunction");
   }
+
+  // Regression: a `.nb` notebook's `SaveDefinitions -> True` dump can embed a
+  // helper as Mathematica's fully serialized `CompiledFunction[…]` — an id
+  // tuple, argument patterns, type/constant tables, raw bytecode, the
+  // uncompiled pure `Function[…]`, and a trailing evaluation flag — rather
+  // than the 2-argument `[specs, body]` form woxi's own `Compile` produces.
+  // woxi has no bytecode VM to run the middle arguments, so calling such a
+  // value used to fall through to the generic case and stay unevaluated —
+  // `CompiledFunction[…][args]` — which then propagated into anything built
+  // on top of it. Real Mathematica always embeds the uncompiled pure
+  // function alongside the bytecode as a correctness fallback, so applying
+  // that instead gives the right answer without a bytecode interpreter.
+  #[test]
+  fn compiled_function_serialized_form_falls_back_to_pure_function() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        r#"cf = CompiledFunction[{7, 7.0, 42}, {_Integer, _Real}, {{2, 0, 0}}, {{}}, {0, 1, 2, 0, 0}, {{1}},
+          Function[{a, b}, N[a] + b], Evaluate];
+        cf[3, 0.25]"#
+      )
+      .unwrap(),
+      "3.25"
+    );
+  }
+
+  // The same fallback must apply when the compiled helper is called deep
+  // inside a larger computation (a Module composing it several times), which
+  // is the shape that actually matters: the un-reduced call otherwise grows
+  // an ever-larger unevaluated expression at every level it passes through.
+  #[test]
+  fn compiled_function_serialized_form_reduces_inside_nested_calls() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        r#"step = CompiledFunction[{7, 7.0, 42}, {_Integer}, {{2, 0, 0}}, {{}}, {0, 1, 2, 0, 0}, {{1}},
+          Function[{k}, N[2 k]], Evaluate];
+        total[n_] := Module[{acc}, acc = 0; Do[acc = acc + step[i], {i, 1, n}]; acc];
+        total[4]"#
+      )
+      .unwrap(),
+      "20."
+    );
+  }
 }
 
 mod dispatch {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -18364,13 +18364,16 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
     }
 
     let initial_text = widget.text_output.clone();
+    let initial_graphics = widget.graphics_handle.clone();
     assert!(
-      initial_text.is_some() || widget.graphics_handle.is_some(),
+      initial_text.is_some() || initial_graphics.is_some(),
       "the totals table must render as text or a picture"
     );
 
     // Stepping the Setter to a larger table size must change the
-    // rendered totals.
+    // rendered totals. `Text@Style[Grid[…], 16]` renders as a picture (an
+    // SVG typeset of the styled text), not `text_output` — so the picture,
+    // not the (always-`None`-here) text field, is what must differ.
     if let manipulate::ControlState::Discrete { current_index, .. } =
       &mut widget.controls[0]
     {
@@ -18383,7 +18386,8 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
       widget.error
     );
     assert_ne!(
-      widget.text_output, initial_text,
+      (widget.text_output.clone(), widget.graphics_handle.clone()),
+      (initial_text, initial_graphics),
       "switching the table size must change the rendered totals"
     );
   }
@@ -22078,6 +22082,57 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 30, $CellContext`s$$ = 5}, \"
     assert_eq!(
       stats.result, "{15, 15, 5, 3}",
       "wins, losses, longest win streak, longest loss streak"
+    );
+  }
+
+  /// A `SaveDefinitions -> True` dump can embed a helper as Mathematica's
+  /// full serialized `CompiledFunction[…]` — an id tuple, argument
+  /// patterns, type/constant tables, raw bytecode, the uncompiled pure
+  /// `Function[…]`, and a trailing evaluation flag — rather than the
+  /// `Compile[…]` call woxi's own Initialization cells would produce. woxi
+  /// has no bytecode VM, so calling such a value must fall back to the
+  /// embedded pure function instead of returning unevaluated. Before that
+  /// fallback existed, the unevaluated `CompiledFunction[…][args]` call
+  /// propagated into every Module that referenced the helper, and a
+  /// Manipulate composing it across a few dozen list elements (as several
+  /// roulette/epicycloid-style Demonstrations do) blew the resulting
+  /// expression up to gigabytes and never finished loading. Independently
+  /// written, not copied from any specific Wolfram Demonstration.
+  #[test]
+  fn saved_compiled_function_bytecode_falls_back_to_pure_function() {
+    let r = woxi::interpret(
+      r#"radius = CompiledFunction[{9, 9.0, 1234}, {_Integer, _Real}, {{2, 0, 0}}, {{}}, {0, 1, 2, 0, 0}, {{1}},
+        Function[{steps, angle}, N[steps + angle]], Evaluate];
+      radius[3, 0.5]"#,
+    );
+    assert_eq!(
+      r.unwrap_or_else(|e| format!("<error: {e:?}>")),
+      "3.5",
+      "a serialized CompiledFunction with no runnable bytecode VM must fall \
+       back to evaluating its embedded pure Function, not stay unevaluated"
+    );
+
+    // The same fallback must apply when the compiled helper is composed
+    // repeatedly inside a Manipulate's DynamicModule body — the shape that
+    // actually triggered the expression blow-up.
+    let nb_src = r#"Notebook[{
+Cell[BoxData["radius = CompiledFunction[{9, 9.0, 1234}, {_Integer, _Real}, {{2, 0, 0}}, {{}}, {0, 1, 2, 0, 0}, {{1}}, Function[{steps, angle}, N[steps + angle]], Evaluate]"], "Input"],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[Table[radius[k, offset], {k, 1, count}], {{count, 3, \"count\"}, 1, 6, 1}, {{offset, 0.5, \"offset\"}, 0, 1, 0.1}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ = 0.5}, \"…\"]"], "Output"]
+}, Open]]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "Table[radius[k, offset], …] must evaluate cleanly once radius[k, offset] \
+       reduces to a number instead of staying an ever-growing unevaluated call: {:?}",
+      widget.error
     );
   }
 }


### PR DESCRIPTION
## Summary

Following the scheduled routine that pulls a random Wolfram Demonstration and checks whether Woxi Studio fully supports it, this run picked "Roulette (Hypotrochogon) of a Polygon Rolling inside a Circle". Opening it in Woxi Studio hung and grew to several gigabytes of RAM.

Root cause: the notebook's `SaveDefinitions -> True` dump embeds a helper (`offset`) as Mathematica's fully serialized `CompiledFunction[…]` form — an id tuple, argument patterns, type/constant tables, raw bytecode, the uncompiled pure `Function[…]`, and a trailing evaluation flag — rather than the 2-argument `[specs, body]` shape woxi's own `Compile` produces. woxi has no bytecode VM to run the middle arguments, so calling such a value fell through to the generic case and returned unevaluated. That unevaluated `CompiledFunction[…][args]` call then propagated into every computation built on top of it: the notebook's Manipulate composes the helper across ~75 list elements per render, so the unevaluated expression compounded into a multi-gigabyte blow-up instead of collapsing to a number.

- `src/evaluator/function_application.rs`: when a serialized `CompiledFunction[…]` (not woxi's own 2-arg form) is called, apply its embedded pure `Function[…]` instead of falling through to unevaluated — matching what real Mathematica does when it can't run the compiled bytecode.
- `tests/interpreter_tests/function_definitions.rs`: regression tests for the serialized form, standalone and nested inside a `Module`.
- `woxi-studio/src/main.rs`: an end-to-end regression loading a synthetic notebook whose Manipulate composes such a helper, plus a fix for a pre-existing test bug uncovered along the way — `demonstration_setter_grid_totals_manipulate_switches_table_size` compared `text_output`, which a `Text/Style/Grid` Manipulate never sets (it renders as a picture), so the assertion always compared `None` to `None` and could never fail regardless of whether the picture actually changed.

No code from the source notebook is reproduced; all tests use independently written examples exercising the same construct.

## Test plan
- [x] `make test` (27790 tests, all passing)
- [x] `cargo nextest run -p woxi-studio` (196 tests, all passing)
- [x] `make format`
- [x] Manually verified the actual downloaded notebook now loads in Woxi Studio's notebook-loading path in ~0.5s (previously hung, >5.8GB RAM) via a temporary diagnostic harness (not included in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBmefFbfZenUttdKyaocsD)_