### PR TITLE
Fix implicit multiplication when a symbol is directly followed by a power box

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1332,19 +1332,30 @@ fn extract_rowbox_content(s: &str) -> String {
       continue;
     }
     let piece = box_part_source(part);
-    // A bare `#`/`##` and a following letter-initial piece are *separate*
-    // sibling boxes here (implicit multiplication, e.g. `# Sin[Pi/u]`
-    // typeset without a literal space token between them), but gluing
-    // their text together verbatim would read back as named-slot syntax
-    // (`#Sin` = `Slot["Sin"]`) instead. Insert a space to keep the
-    // juxtaposition a product rather than change its meaning.
-    if result.ends_with('#')
-      && piece
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_ascii_alphabetic())
-    {
+    // Two sibling boxes juxtaposed with no operator between them (no
+    // `\[InvisibleTimes]`, no literal `" "` part) mean implicit
+    // multiplication — e.g. `RowBox[{"a", RowBox[{"x", "^", "3"}]}]` for
+    // `a*x^3`. Gluing their text together verbatim would instead read back
+    // as one longer identifier: a trailing symbol swallows a following
+    // letter into a different name (`ax^3` parses as the single identifier
+    // `ax` to the third power, not `a` times `x^3`), and for a bare `#` it
+    // reads as named-slot syntax (`#Sin` = `Slot["Sin"]`). A trailing plain
+    // number is unambiguous either way (`2Product[…]` already reads back as
+    // `2*Product[…]`, since digits can't extend into letters), so only a
+    // trailing run that itself contains a letter is at risk.
+    let piece_starts_alpha = piece
+      .chars()
+      .next()
+      .is_some_and(|c| c.is_ascii_alphabetic());
+    let trailing_run_has_letter = result
+      .chars()
+      .rev()
+      .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+      .any(|c| c.is_ascii_alphabetic());
+    if result.ends_with('#') && piece_starts_alpha {
       result.push(' ');
+    } else if trailing_run_has_letter && piece_starts_alpha {
+      result.push('*');
     }
     result.push_str(&piece);
     i += 1;
@@ -4808,6 +4819,23 @@ Cell["Chapter 2", "Chapter"]
     assert_eq!(
       crate::interpret(&format!("({content})&[3]")).unwrap(),
       "3*Cos[x]"
+    );
+  }
+
+  #[test]
+  fn test_extract_cell_content_symbol_before_power_juxtaposition() {
+    // A coefficient symbol directly followed by a power box with no
+    // operator between them — `RowBox[{"a", RowBox[{"x", "^", "3"}]}]` — is
+    // the FrontEnd's typeset form of `a*x^3` (implicit multiplication with
+    // no `\[InvisibleTimes]` token). Gluing the two pieces' text together
+    // verbatim reads back as the single identifier `ax` to the third power
+    // instead of `a` times `x^3`.
+    let s = r#"BoxData[RowBox[{"a", RowBox[{"x", "^", "3"}]}]]"#;
+    let content = extract_cell_content(s);
+    assert_eq!(content, "a*x^3");
+    assert_eq!(
+      crate::interpret(&format!("({content}) /. {{a -> 2, x -> 3}}")).unwrap(),
+      "54"
     );
   }
 


### PR DESCRIPTION
## Summary

- Found via the scheduled "check a random Demonstration notebook" task: downloaded the [Reflection from a Polynomial Mirror](https://demonstrations.wolfram.com/ReflectionFromAPolynomialMirror/) notebook and checked it against Woxi Studio using the `dump_manipulate` diagnostic example.
- The `Manipulate` widget built without error, but its `Plot` rendered as a completely empty `<svg>` — no error, no warning, just a blank graphic.
- Root cause: when converting a notebook's box form to source text, `extract_rowbox_content` in `src/notebook.rs` concatenated two sibling boxes with no operator between them (e.g. `RowBox[{"a", RowBox[{"x", "^", "3"}]}]`, the FrontEnd's typeset form of `a*x^3`) directly into `"ax^3"`. Re-parsed as source text, `ax` reads as a single identifier raised to the third power instead of `a` times `x^3` — so the `Manipulate`'s `a`, `b`, `c` control variables never actually reached the `Plot`, which then had nothing numeric to draw.
- Fix: insert `*` between two juxtaposed pieces whenever the trailing text run contains a letter (i.e. could be swallowed into a longer identifier) and the next piece starts with a letter. A trailing plain number is left alone, since digits can't extend into an identifier (`2Product[...]` already correctly round-trips as `2*Product[...]`) — this is what the two pre-existing tests that initially regressed depend on.
- Added a regression test (`test_extract_cell_content_symbol_before_power_juxtaposition`) covering the juxtaposition case directly.

## Test plan

- [x] `make test` — all 27,822 unit tests pass
- [x] `make test-studio` — all 201 woxi-studio tests pass
- [x] `make format`
- [x] Re-ran the `dump_manipulate` diagnostic on the downloaded notebook: the widget now renders a real 11857-byte SVG (curve + mirror reflection rays) instead of an empty one


---
_Generated by [Claude Code](https://claude.ai/code/session_01P9vztyTKccpuDYwLnnrkti)_