### PR TITLE
Fix Dot and FindRoot quadratic blowups that hung a PDE Demonstration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,25 @@
 
 # Unreleased
 
+- `Dot` sums a vector/matrix product's terms in one `Plus` call instead of
+    folding them pairwise. The pairwise fold re-flattened and re-collected
+    the whole running sum on every term, turning an n-term dot product into
+    O(n²) work; a PDE collocation method's equations — each a numeric
+    matrix row dotted against a vector of unknowns — made this the
+    dominant cost of solving even a moderately large linear system, which
+    is what kept a Wolfram Demonstration's `Manipulate` from ever finishing
+    in Woxi Studio.
+
+- Multivariate `FindRoot` tracks the best iterate seen and stops once the
+    residual stops improving, instead of always running all
+    `MaxIterations -> 100` steps. A numerically ill-conditioned but
+    genuinely linear system (a Chebyshev spectral-collocation
+    differentiation matrix, as PDE-solving Demonstrations commonly build,
+    is a classic example) can have an achievable residual floor above the
+    solver's tolerance purely from `f64` rounding in the linear solve; the
+    loop used to spend every remaining iteration re-evaluating the
+    equations and Jacobian chasing that unreachable tolerance.
+
 - `Table` and `Array` splice a per-iteration `Sequence[…]` result into the
     surrounding list instead of keeping it as one element, matching how
     `List[…]` construction always simplifies. This is what makes

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -387,6 +387,31 @@ fn fallback_plus(a: &Expr, b: &Expr) -> Expr {
   }
 }
 
+/// Sum every term in one `plus_ast` call instead of folding pairwise.
+///
+/// `plus_ast` flattens and re-collects *all* of its arguments on every
+/// call, so folding `n` terms with `n - 1` two-argument calls (`sum =
+/// eval_add(sum, term)`) re-flattens the ever-growing `sum` each time —
+/// O(1) + O(2) + … + O(n) = O(n²) work to add up `n` terms. A dot product
+/// of two length-`n` vectors needs exactly this sum, so that quadratic
+/// blowup turned every `Dot` call in a Newton-solved PDE discretization
+/// (each equation a dot product of a matrix row with hundreds of unknowns)
+/// into the dominant cost of the whole solve. Passing every term to
+/// `plus_ast` at once flattens and combines them in a single pass.
+fn eval_add_many(terms: Vec<Expr>) -> Expr {
+  match terms.len() {
+    0 => Expr::Integer(0),
+    1 => terms.into_iter().next().unwrap(),
+    _ => match crate::functions::math_ast::plus_ast(&terms) {
+      Ok(r) => r,
+      Err(_) => Expr::FunctionCall {
+        name: "Plus".to_string(),
+        args: terms.into(),
+      },
+    },
+  }
+}
+
 fn eval_mul(a: &Expr, b: &Expr) -> Expr {
   match (a, b) {
     (Expr::Integer(x), Expr::Integer(y)) => match x.checked_mul(*y) {
@@ -985,11 +1010,12 @@ pub fn dot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if va.len() != vb.len() {
       return dotsh();
     }
-    let mut sum = Expr::Integer(0);
-    for (a, b) in va.iter().zip(vb.iter()) {
-      sum = eval_add(&sum, &eval_mul(a, b));
-    }
-    return Ok(sum);
+    let terms: Vec<Expr> = va
+      .iter()
+      .zip(vb.iter())
+      .map(|(a, b)| eval_mul(a, b))
+      .collect();
+    return Ok(eval_add_many(terms));
   }
 
   // Matrix . Vector → vector
@@ -1002,11 +1028,12 @@ pub fn dot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     let mut result = Vec::new();
     for row in &ma {
-      let mut sum = Expr::Integer(0);
-      for (a, b) in row.iter().zip(vb.iter()) {
-        sum = eval_add(&sum, &eval_mul(a, b));
-      }
-      result.push(sum);
+      let terms: Vec<Expr> = row
+        .iter()
+        .zip(vb.iter())
+        .map(|(a, b)| eval_mul(a, b))
+        .collect();
+      result.push(eval_add_many(terms));
     }
     return Ok(Expr::List(result.into()));
   }
@@ -1022,11 +1049,9 @@ pub fn dot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let b_cols = mb.first().map_or(0, std::vec::Vec::len);
     let mut result = Vec::with_capacity(b_cols);
     for j in 0..b_cols {
-      let mut sum = Expr::Integer(0);
-      for i in 0..b_rows {
-        sum = eval_add(&sum, &eval_mul(&va[i], &mb[i][j]));
-      }
-      result.push(sum);
+      let terms: Vec<Expr> =
+        (0..b_rows).map(|i| eval_mul(&va[i], &mb[i][j])).collect();
+      result.push(eval_add_many(terms));
     }
     return Ok(Expr::List(result.into()));
   }
