### PR TITLE
Rebuild a Manipulate widget from a standalone box dump with no Input cell

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -2111,6 +2111,72 @@ pub fn saved_initialization_context_symbols(box_dump: &str) -> Vec<String> {
   names
 }
 
+/// The value of `"<key>" :> <value>` inside a FrontEnd box dump, up to the
+/// first top-level comma (or the end of the enclosing bracket/brace/paren).
+/// Skips over string literals, where brackets are just text.
+fn extract_arrow_value<'a>(box_dump: &'a str, key: &str) -> Option<&'a str> {
+  let marker = format!("\"{key}\"");
+  let rel = box_dump.find(&marker)?;
+  let rest = box_dump[rel + marker.len()..].trim_start();
+  let rest = rest.strip_prefix(":>")?.trim_start();
+
+  let mut depth = 0i32;
+  let mut in_string = false;
+  let mut prev_backslash = false;
+  for (i, c) in rest.char_indices() {
+    if in_string {
+      if c == '"' && !prev_backslash {
+        in_string = false;
+      }
+      prev_backslash = c == '\\' && !prev_backslash;
+      continue;
+    }
+    match c {
+      '"' => in_string = true,
+      '(' | '[' | '{' => depth += 1,
+      ')' | ']' | '}' => {
+        if depth == 0 {
+          return Some(rest[..i].trim_end());
+        }
+        depth -= 1;
+      }
+      ',' if depth == 0 => return Some(rest[..i].trim_end()),
+      _ => {}
+    }
+  }
+  let trimmed = rest.trim_end();
+  if trimmed.is_empty() {
+    None
+  } else {
+    Some(trimmed)
+  }
+}
+
+/// Rebuild a plain `Manipulate[body, spec, …]` source expression from a
+/// saved FrontEnd dynamic-widget dump (the `DynamicModuleBox[…]` text
+/// stored in the Output cell of an evaluated `Manipulate[…]`) when there is
+/// no Input cell holding the original source to re-evaluate — e.g. a
+/// notebook downloaded straight from a Wolfram Demonstrations Project share
+/// link, which carries only the compiled `Manipulate\`ManipulateBoxes[…]`
+/// widget and no editable Wolfram Language source.
+///
+/// The dump's `"Body" :> …` and `"Specifications" :> {…}` entries carry
+/// exactly the two pieces a `Manipulate[…]` call needs; `` $CellContext` ``
+/// prefixes and the FrontEnd's line-continuation `\` markers are stripped
+/// the same way [`extract_saved_initialization`] strips them, so the result
+/// evaluates as ordinary session-level input.
+pub fn reconstruct_manipulate_from_box_dump(box_dump: &str) -> Option<String> {
+  let clean = |s: &str| s.replace("$CellContext`", "").replace("\\\n", "");
+  let body = clean(extract_arrow_value(box_dump, "Body")?);
+  let specs = clean(extract_arrow_value(box_dump, "Specifications")?);
+  let specs = specs.trim();
+  let specs_inner = specs.strip_prefix('{')?.strip_suffix('}')?.trim();
+  if specs_inner.is_empty() {
+    return Some(format!("Manipulate[{body}]"));
+  }
+  Some(format!("Manipulate[{body}, {specs_inner}]"))
+}
+
 /// The prefix of `s` up to (excluding) the `)` matching an already-consumed
 /// `(`. Skips over string literals, where parentheses are just text.
 fn matching_paren_prefix(s: &str) -> Option<&str> {
@@ -4768,6 +4834,52 @@ yf4GL4DwC5VA4w
         "DynamicModuleBox[{}, DynamicBox[…]]"
       ),
       Vec::<String>::new()
