### PR TITLE
Densify a SparseArray argument before ArrayPlot/MatrixPlot

### DIFF
--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -2863,6 +2863,8 @@ fn apply_named_color_function(name: &str, t: f64) -> (u8, u8, u8) {
 /// Cells can also be explicit color directives (e.g. Pink, Red).
 pub fn array_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let data = evaluate_expr_to_expr(&args[0])?;
+  let data = crate::functions::list_helpers_ast::densify_sparse_array(&data)
+    .unwrap_or(data);
   let Expr::List(rows) = &data else {
     return Err(InterpreterError::EvaluationError(
       "ArrayPlot: first argument must be a matrix (list of lists)".into(),
@@ -3186,6 +3188,8 @@ fn frame_labelled_svg(
 /// MatrixPlot[matrix] - like ArrayPlot with automatic color scaling
 pub fn matrix_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let data = evaluate_expr_to_expr(&args[0])?;
+  let data = crate::functions::list_helpers_ast::densify_sparse_array(&data)
+    .unwrap_or(data);
   let Expr::List(rows) = &data else {
     return Err(InterpreterError::EvaluationError(
       "MatrixPlot: first argument must be a matrix".into(),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11054,10 +11054,32 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     }
 
     #[test]
+    fn array_plot_sparse_array() {
+      // Regression: SparseArray's canonical internal form isn't a plain
+      // nested List, so ArrayPlot used to reject it with "first argument
+      // must be a matrix (list of lists)" instead of densifying it first.
+      let dense = export_svg("ArrayPlot[{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}]");
+      let sparse = export_svg(
+        "ArrayPlot[SparseArray[{{1, 1} -> 1, {2, 2} -> 1, {3, 3} -> 1}, {3, 3}]]",
+      );
+      assert_eq!(sparse, dense);
+    }
+
+    #[test]
     fn matrix_plot_basic() {
       insta::assert_snapshot!(export_svg(
         "MatrixPlot[{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}]"
       ));
+    }
+
+    #[test]
+    fn matrix_plot_sparse_array() {
+      // Regression: same SparseArray-densification bug as ArrayPlot.
+      let dense = export_svg("MatrixPlot[{{1, 0}, {0, 2}}]");
+      let sparse = export_svg(
+        "MatrixPlot[SparseArray[{{1, 1} -> 1, {2, 2} -> 2}, {2, 2}]]",
+      );
+      assert_eq!(sparse, dense);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Found via a random Wolfram Demonstration ("Density Map for the 3n+1 Problem") that Woxi Studio failed to render: its `Manipulate` body pipes a `SparseArray` built from index `->` value rules straight into `ArrayPlot`.
- Root cause: `SparseArray`'s canonical internal form is a symbolic `SparseArray[Automatic, dims, default, data]` call, not a plain nested `List`. Both `array_plot_ast` and `matrix_plot_ast` required their first argument to already be `Expr::List` and rejected a `SparseArray` with `"... first argument must be a matrix (list of lists)"` instead of converting it to a dense list first — the way most other list-consuming functions already do via the existing `densify_sparse_array` helper.
- Fix: call `densify_sparse_array` on the evaluated argument in both `array_plot_ast` and `matrix_plot_ast` before requiring a `List`, falling back to the original value when it isn't a `SparseArray`.
- Re-ran the notebook's `Manipulate` through Woxi Studio's `dump_manipulate` diagnostic afterward: it now builds and renders the interactive widget without error.

No verbatim code from the (copyrighted) demonstration notebook is included; the added tests use independently written, structurally analogous examples that compare a `SparseArray`-driven plot's SVG output to the equivalent dense-list plot.

## Test plan

- [x] `make test` — all 27,801 unit tests pass, no regressions
- [x] `make format`
- [x] Added regression tests in `tests/interpreter_tests/graphics.rs`: `array_plot_sparse_array` and `matrix_plot_sparse_array`, each asserting the `SparseArray` form renders identically to the equivalent dense-list form
- [x] Re-verified the source Wolfram Demonstration notebook (downloaded from `demonstrations.wolfram.com`) now builds and renders in Woxi Studio via the `dump_manipulate` example, with no evaluation error

---
_Generated by [Claude Code](https://claude.ai/code/session_019285CvQvuouxDw39jm5eDY)_