### PR TITLE
Fix FindRoot secant domain excursions and Grid/LineLegend rendering gaps

### DIFF
--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -4644,6 +4644,11 @@ pub(crate) fn lays_out_a_graphic(expr: &Expr) -> bool {
   {
     return true;
   }
+  // A bare `LineLegend[…]` is a picture too — a Demonstration placing a
+  // legend beside its plot rather than attached via `Legended`.
+  if matches!(expr, Expr::FunctionCall { name, .. } if name == "LineLegend") {
+    return true;
+  }
   match expr {
     Expr::List(items) => items.iter().any(lays_out_a_graphic),
     // `Pane` and `Deploy` are transparent here: their own arms export what
@@ -5111,6 +5116,12 @@ pub(crate) fn expr_to_svg(expr: &Expr) -> String {
       if name == "Legended" && !args.is_empty() =>
     {
       expr_to_svg(&args[0])
+    }
+    // A bare `LineLegend[…]` (not wrapped in `Legended`) is how a
+    // Demonstration places a legend beside its plot instead of attached to
+    // it — the front end typesets it as swatches either way.
+    Expr::FunctionCall { name, args } if name == "LineLegend" => {
+      crate::functions::graphics::line_legend_svg(args).unwrap_or_default()
     }
     // ComputationalMusic objects render as musical-staff notation.
     Expr::FunctionCall { name, .. }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1226,6 +1226,90 @@ pub(crate) fn color_swatch_svg(color: &Color) -> String {
   )
 }
 
+/// Render a standalone `LineLegend[{styles…}, {labels…}]` as its own small
+/// picture: one row per entry, a short line sample drawn in that entry's
+/// style followed by its label. A bare `LineLegend` (not wrapped in
+/// `Legended`) is how Demonstrations commonly place a legend beside a plot
+/// rather than attached to it via `PlotLegends`, and Wolfram's front end
+/// typesets it the same way either way — as swatches, not as source text.
+///
+/// Each style entry is either a plain color directive or a list ending in
+/// one (`{Thickness[Tiny], color}`, `{Dashing[{0, Small}], color}`);
+/// `apply_directive` — the same directive parser `Graphics` primitives use
+/// — reads each one, so `Thickness`/`AbsoluteThickness`/`Dashing` on a
+/// legend line render exactly as they would on the plotted line itself.
+pub(crate) fn line_legend_svg(args: &[Expr]) -> Option<String> {
+  if args.len() < 2 {
+    return None;
+  }
+  let Expr::List(style_specs) = &args[0] else {
+    return None;
+  };
+  let Expr::List(labels) = &args[1] else {
+    return None;
+  };
+  if style_specs.is_empty() || labels.is_empty() {
+    return None;
+  }
+
+  let sample_w = 30.0_f64;
+  let sample_h = 16.0_f64;
+  // `thickness_px`/`dash_attr` only read `bb` for the (unused, since a
+  // legend sample has no data range) relative-dashing branch, so any
+  // BBox is fine here.
+  let bb = BBox {
+    x_min: 0.0,
+    x_max: 1.0,
+    y_min: 0.0,
+    y_max: 1.0,
+  };
+
+  let mut entries: Vec<Expr> = Vec::new();
+  for (label, spec) in labels.iter().zip(style_specs.iter()) {
+    let mut style = StyleState::default();
+    // LineLegend's sample draws a plain visible stroke by default — not
+    // the hairline `AbsoluteThickness[1]` an undirected `Line[…]`
+    // primitive gets — so an entry with no `Thickness` directive of its
+    // own still reads as a line, matching wolframscript's legend.
+    style.thickness = 0.05;
+    match spec {
+      Expr::List(directives) => {
+        for d in directives {
+          apply_directive(d, &mut style);
+        }
+      }
+      other => {
+        apply_directive(other, &mut style);
+      }
+    }
+    let sw = thickness_px(style.thickness, &bb, sample_w).max(1.0);
+    let dash = dash_attr(style.dashing.as_ref(), &bb, sample_w);
+    let y = sample_h / 2.0;
+    let line_svg = format!(
+      "<svg width=\"{sample_w}\" height=\"{sample_h}\" viewBox=\"0 0 {sample_w} {sample_h}\" xmlns=\"http://www.w3.org/2000/svg\"><line x1=\"1\" y1=\"{y:.1}\" x2=\"{x2:.1}\" y2=\"{y:.1}\" stroke=\"{color}\" stroke-width=\"{sw:.2}\"{dash} stroke-linecap=\"butt\"/></svg>",
+      x2 = sample_w - 1.0,
+      color = style.color.to_svg_rgb(),
+    );
+    let line_item = Expr::Graphics {
+      svg: line_svg,
+      is_3d: false,
+      source: None,
+      head: None,
+      structure: None,
+    };
+    entries.push(call(
+      "Row",
+      vec![Expr::List(
+        vec![line_item, Expr::String(" ".to_string()), label.clone()].into(),
+      )],
+    ));
+  }
+  if entries.is_empty() {
+    return None;
+  }
+  column_to_svg(&[Expr::List(entries.into())])
+}
+
 // ── Directive parsing ────────────────────────────────────────────────────
 
 fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
@@ -11791,6 +11875,28 @@ pub fn parse_grid_style(directives: &[Expr]) -> GridStyle {
 /// expression's text form.
 fn grid_cell_graphic(cell: &Expr) -> Option<(String, f64, f64)> {
   let svg = match cell {
+    // `"label" -> Graphics[…]` is the idiom Wolfram demonstrations use for
+    // a caption row with an inline swatch (e.g. a color-preview disk next
+    // to its name). WL typesets a `Rule` as its pattern, an arrow, and its
+    // replacement, so build exactly that through the row layout rather
+    // than a bespoke composer, and only when the replacement is actually a
+    // picture — a `Rule` between two plain values still prints as text.
+    Expr::Rule {
+      pattern,
+      replacement,
+    } if grid_cell_graphic(replacement).is_some() => {
+      let row = Expr::List(
+        vec![
+          (**pattern).clone(),
+          Expr::String("\u{2192}".to_string()),
+          (**replacement).clone(),
+        ]
+        .into(),
+      );
+      return row_to_svg(std::slice::from_ref(&row)).and_then(|svg| {
+        parse_svg_dimensions(&svg).map(|d| (svg, d.nat_w, d.nat_h))
+      });
+    }
     Expr::Graphics { svg, .. } => svg.clone(),
     // A styled graphic is still a graphic.
     Expr::FunctionCall { name, args }
@@ -11808,6 +11914,12 @@ fn grid_cell_graphic(cell: &Expr) -> Option<(String, f64, f64)> {
     // button and the waveform — rather than the `Play[…]` source text.
     Expr::FunctionCall { name, .. } if name == "Sound" || name == "Play" => {
       crate::functions::sound::sound_svg(cell)?
+    }
+    // A bare `LineLegend[…]` cell (not wrapped in `Legended`) is a legend
+    // key a Demonstration placed beside its plot — drawn as swatches, the
+    // same as when it is Legended's second argument.
+    Expr::FunctionCall { name, args } if name == "LineLegend" => {
+      line_legend_svg(args)?
     }
     // As above, a display wrapper that resolves to a picture is drawn
     // rather than printed as source.

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1266,12 +1266,14 @@ pub(crate) fn line_legend_svg(args: &[Expr]) -> Option<String> {
 
   let mut entries: Vec<Expr> = Vec::new();
   for (label, spec) in labels.iter().zip(style_specs.iter()) {
-    let mut style = StyleState::default();
     // LineLegend's sample draws a plain visible stroke by default — not
     // the hairline `AbsoluteThickness[1]` an undirected `Line[…]`
     // primitive gets — so an entry with no `Thickness` directive of its
     // own still reads as a line, matching wolframscript's legend.
-    style.thickness = 0.05;
+    let mut style = StyleState {
+      thickness: 0.05,
+      ..StyleState::default()
+    };
     match spec {
       Expr::List(directives) => {
         for d in directives {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5880,9 +5880,9 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut x_prev = x0;
     let mut x_curr = x1_opt.unwrap_or(x0 + 0.1);
     let mut f_prev = find_root_eval_at(&func, &var, x_prev)?;
+    let mut f_curr = find_root_eval_at(&func, &var, x_curr)?;
 
     for _ in 0..max_iter {
-      let f_curr = find_root_eval_at(&func, &var, x_curr)?;
       if f_curr.abs() < tol {
         break;
       }
@@ -5890,10 +5890,37 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if denom.abs() < 1e-30 {
         break;
       }
-      let x_next = x_curr - f_curr * (x_curr - x_prev) / denom;
+      let step = f_curr * (x_curr - x_prev) / denom;
+      // A step can overshoot out of the function's real domain — e.g. a
+      // fractional power's base going negative — where evaluating the
+      // residual there yields a complex number rather than a real one.
+      // Halve the step toward the current point until it lands somewhere
+      // evaluable, the same backtracking the damped-Newton path above
+      // uses, instead of failing the whole solve over one bad iterate.
+      let mut shrink = 1.0;
+      let mut x_next = x_curr - step;
+      let mut f_next = find_root_eval_at(&func, &var, x_next)
+        .ok()
+        .filter(|v| v.is_finite());
+      for _ in 0..FIND_ROOT_MAX_BACKTRACKS {
+        if f_next.is_some() {
+          break;
+        }
+        shrink *= 0.5;
+        x_next = x_curr - step * shrink;
+        f_next = find_root_eval_at(&func, &var, x_next)
+          .ok()
+          .filter(|v| v.is_finite());
+      }
+      let Some(f_next_val) = f_next else {
+        return Err(InterpreterError::EvaluationError(
+          "FindRoot: cannot evaluate expression numerically".into(),
+        ));
+      };
       x_prev = x_curr;
       f_prev = f_curr;
       x_curr = x_next;
+      f_curr = f_next_val;
     }
 
     let result_val = Expr::Real(x_curr);

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -9398,6 +9398,51 @@ mod findroot_symbolic_start {
   }
 }
 
+// A two-point `{var, x0, x1}` spec runs the secant method. Its raw step can
+// overshoot into a region where the residual isn't a real number — e.g. a
+// fractional power's base going negative — which used to abort the whole
+// solve with `FindRoot::nlnum` even though a root exists inside the given
+// bracket. The secant loop now backtracks (halves the step toward the
+// current point) the same way the damped single-point Newton path already
+// does, instead of failing on the first bad iterate.
+mod findroot_secant_domain_backtracking {
+  use super::*;
+
+  #[test]
+  fn secant_recovers_from_fractional_power_going_negative() {
+    // With coefficient 50, an unguarded secant step from {0.001, 0.9}
+    // lands on a negative x on its third iterate, where x^0.6 is complex —
+    // this used to report FindRoot::nlnum instead of the real root.
+    let result = interpret("FindRoot[5 == 50*x^0.6, {x, 0.001, 0.9}]").unwrap();
+    assert_eq!(result, "{x -> 0.021544346900318825}");
+  }
+
+  #[test]
+  fn secant_recovered_root_actually_solves_the_equation() {
+    let root =
+      interpret("x /. FindRoot[5 == 50*x^0.6, {x, 0.001, 0.9}]").unwrap();
+    let residual = interpret(&format!("N[50*({root})^0.6]")).unwrap();
+    assert_eq!(residual, "4.999999999999999");
+  }
+
+  #[test]
+  fn secant_still_works_for_a_larger_coefficient() {
+    let result =
+      interpret("FindRoot[5 == 100*x^0.6, {x, 0.001, 0.9}]").unwrap();
+    assert_eq!(result, "{x -> 0.006786044041487266}");
+  }
+
+  // A coefficient small enough that the unguarded secant path never left
+  // the real domain in the first place — guards against a regression that
+  // only shows up once backtracking is removed again.
+  #[test]
+  fn secant_regression_case_still_converges_directly() {
+    let result =
+      interpret("FindRoot[5 == 0.41*x^0.6, {x, 0.001, 0.9}]").unwrap();
+    assert_eq!(result, "{x -> 64.61156284605313}");
+  }
+}
+
 mod laplace_transform {
   use super::*;
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14407,7 +14407,7 @@ mod line_legend {
       .collect();
     assert!(
       widths.len() >= 2
-        && widths.iter().cloned().fold(0.0, f64::max) > widths[0],
+        && widths.iter().copied().fold(0.0, f64::max) > widths[0],
       "Thickness[Large] should widen its sample relative to the default: {widths:?}"
     );
   }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14315,6 +14315,117 @@ mod graphics_grid {
       "Missing[] should not render as literal text"
     );
   }
+
+  // `"label" -> Graphics[…]` is the idiom Wolfram demonstrations use for a
+  // caption cell with an inline swatch (a color-preview disk next to its
+  // name, e.g. Wolfram Demonstrations Project's "Design of Mass Timber
+  // Panels as Heat Exchangers"). Wolfram typesets a `Rule` cell as its
+  // pattern, an arrow, and its replacement; only a Graphics-valued
+  // replacement is drawn — a Rule between two plain values still prints
+  // as text.
+  #[test]
+  fn rule_cell_with_graphics_replacement_renders_inline() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "Grid[{{\"option\" -> Graphics[{Red, Disk[]}, ImageSize -> 20]}}]",
+    )
+    .unwrap();
+    let svg = result.graphics.unwrap();
+    assert!(svg.starts_with("<svg"), "Should produce SVG output");
+    assert!(
+      !svg.contains("Graphics["),
+      "The Graphics[…] call should be rendered, not printed as source: {svg}"
+    );
+    assert!(
+      svg.contains("option"),
+      "The rule's pattern should still be shown as a label: {svg}"
+    );
+    assert!(
+      svg.contains("<circle") || svg.contains("<ellipse"),
+      "The rule's Graphics replacement should draw the disk: {svg}"
+    );
+  }
+
+  #[test]
+  fn rule_cell_with_plain_values_still_prints_as_text() {
+    clear_state();
+    let svg = export_svg("Grid[{{\"a\" -> 1}}]");
+    assert!(svg.contains('a'));
+    assert!(svg.contains('1'));
+  }
+}
+
+// A bare `LineLegend[…]` (not wrapped in `Legended`) is how Wolfram
+// Demonstrations often place a legend beside a plot instead of attaching it
+// via `PlotLegends` — Wolfram's front end typesets it as line-style swatches
+// and labels either way, rather than the symbolic `LineLegend[…]` call.
+mod line_legend {
+  use super::*;
+
+  #[test]
+  fn bare_line_legend_renders_as_swatches() {
+    clear_state();
+    // `LineLegend[…]` alone (no `Legended`/`Grid`/`Row` wrapper) still
+    // stays symbolic in its *printed* form, matching wolframscript's
+    // kernel-level InputForm — this only covers how it draws when a
+    // picture of it is asked for (`ExportString[…, "SVG"]`, or nested in
+    // a layout, which `line_legend_nested_in_grid_cell_renders_inline`
+    // below covers, and which is how Woxi Studio actually reaches it: a
+    // Demonstration places `LineLegend[…]` inside the `Grid`/`Row` a
+    // `Manipulate` body returns, never as the body's sole result).
+    let svg = export_svg("LineLegend[{Red, Blue}, {\"A\", \"B\"}]");
+    assert!(
+      !svg.contains("LineLegend["),
+      "Should be drawn, not printed as source: {svg}"
+    );
+    assert_eq!(
+      svg.matches("<line ").count(),
+      2,
+      "One line sample per entry: {svg}"
+    );
+    assert!(svg.contains('A') && svg.contains('B'));
+  }
+
+  #[test]
+  fn line_legend_honours_thickness_and_dashing_directives() {
+    clear_state();
+    let svg = export_svg(
+      "LineLegend[{Red, {Thickness[Large], Blue}, \
+       {Dashing[{0.05, 0.03}], Green}}, {\"A\", \"B\", \"C\"}]",
+    );
+    assert_eq!(svg.matches("<line ").count(), 3);
+    assert!(
+      svg.contains("stroke-dasharray"),
+      "The Dashing entry should produce a dashed sample: {svg}"
+    );
+    // The thick entry's stroke-width must exceed the plain-color entry's.
+    let widths: Vec<f64> = svg
+      .split("stroke-width=\"")
+      .skip(1)
+      .filter_map(|s| s.split('"').next())
+      .filter_map(|s| s.parse().ok())
+      .collect();
+    assert!(
+      widths.len() >= 2
+        && widths.iter().cloned().fold(0.0, f64::max) > widths[0],
+      "Thickness[Large] should widen its sample relative to the default: {widths:?}"
+    );
+  }
+
+  #[test]
+  fn line_legend_nested_in_grid_cell_renders_inline() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "Grid[{{Graphics[{Red, Disk[]}], LineLegend[{Red, Blue}, {\"x\", \"y\"}]}}]",
+    )
+    .unwrap();
+    let svg = result.graphics.unwrap();
+    assert!(
+      !svg.contains("LineLegend["),
+      "Should be drawn inside the grid cell, not printed as source: {svg}"
+    );
+    assert_eq!(svg.matches("<line ").count(), 2);
+  }
 }
 
 mod plot_grid {


### PR DESCRIPTION
## Summary

Ran the scheduled "sample a random Wolfram Demonstration and check Woxi Studio support" routine. It fetched **"Design of Mass Timber Panels as Heat Exchangers"** and found three real gaps, all fixed here (no notebook code was copied — each fix is verified with synthetic, independently-authored reproductions):

- **`FindRoot`'s secant (two-point) form** took an unguarded step that could overshoot into a region where the residual isn't a real number (e.g. a fractional power's base going negative), aborting the whole solve with `FindRoot::nlnum` even though a root existed inside the given bracket. The secant loop now backtracks the step toward the current point — the same recovery the damped single-point Newton path already had — instead of failing on the first bad iterate. This was the root cause of the notebook's results table staying symbolic instead of showing computed numbers.
- **A Grid cell whose value is `"label" -> Graphics[…]`** (a caption-plus-swatch idiom Demonstrations commonly use — e.g. a color-preview disk next to its name) printed as raw source instead of the typeset label → picture Wolfram's front end shows.
- **A bare `LineLegend[…]`** (not wrapped in `Legended`) had no renderer at all and printed as raw source wherever a Demonstration placed one beside a plot, instead of drawing line-style swatches with labels.

With all three fixed, the notebook's interactive `Manipulate` now renders end-to-end with no residual warnings — verified by rasterizing the actual widget before and after.

## Test plan

- [x] Added regression tests for the `FindRoot` secant backtracking fix (`tests/interpreter_tests/calculus.rs`)
- [x] Added regression tests for the `Rule -> Graphics` Grid cell and `LineLegend` rendering fixes (`tests/interpreter_tests/graphics.rs`)
- [x] `make test` — all 27,806 tests pass
- [x] `make format`
- [x] Manually rasterized the actual downloaded notebook's `Manipulate` widget before/after to visually confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Atc7rqEyzukwbjuh7EenVx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atc7rqEyzukwbjuh7EenVx)_