### PR TITLE
Fall back to Superscript for a bare-minus SuperscriptBox exponent

### DIFF
--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -787,6 +787,24 @@ fn extract_typeset_box(s: &str) -> Option<String> {
       "SuperscriptBox" if args.len() == 2 && draws_nothing(&conv(&args[0])) => {
         format!("Superscript[\"\", {}]", conv(&args[1]))
       }
+      // A script that isn't a valid expression on its own — e.g. a bare
+      // `-` used only to typeset an ion's charge, like the "H" of "H⁻"
+      // (`SuperscriptBox["H", "-"]`) — can't become `(a)^(b)`: `("H")^(-)`
+      // dangles the minus sign with no operand and fails to parse.
+      // Mathematica's own box-to-expression conversion falls back to the
+      // display wrapper `Superscript` whenever a script doesn't parse as
+      // an expression; mirror that here (same fallback `SubscriptBox`
+      // uses below for its subscript).
+      "SuperscriptBox"
+        if args.len() == 2
+          && crate::parse_to_expr(&conv(&args[1])).is_err() =>
+      {
+        format!(
+          "Superscript[{}, \"{}\"]",
+          conv(&args[0]),
+          escape_string(&conv(&args[1]))
+        )
+      }
       // `SuperscriptBox[a, b]` → `(a)^(b)`.
       "SuperscriptBox" if args.len() == 2 => {
         format!("({})^({})", conv(&args[0]), conv(&args[1]))
@@ -4781,6 +4799,18 @@ Cell["Chapter 2", "Chapter"]
     // A plain power whose box carries a display option must still convert.
     let s = r#"BoxData[SuperscriptBox["x", "2", MultilineFunction->None]]"#;
     assert_eq!(extract_cell_content(s), "(x)^(2)");
+  }
+
+  /// `SuperscriptBox["H", "-"]` typesets the hydride ion "H⁻": a bare `-`
+  /// with no operand, used purely for display. `(H)^(-)` would dangle the
+  /// minus sign and fail to parse — Mathematica itself falls back to the
+  /// unevaluated `Superscript` wrapper whenever a script isn't a valid
+  /// expression on its own. From the "Variational Calculations on the
+  /// Helium Isoelectronic Series" Demonstration's element/ion table.
+  #[test]
+  fn test_extract_cell_content_superscript_bare_minus() {
+    let s = r#"BoxData[SuperscriptBox["\"\<H\>\"", "-"]]"#;
+    assert_eq!(extract_cell_content(s), "Superscript[\"H\", \"-\"]");
   }
 
   #[test]


### PR DESCRIPTION
## Summary
- Found while checking whether Woxi Studio fully supports a random Wolfram Demonstrations notebook ("Variational Calculations on the Helium Isoelectronic Series"): one of its initialization cells failed to parse.
- `SuperscriptBox["H", "-"]` typesets the hydride ion "H⁻" using a raw `-` box token with no operand, purely for display. The notebook-to-text conversion turned this into `("H")^(-)`, which dangles the minus sign and fails to parse.
- Mathematica's own box-to-expression conversion falls back to the unevaluated `Superscript` wrapper whenever a script isn't a valid expression on its own (the same fallback already used for `SubscriptBox`). This change applies that same fallback to `SuperscriptBox`: when the exponent doesn't parse as a valid expression, emit `Superscript[base, "exp"]` instead of `(base)^(exp)`.

## Test plan
- [x] Added a regression unit test (`test_extract_cell_content_superscript_bare_minus`) reproducing the exact box from the Demonstration notebook.
- [x] `cargo test --lib` — 259 passed, 0 failed (`cargo nextest` was unavailable in this sandbox, so `cargo test` was used instead).
- [x] Re-ran `cargo run -p woxi-studio --example test_notebook -- <downloaded .nb>` before and after the fix: 1 error → 0 errors across all 27 input cells.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNKFih9Ro7N2uw8rTNAwDf)_