### PR TITLE
Support explicit Ticks in Histogram

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -462,6 +462,11 @@ pub(crate) struct ChartOptions {
   /// renderer computes itself. Currently consumed by `Histogram`.
   pub ticks_x: Option<Vec<(f64, String)>>,
   pub ticks_y: Option<Vec<(f64, String)>>,
+  /// `Ticks -> None` suppresses tick marks/labels on both axes entirely,
+  /// matching `Plot`'s `Ticks` handling. `Automatic`/`All`/an explicit list
+  /// leave this `true` (the explicit list still overrides individual axes
+  /// via `ticks_x`/`ticks_y` above).
+  pub ticks: bool,
 }
 
 /// A chart label with optional rotation angle (in radians).
@@ -1360,6 +1365,7 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
     labeling_function: None,
     ticks_x: None,
     ticks_y: None,
+    ticks: true,
   };
   for opt in &args[1..] {
     if let Some((name, replacement)) =
@@ -1478,21 +1484,24 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
           opts.plot_range_x = rx;
           opts.plot_range_y = ry;
         }
-        // `Ticks -> {xspec, yspec}` with explicit positions (each an
-        // optional `{pos, label}` pair). `None`/`Automatic`/`All` leave the
-        // renderer's own automatic ticks in place — only an explicit list
-        // overrides them, matching Plot's `Ticks` handling.
-        "Ticks" => {
-          if let Expr::List(items) = replacement
-            && (1..=2).contains(&items.len())
-          {
+        // `Ticks -> None` suppresses ticks entirely; `Automatic`/`All` leave
+        // the renderer's own automatic ticks in place; an explicit
+        // `{xspec, yspec}` list overrides individual axes (each entry an
+        // optional `{pos, label}` pair) — matching Plot's `Ticks` handling.
+        "Ticks" => match replacement {
+          Expr::Identifier(s) if s == "None" => opts.ticks = false,
+          Expr::Identifier(s) if s == "Automatic" || s == "All" => {
+            opts.ticks = true;
+          }
+          Expr::List(items) if (1..=2).contains(&items.len()) => {
             opts.ticks_x =
               crate::functions::plot::parse_explicit_ticks(&items[0]);
             if let Some(y) = items.get(1) {
               opts.ticks_y = crate::functions::plot::parse_explicit_ticks(y);
             }
           }
-        }
+          _ => {}
+        },
         "BarOrigin" => {
           // Left/Right give horizontal bars; Bottom/Top stay vertical.
           if let Expr::Identifier(side) = replacement {

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -430,6 +430,10 @@ pub(crate) enum LabelPosition {
 }
 
 /// Parsed chart options.
+// Each flag is an independent Wolfram option (ImageSize's full-width mode,
+// Ticks, …), not a state machine, so they do not collapse into an enum —
+// matching `PlotOptions`, which has the same shape for the same reason.
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ChartOptions {
   pub svg_width: u32,
   pub svg_height: u32,

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -457,6 +457,11 @@ pub(crate) struct ChartOptions {
   /// `LabelingFunction -> f` — applied to each bar value to produce a label
   /// drawn at the bar's end. Stored unevaluated and applied per value.
   pub labeling_function: Option<Expr>,
+  /// `Ticks -> {xspec, yspec}` with explicit positions: each entry is a
+  /// position and the text drawn at it. `None` = the automatic ticks a
+  /// renderer computes itself. Currently consumed by `Histogram`.
+  pub ticks_x: Option<Vec<(f64, String)>>,
+  pub ticks_y: Option<Vec<(f64, String)>>,
 }
 
 /// A chart label with optional rotation angle (in radians).
@@ -1353,6 +1358,8 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
     plot_range_y: None,
     bar_origin_left: false,
     labeling_function: None,
+    ticks_x: None,
+    ticks_y: None,
   };
   for opt in &args[1..] {
     if let Some((name, replacement)) =
@@ -1470,6 +1477,21 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
           let (rx, ry) = crate::functions::plot::parse_plot_range(replacement);
           opts.plot_range_x = rx;
           opts.plot_range_y = ry;
+        }
+        // `Ticks -> {xspec, yspec}` with explicit positions (each an
+        // optional `{pos, label}` pair). `None`/`Automatic`/`All` leave the
+        // renderer's own automatic ticks in place — only an explicit list
+        // overrides them, matching Plot's `Ticks` handling.
+        "Ticks" => {
+          if let Expr::List(items) = replacement
+            && (1..=2).contains(&items.len())
+          {
+            opts.ticks_x =
+              crate::functions::plot::parse_explicit_ticks(&items[0]);
+            if let Some(y) = items.get(1) {
+              opts.ticks_y = crate::functions::plot::parse_explicit_ticks(y);
+            }
+          }
         }
         "BarOrigin" => {
           // Left/Right give horizontal bars; Bottom/Top stay vertical.

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -6757,15 +6757,16 @@ pub(crate) fn generate_histogram_svg(
     let y_major = nice_step(y_max - y_min, AXIS_TICK_TARGET);
     let x_minor_step = x_major / 5.0;
     let y_minor_step = y_major / 5.0;
-    // An axis given explicit `Ticks` draws its own marks/labels at exactly
-    // the positions asked for (after the mesh below), so plotters' automatic
-    // ones on that axis are suppressed here.
-    let x_tick_count = if opts.ticks_x.is_some() {
+    // `Ticks -> None` suppresses automatic ticks on both axes outright. An
+    // axis given explicit `Ticks` draws its own marks/labels at exactly the
+    // positions asked for (after the mesh below), so plotters' automatic
+    // ones on that axis are suppressed here too.
+    let x_tick_count = if !opts.ticks || opts.ticks_x.is_some() {
       0
     } else {
       ((x_hi - x_lo) / x_minor_step).round() as usize + 1
     };
-    let y_tick_count = if opts.ticks_y.is_some() {
+    let y_tick_count = if !opts.ticks || opts.ticks_y.is_some() {
       0
     } else {
       ((y_max - y_min) / y_minor_step).round() as usize + 1
@@ -6895,7 +6896,8 @@ pub(crate) fn generate_histogram_svg(
 
   // Extend labeled (major) ticks beyond the minor ticks drawn by plotters.
   // An axis given explicit `Ticks` draws its own marks/labels below instead,
-  // so the automatic majors must not be extended over it.
+  // so the automatic majors must not be extended over it; `Ticks -> None`
+  // suppresses this on both axes.
   {
     let x_major = nice_step(x_hi - x_lo, AXIS_TICK_TARGET);
     let y_major = nice_step(y_max - y_min, AXIS_TICK_TARGET);
@@ -6905,8 +6907,8 @@ pub(crate) fn generate_histogram_svg(
       plot_y0,
       plot_w,
       plot_h,
-      (opts.ticks_x.is_none()).then_some((x_lo, x_hi, x_major)),
-      (opts.ticks_y.is_none()).then_some((y_min, y_max, y_major)),
+      (opts.ticks && opts.ticks_x.is_none()).then_some((x_lo, x_hi, x_major)),
+      (opts.ticks && opts.ticks_y.is_none()).then_some((y_min, y_max, y_major)),
       MINOR_TICK_LEN as f64 * sf,
       MAJOR_TICK_LEN as f64 * sf,
       sf,

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -2342,8 +2342,13 @@ fn grid_line_props(
 /// the tick was given as an expression (`Pi/2` reads `π/2`).
 /// `area` is the plotting rectangle `(x0, y0, w, h)` and `range` the data
 /// range `(x_min, x_max, y_min, y_max)` it maps, both in render units.
-fn explicit_ticks_svg(
-  opts: &PlotOptions,
+///
+/// Takes the explicit tick lists directly (rather than a whole options
+/// struct) so the plotters-based chart renderers (`Histogram`, `BarChart`, …)
+/// can share this one drawing routine instead of duplicating it.
+pub(crate) fn explicit_ticks_svg(
+  ticks_x: Option<&Vec<(f64, String)>>,
+  ticks_y: Option<&Vec<(f64, String)>>,
   (plot_x0, plot_y0, plot_w, plot_h): (f64, f64, f64, f64),
   (x_min, x_max, y_min, y_max): (f64, f64, f64, f64),
   sf: f64,
@@ -2353,7 +2358,7 @@ fn explicit_ticks_svg(
   let axis_y = plot_y0 + plot_h;
   let tick_len = sf * 5.0;
   let tick_font = sf * 13.0;
-  if let Some(ticks) = &opts.ticks_x {
+  if let Some(ticks) = ticks_x {
     for (pos, label) in ticks {
       if *pos < x_min || *pos > x_max || x_max <= x_min {
         continue;
@@ -2369,7 +2374,7 @@ fn explicit_ticks_svg(
       ));
     }
   }
-  if let Some(ticks) = &opts.ticks_y {
+  if let Some(ticks) = ticks_y {
     for (pos, label) in ticks {
       if *pos < y_min || *pos > y_max || y_max <= y_min {
         continue;
@@ -3463,7 +3468,8 @@ fn generate_svg_with_options(
 
     if let Some(insert_pos) = buf.rfind("</svg>") {
       let mut labels_svg = explicit_ticks_svg(
-        opts,
+        opts.ticks_x.as_ref(),
+        opts.ticks_y.as_ref(),
         (plot_x0, margin_top, plot_w, plot_h),
         (x_min, x_max, y_min, y_max),
         sf,
@@ -4416,7 +4422,8 @@ pub(crate) fn generate_scatter_svg_with_options(
   // in the same place the automatic ones would sit.
   if opts.ticks_x.is_some() || opts.ticks_y.is_some() {
     let ticks_svg = explicit_ticks_svg(
-      opts,
+      opts.ticks_x.as_ref(),
+      opts.ticks_y.as_ref(),
       (plot_x0, plot_y0, plot_w, plot_h),
       (x_min, x_max, y_min, y_max),
       RESOLUTION_SCALE as f64,
@@ -6750,8 +6757,19 @@ pub(crate) fn generate_histogram_svg(
     let y_major = nice_step(y_max - y_min, AXIS_TICK_TARGET);
     let x_minor_step = x_major / 5.0;
     let y_minor_step = y_major / 5.0;
-    let x_tick_count = ((x_hi - x_lo) / x_minor_step).round() as usize + 1;
-    let y_tick_count = ((y_max - y_min) / y_minor_step).round() as usize + 1;
+    // An axis given explicit `Ticks` draws its own marks/labels at exactly
+    // the positions asked for (after the mesh below), so plotters' automatic
+    // ones on that axis are suppressed here.
+    let x_tick_count = if opts.ticks_x.is_some() {
+      0
+    } else {
+      ((x_hi - x_lo) / x_minor_step).round() as usize + 1
+    };
+    let y_tick_count = if opts.ticks_y.is_some() {
+      0
+    } else {
+      ((y_max - y_min) / y_minor_step).round() as usize + 1
+    };
 
     chart
       .configure_mesh()
@@ -6876,6 +6894,8 @@ pub(crate) fn generate_histogram_svg(
     render_height as f64 - top_margin as f64 - 10.0 * sf - x_label_area as f64;
 
   // Extend labeled (major) ticks beyond the minor ticks drawn by plotters.
+  // An axis given explicit `Ticks` draws its own marks/labels below instead,
+  // so the automatic majors must not be extended over it.
   {
     let x_major = nice_step(x_hi - x_lo, AXIS_TICK_TARGET);
     let y_major = nice_step(y_max - y_min, AXIS_TICK_TARGET);
@@ -6885,8 +6905,8 @@ pub(crate) fn generate_histogram_svg(
       plot_y0,
       plot_w,
       plot_h,
-      Some((x_lo, x_hi, x_major)),
-      Some((y_min, y_max, y_major)),
+      (opts.ticks_x.is_none()).then_some((x_lo, x_hi, x_major)),
+      (opts.ticks_y.is_none()).then_some((y_min, y_max, y_major)),
       MINOR_TICK_LEN as f64 * sf,
       MAJOR_TICK_LEN as f64 * sf,
       sf,
@@ -6898,7 +6918,14 @@ pub(crate) fn generate_histogram_svg(
   let font_size = sf * 18.0;
   let title_font_size = sf * 22.0;
   if let Some(insert_pos) = buf.rfind("</svg>") {
-    let mut labels_svg = String::new();
+    let mut labels_svg = explicit_ticks_svg(
+      opts.ticks_x.as_ref(),
+      opts.ticks_y.as_ref(),
+      (plot_x0, plot_y0, plot_w, plot_h),
+      (x_lo, x_hi, y_min, y_max),
+      sf,
+      label_fill,
+    );
     let axis_y = plot_y0 + plot_h;
 
     // FrameLabel: centred outside the bottom/left edge.

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -40,6 +40,29 @@ fn y_tick_labels(svg: &str) -> Vec<String> {
   labels.into_iter().map(|(_, text)| text).collect()
 }
 
+/// The x-axis tick labels of a rendered plot, left to right — the
+/// `text-anchor="middle"` counterpart of `y_tick_labels` above. Needed
+/// because a bare `svg.contains(">1</text>")`-style check can't tell an
+/// x-axis label from an unrelated y-axis label with the same text (and
+/// plotters wraps an automatic label's text in newlines, e.g. `>\n1\n</text>`,
+/// unlike the inline `>a</text>` explicit ticks render).
+fn x_tick_labels(svg: &str) -> Vec<String> {
+  let mut labels: Vec<(i64, String)> = svg
+    .split("<text ")
+    .skip(1)
+    .filter_map(|tag| tag.split_once('>'))
+    .filter(|(open, _)| open.contains("text-anchor=\"middle\""))
+    .filter_map(|(open, rest)| {
+      let x = open.split("x=\"").nth(1)?.split('"').next()?;
+      let text = rest.split('<').next()?.trim().to_string();
+      Some((x.parse::<f64>().ok()? as i64, text))
+    })
+    .filter(|(_, text)| !text.is_empty())
+    .collect();
+  labels.sort_by_key(|(x, _)| *x);
+  labels.into_iter().map(|(_, text)| text).collect()
+}
+
 /// Remove the embedded-font `<defs><style>…</style></defs>` block the exporter
 /// injects right after the opening `<svg>` tag, leaving the rest untouched.
 fn strip_font_style(svg: &str) -> String {
@@ -9291,23 +9314,14 @@ ParametricPlot[f[t], {t, 0, 1}]]",
         "Histogram[{1, 2, 2, 3, 3, 3, 4, 4, 5}, {1}, Ticks -> \
          {{{1.5, \"a\"}, {2.5, \"b\"}, {3.5, \"c\"}}, Automatic}]",
       );
+      // The x axis shows exactly the explicit labels, in position order —
+      // none of the automatic bin-edge labels (1, 2, 3, 4, 5) leak through.
+      assert_eq!(x_tick_labels(&svg), ["a", "b", "c"]);
+      // The y axis (left on `Automatic`) keeps its own automatic labels,
+      // unaffected by the x axis's explicit ones.
       assert!(
-        svg.contains(">a</text>"),
-        "explicit x tick label 'a' missing"
-      );
-      assert!(
-        svg.contains(">b</text>"),
-        "explicit x tick label 'b' missing"
-      );
-      assert!(
-        svg.contains(">c</text>"),
-        "explicit x tick label 'c' missing"
-      );
-      // The automatic x labels (bin edges 1, 2, 3, 4, 5) must not leak
-      // through once explicit ticks replace them.
-      assert!(
-        !svg.contains(">1</text>"),
-        "automatic x tick label must be suppressed: {svg}"
+        !y_tick_labels(&svg).is_empty(),
+        "y axis should keep its automatic labels: {svg}"
       );
     }
 
@@ -9318,13 +9332,34 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       let svg = export_svg(
         "Histogram[{1, 2, 2, 3, 3, 3}, {1}, Ticks -> {{{1.5, \"lo\"}}}]",
       );
-      assert!(svg.contains(">lo</text>"), "explicit x tick label missing");
+      assert_eq!(x_tick_labels(&svg), ["lo"]);
       // Automatic y labels (e.g. the tallest bar's count) still show up,
       // same as without any `Ticks` option at all.
-      assert!(
-        svg.contains(">3</text>") == default_svg.contains(">3</text>"),
+      assert_eq!(
+        y_tick_labels(&svg),
+        y_tick_labels(&default_svg),
         "y axis must keep its automatic labels when only x ticks are given"
       );
+    }
+
+    #[test]
+    fn histogram_ticks_none_suppresses_all_ticks() {
+      // `Ticks -> None` draws no tick marks/labels on either axis, matching
+      // Plot's `Ticks -> None` semantics.
+      let svg = export_svg("Histogram[{1, 2, 2, 3, 3, 3}, {1}, Ticks -> None]");
+      assert!(
+        x_tick_labels(&svg).is_empty(),
+        "no automatic x tick labels expected with Ticks -> None: {svg}"
+      );
+      assert!(
+        y_tick_labels(&svg).is_empty(),
+        "no automatic y tick labels expected with Ticks -> None: {svg}"
+      );
+      // A *different* Histogram call without `Ticks -> None` still shows its
+      // automatic labels on both axes (independent options per call).
+      let svg_default = export_svg("Histogram[{1, 2, 2, 3, 3, 3}, {1}]");
+      assert!(!x_tick_labels(&svg_default).is_empty());
+      assert!(!y_tick_labels(&svg_default).is_empty());
     }
 
     #[test]

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -9283,6 +9283,51 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     }
 
     #[test]
+    fn histogram_explicit_ticks() {
+      // `Ticks -> {xspec, yspec}` draws exactly the given x positions/labels
+      // (bin-center labels here) instead of the automatic "nice step" ones,
+      // and leaves the y axis on `Automatic` untouched.
+      let svg = export_svg(
+        "Histogram[{1, 2, 2, 3, 3, 3, 4, 4, 5}, {1}, Ticks -> \
+         {{{1.5, \"a\"}, {2.5, \"b\"}, {3.5, \"c\"}}, Automatic}]",
+      );
+      assert!(
+        svg.contains(">a</text>"),
+        "explicit x tick label 'a' missing"
+      );
+      assert!(
+        svg.contains(">b</text>"),
+        "explicit x tick label 'b' missing"
+      );
+      assert!(
+        svg.contains(">c</text>"),
+        "explicit x tick label 'c' missing"
+      );
+      // The automatic x labels (bin edges 1, 2, 3, 4, 5) must not leak
+      // through once explicit ticks replace them.
+      assert!(
+        !svg.contains(">1</text>"),
+        "automatic x tick label must be suppressed: {svg}"
+      );
+    }
+
+    #[test]
+    fn histogram_explicit_ticks_x_only() {
+      // `Ticks -> {xspec}` (no yspec) leaves the y axis on its own default.
+      let default_svg = export_svg("Histogram[{1, 2, 2, 3, 3, 3}, {1}]");
+      let svg = export_svg(
+        "Histogram[{1, 2, 2, 3, 3, 3}, {1}, Ticks -> {{{1.5, \"lo\"}}}]",
+      );
+      assert!(svg.contains(">lo</text>"), "explicit x tick label missing");
+      // Automatic y labels (e.g. the tallest bar's count) still show up,
+      // same as without any `Ticks` option at all.
+      assert!(
+        svg.contains(">3</text>") == default_svg.contains(">3</text>"),
+        "y axis must keep its automatic labels when only x ticks are given"
+      );
+    }
+
+    #[test]
     fn histogram_image_size() {
       let svg =
         export_svg("Histogram[{1, 2, 2, 3, 3, 3}, ImageSize -> {500, 400}]");

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -21479,6 +21479,181 @@ SaveDefinitions -> True]";
     );
   }
 
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook
+  /// simulating repeated die rolls and histogramming the results.
+  /// Independently written, not copied from any specific Demonstration:
+  /// this version rolls one die (not two summed), lets the number of sides
+  /// vary via its own explicit-choice slider, and tracks a running tally of
+  /// one chosen face via `Count` rather than the mode of a sum.
+  ///
+  /// The construct worth pinning down is the combination the sampled
+  /// Demonstration leans on: an explicit-value-list slider
+  /// (`{{sides, 6, …}, {4, 6, 8, 10, 12}}`) alongside a min/max/step slider
+  /// with `Appearance -> "Labeled"`, two `ControlType -> None` hidden state
+  /// variables a `Button` rewrites, `TrackedSymbols`, `AutorunSequencing`,
+  /// and an `Initialization :> (…)` block defining both a small
+  /// `Disk`/`Rectangle` die-face helper and a `Module`-based histogram
+  /// helper — including that helper's `Histogram[…, Ticks -> {explicit, …}]`
+  /// call, so this also exercises `Histogram`'s explicit-`Ticks` rendering
+  /// through the full Studio pipeline (not just a bare `Histogram[…]` call).
+  #[test]
+  fn demonstration_die_roll_histogram_manipulate_renders_with_hidden_state() {
+    let code = r#"Manipulate[
+      Column[{
+        rollHistogram[history, sides],
+        Row[{faceGraphic[Last[history]], "   tally: ", ToString[tally]}]
+      }],
+      Button["roll again",
+        history = Table[RandomInteger[{1, sides}], {trialCount}];
+        tally = Count[history, sides]
+      ],
+      {{sides, 6, "die sides"}, {4, 6, 8, 10, 12}},
+      {{trialCount, 30, "rolls"}, 1, 200, 1, Appearance -> "Labeled"},
+      {{history, {1, 2, 3}}, ControlType -> None},
+      {{tally, 0}, ControlType -> None},
+      TrackedSymbols :> {sides, trialCount, history, tally},
+      AutorunSequencing -> {1},
+      Initialization :> (
+        pipOffsets = {
+          {{0, 0}},
+          {{0.5, 0.5}, {-0.5, -0.5}},
+          {{0.5, 0.5}, {0, 0}, {-0.5, -0.5}}
+        };
+        faceGraphic[face_] := Graphics[
+          {{White, EdgeForm[Black], Rectangle[{-1, -1}, {1, 1}]},
+           {Black,
+            Disk[#, 0.15] & /@
+              pipOffsets[[Mod[face - 1, Length[pipOffsets]] + 1]]}},
+          ImageSize -> 40
+        ];
+        rollHistogram[data_, n_] := Module[{edges},
+          edges = Range[0.5, n + 0.5];
+          If[Length[data] == 0,
+            Graphics[{}, ImageSize -> {200, 150}],
+            Histogram[data, {edges}, ChartStyle -> Blue,
+              Ticks -> {Table[{k, ToString[k]}, {k, 1, n}], Automatic},
+              ImageSize -> {200, 150}]
+          ]
+        ];
+      )
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "an explicit-list slider, a Labeled slider, two hidden ControlType \
+       -> None variables and a Module/graphics Initialization block \
+       should all build a ManipulateState",
+    );
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the die face must render");
+
+    // The Button is its own control row (binding no variable); the two
+    // hidden `ControlType -> None` variables bind no visible row at all.
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(
+      names,
+      ["", "sides", "trialCount"],
+      "the button plus the two visible sliders, in spec order"
+    );
+    assert!(matches!(
+      &state.controls[0],
+      manipulate::ControlState::Button { .. }
+    ));
+
+    match &state.controls[1] {
+      manipulate::ControlState::Discrete {
+        values,
+        current_index,
+        ..
+      } => {
+        assert_eq!(values, &["4", "6", "8", "10", "12"]);
+        assert_eq!(*current_index, 1, "sides should start at 6");
+      }
+      other => panic!("sides should be an explicit-choice control: {other:?}"),
+    }
+    match &state.controls[2] {
+      manipulate::ControlState::Continuous {
+        min, max, current, ..
+      } => assert_eq!((*min, *max, *current), (1.0, 200.0, 30.0)),
+      other => panic!("trialCount should be a Labeled slider: {other:?}"),
+    }
+
+    let hidden = |s: &manipulate::ManipulateState, name: &str| -> String {
+      s.state
+        .iter()
+        .find(|(n, _)| n == name)
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+    };
+    assert_eq!(hidden(&state, "history"), "{1, 2, 3}");
+    assert_eq!(hidden(&state, "tally"), "0");
+
+    // Re-evaluate the body directly to inspect the actual rendered SVG: the
+    // Module-based helper's `Histogram[…, Ticks -> {explicit list, …}]`
+    // must draw exactly the face labels it was given (1..6 for the default
+    // 6-sided die), not the automatic "nice step" ones.
+    let render_body = |s: &manipulate::ManipulateState| -> String {
+      let bindings: Vec<(String, String)> = s
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .chain(s.state.iter().cloned())
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&s.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the histogram + die face must render")
+    };
+    let svg = render_body(&state);
+    for face in 1..=6 {
+      assert!(
+        svg.contains(&format!(">{face}</text>")),
+        "explicit histogram tick label {face} missing: {svg}"
+      );
+    }
+    // Pip dots from the die-face helper's `Disk[...]`.
+    assert!(
+      svg.contains("<circle") || svg.contains("<ellipse"),
+      "the die face's pips must render as circles: {svg}"
+    );
+
+    // Pressing the button rewrites both hidden state variables; the widget
+    // must keep rendering afterwards with the new roll history.
+    let reroll = state
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Button { action, .. } => Some(action.clone()),
+        _ => None,
+      })
+      .expect("a reroll button");
+    state.apply_button_action(&reroll);
+    assert!(
+      state.error.is_none(),
+      "reroll button failed: {:?}",
+      state.error
+    );
+    assert_ne!(
+      hidden(&state, "history"),
+      "{1, 2, 3}",
+      "the button must overwrite the hidden roll history"
+    );
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "re-render after rerolling failed: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+  }
+
   /// visualizing node-prominence measures on a network: a `GraphPlot` whose
   /// `VertexRenderingFunction` sizes each point by a chosen centrality
   /// measure, with a `SetterBar` picking which of several small hardcoded


### PR DESCRIPTION
## Summary
- `Histogram` now accepts `Ticks -> {xspec, yspec}` with explicit `{position, label}` pairs, matching the support `Plot` already had.
- The shared tick-drawing routine (`explicit_ticks_svg`) is reused rather than duplicated across chart renderers, per the project's "never implement a construct twice" rule.
- Explicit ticks on an axis suppress that axis's automatic ("nice step") ticks so labels don't collide.

This gap was found while checking whether a randomly sampled Wolfram Demonstrations Project notebook (a dice-rolling/histogram simulation) renders correctly end-to-end in Woxi Studio. The notebook's `Manipulate` widget used a `Module`-based helper function that called `Histogram[..., Ticks -> {explicit list, Automatic}]`, which previously fell through to the automatic tick logic and silently ignored the explicit labels.

## Changes
- `src/functions/chart.rs`: parse `Ticks -> {xspec, yspec}` in `ChartOptions` for `Histogram`.
- `src/functions/plot.rs`: generalize `explicit_ticks_svg` to take tick lists directly (instead of a whole `PlotOptions`) so it can be shared by the histogram/chart renderer too; wire explicit ticks into `generate_histogram_svg`, suppressing the automatic ticks on any axis that has them.
- `tests/interpreter_tests/graphics.rs`: unit tests for `Histogram` with explicit x ticks (and mixed explicit-x/automatic-y).
- `woxi-studio/src/main.rs`: an original (not copied from any Demonstration) Studio-level regression test — a `Manipulate` with an explicit-choice slider, a `Labeled` min/max/step slider, two `ControlType -> None` hidden state variables, `TrackedSymbols`, `AutorunSequencing`, an `Initialization :> (...)` block defining helper functions (including a `Histogram` call using explicit `Ticks`), and a `Button` that mutates hidden state and triggers a re-render — verifying the whole pipeline builds, renders, and survives a button-driven state update.

## Test plan
- [x] `make test` — 27799 tests passed
- [x] `make test-studio` — 198 tests passed (includes the new regression test)
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_018dke3qSnLYvCpBc2qibJwV)_