@@ -1045,11 +1070,10 @@ pub fn dot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for i in 0..ma.len() {
       let mut row = Vec::new();
       for j in 0..b_cols {
-        let mut sum = Expr::Integer(0);
-        for k in 0..a_cols {
-          sum = eval_add(&sum, &eval_mul(&ma[i][k], &mb[k][j]));
-        }
-        row.push(sum);
+        let terms: Vec<Expr> = (0..a_cols)
+          .map(|k| eval_mul(&ma[i][k], &mb[k][j]))
+          .collect();
+        row.push(eval_add_many(terms));
       }
       result.push(row);
     }

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6865,7 +6865,7 @@ fn find_root_multivariate(
     let resid = fv.iter().fold(0.0f64, |a, &b| a.max(b.abs()));
     if resid < best_resid {
       best_resid = resid;
-      best_x = x.clone();
+      best_x.clone_from(&x);
     }
     if resid < tol {
       break;

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -6643,6 +6643,12 @@ fn find_root_rename_walk(
 
 /// Evaluate `expr` to an f64 with every variable in `vars` bound to the
 /// corresponding value in `vals`, in a single substitution pass.
+///
+/// Builds a fresh `vars`-length binding table on every call, so it is only
+/// cheap when called a handful of times per point. The Newton loop below
+/// evaluates a whole equation *and* Jacobian row at the same point `x` —
+/// call [`find_root_eval_multivar_at`] there instead, sharing one binding
+/// table across all of those calls (see its doc comment).
 fn find_root_eval_multivar(
   expr: &Expr,
   vars: &[String],
@@ -6651,7 +6657,26 @@ fn find_root_eval_multivar(
   let reals: Vec<Expr> = vals.iter().map(|&x| Expr::Real(x)).collect();
   let bindings: Vec<(&str, &Expr)> =
     vars.iter().map(String::as_str).zip(reals.iter()).collect();
-  let e = crate::syntax::substitute_variables(expr, &bindings);
+  find_root_eval_multivar_at(expr, &bindings)
+}
+
+/// Same as [`find_root_eval_multivar`], but takes an already-built binding
+/// table instead of rebuilding one from `vars`/`vals`.
+///
+/// A Newton iteration over `n` variables evaluates `n` equations plus an
+/// `n`×`n` Jacobian at the *same* point — up to `n^2 + n` calls that all
+/// need the identical `var -> value` table. Rebuilding that O(n) table
+/// inside every one of those calls (as [`find_root_eval_multivar`] does)
+/// turns one Newton iteration into O(n^3) work regardless of how sparse
+/// the equations are, since the rebuild cost is paid even when a given
+/// equation or Jacobian entry mentions only a few variables. Building the
+/// table once per iteration and sharing it here keeps that cost O(n) per
+/// iteration instead.
+fn find_root_eval_multivar_at(
+  expr: &Expr,
+  bindings: &[(&str, &Expr)],
+) -> Result<f64, InterpreterError> {
+  let e = crate::syntax::substitute_variables(expr, bindings);
   let evaled = crate::evaluator::evaluate_expr_to_expr(&e)?;
   match &evaled {
     Expr::Integer(k) => Ok(*k as f64),
@@ -6809,19 +6834,51 @@ fn find_root_multivariate(
   // Newton iteration.
   let max_iter = 100;
   let tol = 1e-13;
+  // The point with the smallest residual seen so far, and that residual.
+  // A large, ill-conditioned system (e.g. a PDE collocation matrix, whose
+  // condition number grows with the grid size) can have an achievable
+  // residual floor well above `tol` — f64 rounding in the linear solve
+  // limits it, not the loop's remaining iterations. Once the residual
+  // stops improving from one iteration to the next, every further
+  // iteration is spending equation/Jacobian evaluations (each O(n)-plus)
+  // on numerical noise, not progress: burning through the rest of
+  // `max_iter` this way costs seconds to minutes on a large system
+  // without moving the answer. Tracking the best iterate and stopping the
+  // moment progress stalls returns that already-best point immediately
+  // instead, while leaving genuinely (even slowly) converging cases to
+  // keep iterating exactly as before.
+  let mut best_x = x.clone();
+  let mut best_resid = f64::INFINITY;
+  let mut prev_resid = f64::INFINITY;
   for _ in 0..max_iter {
+    // Shared by every equation/Jacobian evaluation at this point — see
+    // `find_root_eval_multivar_at`'s doc comment for why this must be
+    // built once per iteration rather than once per entry.
+    let reals: Vec<Expr> = x.iter().map(|&v| Expr::Real(v)).collect();
+    let bindings: Vec<(&str, &Expr)> =
+      vars.iter().map(String::as_str).zip(reals.iter()).collect();
+
     let mut fv = vec![0.0; n];
     for (i, f) in eqns.iter().enumerate() {
-      fv[i] = find_root_eval_multivar(f, &vars, &x)?;
+      fv[i] = find_root_eval_multivar_at(f, &bindings)?;
     }
-    if fv.iter().fold(0.0f64, |a, &b| a.max(b.abs())) < tol {
+    let resid = fv.iter().fold(0.0f64, |a, &b| a.max(b.abs()));
+    if resid < best_resid {
+      best_resid = resid;
+      best_x = x.clone();
+    }
+    if resid < tol {
       break;
     }
+    if resid >= prev_resid {
+      break;
+    }
+    prev_resid = resid;
     let mut jm = vec![vec![0.0; n]; n];
     for (i, row) in jac.iter().enumerate() {
       for (j, dij) in row.iter().enumerate() {
         let entry = match dij {
-          Some(d) => quietly(|| find_root_eval_multivar(d, &vars, &x))
+          Some(d) => quietly(|| find_root_eval_multivar_at(d, &bindings))
             .ok()
             .filter(|v| v.is_finite()),
           None => None,
@@ -6853,6 +6910,7 @@ fn find_root_multivariate(
       break;
     }
   }
+  x = best_x;
   let rules: Vec<Expr> = raw_vars
     .iter()
     .zip(&x)

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -8685,6 +8685,66 @@ mod find_root {
       "3.8317059702075125"
     );
   }
+
+  // Regression: a multivariate FindRoot on a genuinely *linear* system
+  // (a Jacobian that doesn't depend on x) should converge in essentially
+  // one Newton step. When the equations come from a numerically
+  // ill-conditioned matrix — a Chebyshev spectral-collocation
+  // differentiation matrix is a classic example, and PDE-solving
+  // Demonstrations commonly build one to discretize a Laplacian — the
+  // achievable residual can plateau well above the loop's tolerance
+  // purely from f64 rounding in the linear solve. The Newton loop used
+  // to burn through all `MaxIterations -> 100` iterations chasing that
+  // unreachable tolerance every single time, each iteration paying for a
+  // fresh equation/Jacobian evaluation — turning a solve that should
+  // finish in a handful of steps into the dominant cost of the whole
+  // computation. Tracking the best iterate seen and stopping as soon as
+  // the residual stops improving fixes this without weakening genuinely
+  // (even slowly) converging cases.
+  #[test]
+  fn ill_conditioned_linear_system_does_not_exhaust_max_iterations() {
+    // A Chebyshev differentiation matrix (Trefethen's standard formula)
+    // for a small spectral grid, applied twice (`Dm . Dm`) to get a
+    // second-derivative operator, then combined via a Kronecker sum into
+    // a 2D discrete Laplacian. Dirichlet boundary points get a trivial
+    // `u == 0` equation; interior points get the Laplacian row dotted
+    // against the full unknown vector, equal to zero except at one
+    // source point — a standard finite-difference/spectral Poisson setup.
+    let code = "\
+      n = 16; \
+      Dm = Table[ \
+        Which[ \
+          i == 0 && j == 0, (2 n^2 + 1)/6., \
+          i == n && j == n, -(2 n^2 + 1)/6., \
+          i == j, -N[Cos[i Pi/n]]/(2 (1 - Cos[i Pi/n]^2)), \
+          True, (If[i == 0 || i == n, 2., 1.]/If[j == 0 || j == n, 2., 1.]) * \
+            (-1)^(i + j)/(N[Cos[i Pi/n]] - N[Cos[j Pi/n]]) \
+        ], \
+        {i, 0, n}, {j, 0, n} \
+      ]; \
+      Dm2 = Dm . Dm; \
+      Lap = KroneckerProduct[Dm2, IdentityMatrix[n + 1]] + \
+        KroneckerProduct[IdentityMatrix[n + 1], Dm2]; \
+      m = (n + 1)^2; \
+      U = Array[u, m]; \
+      idx[p_, q_] := p*(n + 1) + q + 1; \
+      eqns = Flatten[Table[ \
+        If[p == 0 || p == n || q == 0 || q == n, \
+          u[idx[p, q]] == 0, \
+          Lap[[idx[p, q]]] . U == If[p == 8 && q == 8, 1., 0.]], \
+        {p, 0, n}, {q, 0, n}]]; \
+      guess = Table[{u[i], 0.}, {i, 1, m}]; \
+      sol = FindRoot[eqns, guess]; \
+      Length[sol]";
+    let start = std::time::Instant::now();
+    let result = interpret(code).unwrap();
+    assert!(
+      start.elapsed().as_secs() < 15,
+      "FindRoot on an ill-conditioned but linear system must stop once \
+       the residual stops improving, not chase every MaxIterations step"
+    );
+    assert_eq!(result, "289");
+  }
 }
 
 mod replace {

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -159,6 +159,39 @@ mod dot {
       "{2*x, 3*y}"
     );
   }
+
+  // Regression: Vector.Vector (and the Matrix.Vector/Vector.Matrix/
+  // Matrix.Matrix cases built the same way) summed a symbolic dot
+  // product's terms one at a time via repeated two-argument `Plus`
+  // calls (`sum = eval_add(sum, term)`). Each call re-flattens and
+  // re-collects the *whole* running sum, so summing n terms this way is
+  // O(1) + O(2) + … + O(n) = O(n²) — turning a dot product against a
+  // symbolic vector, the shape a PDE collocation method's equations take
+  // (a numeric matrix row dotted with a vector of unknowns), into the
+  // dominant cost of solving even a moderately large linear system. This
+  // stayed hidden in small tests because the quadratic term only bites
+  // once a single dot product has enough distinct symbolic terms.
+  // Passing every term to `Plus` in one call instead keeps the work
+  // linear in the vector length.
+  #[test]
+  fn large_sparse_symbolic_vector_dot_stays_fast() {
+    let start = std::time::Instant::now();
+    let result = interpret(
+      "k = 45; row = Table[If[Mod[i, k] == 0, N[i], 0.], {i, 1, 2000}]; \
+       total = row . Array[x, 2000]; \
+       total /. Table[x[i] -> 1, {i, 1, 2000}]",
+    )
+    .unwrap();
+    assert!(
+      start.elapsed().as_secs() < 5,
+      "a dot product against a symbolic vector must stay near-linear in \
+       the vector length, not quadratic"
+    );
+    // Sum of every multiple of 45 in [1, 2000]: 45 + 90 + ... + 1980.
+    let expected: f64 = (1..=2000).filter(|i| i % 45 == 0).sum::<i64>() as f64;
+    let val: f64 = result.parse().expect("should be a number");
+    assert_eq!(val, expected);
+  }
 }
 
 mod array_dot {


### PR DESCRIPTION
## Summary

- Woxi Studio couldn't open a Wolfram Demonstration ("Heat Transfer in a Bar with Rectangular Cross Section") solving a 2D heat transfer problem via Chebyshev spectral collocation — its `Manipulate` never finished evaluating.
- `Dot` summed a vector/matrix product's terms one pair at a time via repeated two-argument `Plus` calls, each of which re-flattens and re-collects the whole running sum — O(n²) work to add up n terms. Every equation in the collocation system is a numeric matrix row dotted against the vector of unknowns, so this dominated the cost of building the system. Passing every term to `Plus` in one call keeps the work linear in the vector length.
- Multivariate `FindRoot` always ran all `MaxIterations -> 100` Newton steps, even once the residual had stopped improving. A Chebyshev differentiation matrix is ill-conditioned enough that f64 rounding in the linear solve leaves a residual floor above the loop's tolerance; the loop kept re-evaluating equations and Jacobian entries against that unreachable target instead of stopping. It now tracks the best iterate seen and stops as soon as progress stalls.
- Together these bring the Demonstration's solve from effectively never finishing to well under a minute, with a correct rendered contour plot.

## Test plan

- [x] Added `large_sparse_symbolic_vector_dot_stays_fast` (`tests/interpreter_tests/linear_algebra.rs`) — a symbolic vector `Dot` regression bounded at <5s.
- [x] Added `ill_conditioned_linear_system_does_not_exhaust_max_iterations` (`tests/interpreter_tests/algebra.rs`) — a Chebyshev-collocation `FindRoot` regression bounded at <15s.
- [x] `cargo test` — all 25,661 interpreter tests + 576 script snapshot tests pass.
- [x] Downloaded a fresh random Demonstration notebook via the Wolfram Cloud API, confirmed it hung before the fix and renders a correct heat-map contour plot after, via `cargo run --example dump_manipulate`.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01JKPFeZVQAEG19ika5NjT2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKPFeZVQAEG19ika5NjT2M)_