### PR TITLE
Accept an Association as ReplaceAll/ReplaceRepeated/Replace rules

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -689,6 +689,9 @@ fn is_valid_replace_rules(expr: &Expr) -> bool {
       true
     }
     Expr::List(items) => items.iter().all(is_valid_replace_rules),
+    // An Association is accepted anywhere a list of rules is expected: it
+    // behaves as if it were the list of its key -> value pairs.
+    Expr::Association(_) => true,
     _ => false,
   }
 }

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -986,6 +986,13 @@ pub fn apply_replace_ast(
   expr: &Expr,
   rules: &Expr,
 ) -> Result<Expr, InterpreterError> {
+  let assoc_list;
+  let rules = if matches!(rules, Expr::Association(_)) {
+    assoc_list = association_to_rules(rules);
+    &assoc_list
+  } else {
+    rules
+  };
   // Check if rules is a list of rule-lists: Replace[x, {{x -> 1}, {x -> 2}}]
   if let Expr::List(outer_items) = rules
     && !outer_items.is_empty()
@@ -2337,6 +2344,26 @@ fn strip_hold_pattern(pattern: &Expr) -> Expr {
   canonicalize_pattern(pattern)
 }
 
+/// An Association used as a replacement-rules argument behaves as if it
+/// were the list of its `key -> value` pairs (Wolfram accepts an
+/// Association anywhere a list of rules is expected). Non-Association
+/// expressions pass through unchanged so callers can use this
+/// unconditionally.
+fn association_to_rules(rules: &Expr) -> Expr {
+  match rules {
+    Expr::Association(pairs) => Expr::List(
+      pairs
+        .iter()
+        .map(|(k, v)| Expr::Rule {
+          pattern: Box::new(k.clone()),
+          replacement: Box::new(v.clone()),
+        })
+        .collect(),
+    ),
+    other => other.clone(),
+  }
+}
+
 /// Canonicalize the left-hand side of every rule in `rules` (see
 /// [`canonicalize_pattern`]), so the AST, Flat and string-based replacement
 /// paths below all see the same pattern — a `HoldPattern[…]` left in place
@@ -2368,6 +2395,13 @@ pub fn apply_replace_all_ast(
   expr: &Expr,
   rules: &Expr,
 ) -> Result<Expr, InterpreterError> {
+  let assoc_list;
+  let rules = if matches!(rules, Expr::Association(_)) {
+    assoc_list = association_to_rules(rules);
+    &assoc_list
+  } else {
+    rules
+  };
   let canonical;
   let rules = if needs_canonicalization(rules) {
     canonical = canonicalize_rules(rules);

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2249,6 +2249,34 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_replace_all_accepts_association_as_rules() {
+    // Regression: an Association used directly as the rules argument of
+    // ReplaceAll / ReplaceRepeated / Replace must behave as if it were the
+    // list of its key -> value pairs, matching wolframscript. Woxi used to
+    // reject it with ReplaceAll::reps ("neither a list of replacement rules
+    // nor a valid dispatch table").
+    clear_state();
+    assert_eq!(
+      interpret(r#"{"a", "b", "c"} /. <|"a" -> 1, "b" -> 2|>"#).unwrap(),
+      "{1, 2, c}",
+    );
+    assert_eq!(
+      interpret("{a, a, b} /. AssociationThread[{a, b}, {1, 2}]").unwrap(),
+      "{1, 1, 2}",
+    );
+    // ReplaceRepeated delegates to the same rule-shape validation.
+    assert_eq!(interpret("a //. <|a -> b, b -> c|>").unwrap(), "c",);
+    // Replace (top-level only) accepts an Association too.
+    assert_eq!(
+      interpret(r#"Replace["a", <|"a" -> 1, "b" -> 2|>]"#).unwrap(),
+      "1",
+    );
+    // An empty Association still counts as a valid (no-op) rule set rather
+    // than triggering the reps error.
+    assert_eq!(interpret("{a, b} /. <||>").unwrap(), "{a, b}");
+  }
+
+  #[test]
   fn test_replace_all_rewrites_head_symbol() {
     // ReplaceAll treats a compound's head as an ordinary subexpression, so a
     // symbol-blank rule rewrites the head too, producing `f[h][...]` (a


### PR DESCRIPTION
## Summary
- Found while checking whether Woxi Studio can open a random Wolfram Demonstrations Project notebook ("Base Conversions from Base 2 through 100 Using Radix Points"). Its digit-parsing helper builds an `Association` with `AssociationThread[...]` and applies it directly as `/.` rules — valid Wolfram Language, since an Association stands in for the list of its `key -> value` pairs anywhere replacement rules are expected.
- Woxi's `ReplaceAll`/`ReplaceRepeated`/`Replace` rejected an Association rules argument with `ReplaceAll::reps`, so the notebook's Manipulate widget failed to build.
- Fixed by treating `Expr::Association` as a valid rules shape and converting it to the equivalent list of `Rule`s before matching, in `is_valid_replace_rules` (src/evaluator/core_eval.rs) and `apply_replace_ast` / `apply_replace_all_ast` (src/evaluator/pattern_matching.rs, the latter also used by `ReplaceRepeated`).
- No code from the notebook itself was copied; the fix and its test use independently written examples of the same general behavior.

## Test plan
- [x] Added `test_replace_all_accepts_association_as_rules` covering `ReplaceAll`, `ReplaceRepeated`, `Replace`, and an empty Association, in `tests/interpreter_tests.rs`.
- [x] `make test` — all 27,822 tests pass.
- [x] `make format`.
- [x] Verified against the downloaded Demonstration notebook with `cargo run --example dump_manipulate -p woxi-studio -- <notebook>.nb`: the widget now builds cleanly with no `ReplaceAll::reps` error and renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nKLz5MAFGqj8AY8EdmrPz

---
_Generated by [Claude Code](https://claude.ai/code/session_019nKLz5MAFGqj8AY8EdmrPz)_