+    );
+  }
+
+  #[test]
+  fn test_reconstruct_manipulate_from_box_dump() {
+    // A minimal stand-in for the `Manipulate`ManipulateBoxes[…]` structure
+    // Wolfram embeds in a saved Output cell: enough surrounding box syntax
+    // to exercise the extraction, with unrelated keys interleaved the way
+    // the real dump orders "Variables"/"ControllerVariables" before "Body".
+    let dump = "DynamicModuleBox[{$CellContext`a$$ = 2}, \
+      DynamicBox[Manipulate`ManipulateBoxes[\n\
+      1, StandardForm, \n\
+      \"Variables\" :> {$CellContext`a$$ = 2}, \n\
+      \"Body\" :> Plot[$CellContext`a$$*Sin[$CellContext`x], {$CellContext`x, 0, \
+      2 Pi}], \n\
+      \"Specifications\" :> {{{$CellContext`a$$, 2, \"amplitude\"}, 1, 5}}, \n\
+      \"Options\" :> {}],\n\
+      DynamicModuleValues:>{}]]";
+    let src = reconstruct_manipulate_from_box_dump(dump).unwrap();
+    assert_eq!(
+      src,
+      "Manipulate[Plot[a$$*Sin[x], {x, 0, 2 Pi}], {{a$$, 2, \"amplitude\"}, 1, 5}]"
+    );
+  }
+
+  #[test]
+  fn test_reconstruct_manipulate_from_box_dump_multiple_specs() {
+    let dump = "DynamicModuleBox[{}, DynamicBox[Manipulate`ManipulateBoxes[\n\
+      1, StandardForm, \n\
+      \"Body\" :> $CellContext`f[$CellContext`n$$, $CellContext`m$$], \n\
+      \"Specifications\" :> {{{$CellContext`n$$, 1, \"n\"}, 1, 10}, \
+      {{$CellContext`m$$, 1, \"m\"}, {1, 2, 3}}}]]]";
+    let src = reconstruct_manipulate_from_box_dump(dump).unwrap();
+    assert_eq!(
+      src,
+      "Manipulate[f[n$$, m$$], {{n$$, 1, \"n\"}, 1, 10}, {{m$$, 1, \"m\"}, {1, 2, 3}}]"
+    );
+  }
+
+  #[test]
+  fn test_reconstruct_manipulate_from_box_dump_absent() {
+    assert_eq!(
+      reconstruct_manipulate_from_box_dump(
+        "DynamicModuleBox[{}, DynamicBox[…]]"
+      ),
+      None
     );
   }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -537,6 +537,50 @@ impl WoxiStudio {
             editors.push(editor);
             continue;
           }
+          // A standalone dynamic-widget dump with no preceding Input cell —
+          // e.g. a notebook downloaded straight from a Wolfram
+          // Demonstrations Project share link — carries only the compiled
+          // widget, never its source. Rebuild a `Manipulate[…]` expression
+          // straight from the dump's "Body"/"Specifications" entries so the
+          // widget still opens live.
+          if matches!(cell.style, CellStyle::Output | CellStyle::Print)
+            && is_dynamic_box_dump(&cell.content)
+          {
+            if !state_cleared {
+              woxi::clear_state();
+              state_cleared = true;
+            }
+            evaluate_pending_initialization(&mut pending_init);
+            if let Some(state) =
+              instantiate_manipulate_from_box_dump(&cell.content)
+            {
+              editors.push(CellEditor {
+                content: text_editor::Content::with_text(&cell.content),
+                style: cell.style,
+                output: None,
+                stdout: None,
+                graphics_svg: None,
+                graphics_handle: None,
+                graphics_image: None,
+                output_svgs: Vec::new(),
+                output_images: Vec::new(),
+                output_dark: false,
+                output_all_svg: false,
+                sound: None,
+                warnings: Vec::new(),
+                undo_stack: Vec::new(),
+                redo_stack: Vec::new(),
+                output_stale: false,
+                is_collapsed: cell.collapsed,
+                manipulate_state: Some(state),
+                hyperlinks: Vec::new(),
+                stored_graphic: false,
+                output_content: text_editor::Content::new(),
+                stdout_content: text_editor::Content::new(),
+              });
+              continue;
+            }
+          }
           if matches!(cell.style, CellStyle::Input | CellStyle::Code) {
             pending_init.push(cell.content.clone());
           }
@@ -5082,6 +5126,23 @@ fn instantiate_stored_manipulate(
   manipulate::ManipulateState::from_expr(&expr)
 }
 
+/// Rebuild the interactive widget for a standalone stored Output cell that
+/// holds a dynamic-widget dump with no preceding Input cell to fall back
+/// on — e.g. a notebook downloaded straight from a Wolfram Demonstrations
+/// Project share link, which carries only the compiled
+/// `Manipulate\`ManipulateBoxes[…]` widget and no editable source.
+/// [`woxi::notebook::reconstruct_manipulate_from_box_dump`] rebuilds a
+/// plain `Manipulate[…]` source expression from the dump's `"Body"` and
+/// `"Specifications"` entries, which [`instantiate_stored_manipulate`] then
+/// instantiates exactly as it would a notebook's own Input-cell source.
+fn instantiate_manipulate_from_box_dump(
+  stored_output: &str,
+) -> Option<manipulate::ManipulateState> {
+  let code =
+    woxi::notebook::reconstruct_manipulate_from_box_dump(stored_output)?;
+  instantiate_stored_manipulate(&code, stored_output)
+}
+
 fn evaluate_cell_statements(
   editor: &mut CellEditor,
   code: &str,
@@ -8270,6 +8331,72 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`glyph$$ = \"pick a letter\"}, \"…
         assert_eq!(tone, "tone");
         assert_eq!(names, "names");
         assert_eq!(name_values, &["True".to_string(), "False".to_string()]);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
+  /// A notebook downloaded straight from a Wolfram Demonstrations Project
+  /// share link carries only the compiled `Manipulate`ManipulateBoxes[…]`
+  /// widget in a standalone Output cell — there is no Input cell with the
+  /// original `Manipulate[…]` source to fall back on, unlike a notebook
+  /// saved from the desktop FrontEnd (which keeps both). The widget must
+  /// still open live, rebuilt straight from the dump's "Body" and
+  /// "Specifications" entries.
+  #[test]
+  fn standalone_widget_dump_with_no_input_cell_opens_live() {
+    let nb_src = r##"Notebook[{
+Cell[BoxData[
+ DynamicModuleBox[{$CellContext`a$$ = 2, $CellContext`b$$ = 1},
+  DynamicBox[Manipulate`ManipulateBoxes[
+   1, StandardForm,
+   "Variables" :> {$CellContext`a$$ = 2, $CellContext`b$$ = 1},
+   "Body" :> Plot[$CellContext`a$$ Sin[$CellContext`b$$ $CellContext`x], \
+{$CellContext`x, 0, 2 Pi}],
+   "Specifications" :> {{{$CellContext`a$$, 2, "amplitude"}, 1, 5}, \
+{{$CellContext`b$$, 1, "frequency"}, {1, 2, 3}}},
+   "Options" :> {}],
+   DynamicModuleValues:>{}]]], "Output"]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect(
+        "a standalone widget dump with no Input cell must still \
+         instantiate on load",
+      );
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some(), "the plot must draw");
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: a,
+          min: a_min,
+          max: a_max,
+          current: a_now,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: b,
+          values: b_values,
+          ..
+        },
+      ] => {
+        assert_eq!(
+          (a.as_str(), *a_min, *a_max, *a_now),
+          ("a$$", 1.0, 5.0, 2.0)
+        );
+        assert_eq!(b, "b$$");
+        assert_eq!(
+          b_values,
+          &["1".to_string(), "2".to_string(), "3".to_string()]
+        );
       }
       other => panic!("unexpected controls: {other:?}"),
     }


### PR DESCRIPTION
## Summary

- A notebook downloaded straight from a Wolfram Demonstrations Project share link carries only the compiled `Manipulate\`ManipulateBoxes[…]` widget in a standalone `Output` cell — there's no accompanying `Input` cell with the original `Manipulate[…]` source, unlike a notebook saved from the desktop FrontEnd. Woxi Studio's existing widget-reconstruction path re-evaluates that source, so such a notebook previously opened as an unreadable block of raw box syntax instead of a live interactive widget.
- Add `woxi::notebook::reconstruct_manipulate_from_box_dump`, which rebuilds a plain `Manipulate[body, spec, …]` expression straight from the dump's `"Body"` and `"Specifications"` entries (stripping `` $CellContext` `` prefixes and line-continuation markers the same way the existing `SaveDefinitions` handling does).
- Wire it into `editors_from_notebook` for a standalone `Output` cell that is a dynamic-widget dump, reusing the existing `instantiate_stored_manipulate` pipeline (including `SaveDefinitions -> True` initialization handling).
- Verified against a real Demonstration ("A Fifth-Degree Polynomial and Its Derivatives") downloaded from the Wolfram Demonstrations Project: both its `RadioButton` and slider controls now build correctly and the plot renders with no error.

## Test plan

- [x] `cargo nextest run` (workspace root, 27800 tests) — all pass
- [x] `cargo nextest run -p woxi-studio` (198 tests, including 3 new `notebook::` unit tests and 1 new `standalone_widget_dump_with_no_input_cell_opens_live` integration test) — all pass
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `make format`
- [x] Manually verified the fix against a real downloaded Demonstration notebook (not included in the repo — copyrighted content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3HEK75LxuoNuKof19yVL)_