### PR TITLE
Support Inset[…] labels in Graphics3D and the \[Backslash] named char

### DIFF
--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -3082,6 +3082,47 @@ fn parse_text3d_offset(spec: &Expr) -> Option<(f64, f64)> {
   }
 }
 
+/// Typesets `label_expr` (a `Text`/`Inset` label, e.g. a plain string or
+/// `Style[…]`) and pushes a `Text3D` primitive for it at `pos`, if it
+/// renders to non-empty text.
+fn push_text3d_label(
+  label_expr: &Expr,
+  pos: Point3D,
+  offset: (f64, f64),
+  style: &StyleState3D,
+  prims: &mut Vec<Primitive3D>,
+) {
+  let styled = crate::functions::chart::parse_styled_label(label_expr);
+  let (label, width_chars, font_size, color) = match styled {
+    Some(s) => (
+      s.svg(),
+      s.text.chars().count(),
+      s.font_size.unwrap_or(12.0),
+      s.color,
+    ),
+    None => (String::new(), 0, 12.0, None),
+  };
+  if label.is_empty() {
+    return;
+  }
+  let mut text_style = style.clone();
+  if let Some(c) = color {
+    text_style.color = Some((
+      (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+      (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+      (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+    ));
+  }
+  prims.push(Primitive3D::Text3D {
+    label,
+    pos,
+    offset,
+    font_size,
+    width_chars,
+    style: text_style,
+  });
+}
+
 fn collect_3d_primitives(
   expr: &Expr,
   style: &mut StyleState3D,
@@ -3258,37 +3299,28 @@ fn collect_3d_primitives(
         // reads the same wherever it is written.
         "Text" if args.len() >= 2 => {
           if let Some(pos) = parse_point3d(&args[1]) {
-            let styled = crate::functions::chart::parse_styled_label(&args[0]);
-            let (label, width_chars, font_size, color) = match styled {
-              Some(s) => (
-                s.svg(),
-                s.text.chars().count(),
-                s.font_size.unwrap_or(12.0),
-                s.color,
-              ),
-              None => (String::new(), 0, 12.0, None),
-            };
-            if !label.is_empty() {
-              let mut text_style = style.clone();
-              if let Some(c) = color {
-                text_style.color = Some((
-                  (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
-                  (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
-                  (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
-                ));
+            let offset = args
+              .get(2)
+              .and_then(parse_text3d_offset)
+              .unwrap_or((0.0, 0.0));
+            push_text3d_label(&args[0], pos, offset, style, prims);
+          }
+        }
+        // `Inset[obj, {x, y, z}]` places `obj` at a point of the scene.
+        // The Demonstrations gallery uses it almost exclusively as
+        // `Inset[Text[Style[…]], pos]`, so unwrap a `Text[…]` wrapper and
+        // fall through to the same label rendering `Text` uses above.
+        "Inset" if args.len() >= 2 => {
+          if let Some(pos) = parse_point3d(&args[1]) {
+            let label_expr = match &args[0] {
+              Expr::FunctionCall { name, args: inner }
+                if name == "Text" && !inner.is_empty() =>
+              {
+                &inner[0]
               }
-              prims.push(Primitive3D::Text3D {
-                label,
-                pos,
-                offset: args
-                  .get(2)
-                  .and_then(parse_text3d_offset)
-                  .unwrap_or((0.0, 0.0)),
-                font_size,
-                width_chars,
-                style: text_style,
-              });
-            }
+              other => other,
+            };
+            push_text3d_label(label_expr, pos, (0.0, 0.0), style, prims);
           }
         }
         "Cylinder" => {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -383,6 +383,10 @@ pub fn named_char_to_unicode(name: &str) -> Option<&'static str> {
     "Times" => "\u{00D7}",
     "Divide" => "\u{00F7}",
     "CenterDot" => "\u{00B7}",
+    // Unlike most named operator glyphs, `\[Backslash]` is not a private-use
+    // look-alike: it is literally the ASCII backslash (its `Backslash[a, b]`
+    // infix rendering is a separate display form, handled elsewhere).
+    "Backslash" => "\\",
     // `\[Equal]` is the typeset `==`; it has its own private-use code point
     // rather than reusing the ASCII `=` (which is `Set`).
     "Equal" => "\u{F431}",

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1893,6 +1893,37 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_graphics3d_inset_text_draws_label() {
+    // `Inset[obj, {x, y, z}]` in `Graphics3D` — the Demonstrations gallery's
+    // usual way to place a label, almost always as
+    // `Inset[Text[Style[…]], pos]`. Regression: `Graphics3D`'s primitive
+    // collector only recognized a bare `Text[…, pos]` call, so `Inset[…]`
+    // was silently dropped and no label was drawn at all.
+    clear_state();
+    let svg = interpret(
+      "ExportString[Graphics3D[{Arrow[{{0, 0, 0}, {1, 1, 1}}], \
+       Inset[Text[Style[\"O\", 15]], {0, 0, 0}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      svg.contains(">O<"),
+      "Inset[Text[…]] label was not drawn in Graphics3D: {svg}"
+    );
+
+    // The label's wrapper content (here a plain string) still typesets the
+    // same way when passed to Inset directly, without the Text[…] wrapper.
+    clear_state();
+    let svg2 = interpret(
+      "ExportString[Graphics3D[{Inset[\"AB\", {0, 0, 0}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      svg2.contains(">AB<"),
+      "Inset[…] with a bare string label was not drawn in Graphics3D: {svg2}"
+    );
+  }
+
+  #[test]
   fn test_plot_aspect_ratio_sizes_frame_not_canvas() {
     // AspectRatio sets the height/width ratio of the plotting *area* (the data
     // frame), not the whole image. A short ratio must therefore NOT squash the

--- a/tests/interpreter_tests/string.rs
+++ b/tests/interpreter_tests/string.rs
@@ -2157,6 +2157,19 @@ mod letter_number {
   }
 
   #[test]
+  fn named_backslash_decodes_to_ascii_backslash() {
+    // Unlike most named operator glyphs, `\[Backslash]` is not a
+    // private-use look-alike for a typeset form: it is literally the ASCII
+    // backslash (its `Backslash[a, b]` infix rendering is a separate
+    // display form). Regression: a Demonstrations Project notebook used
+    // `\[Backslash]` inside a table header string ("R\[Backslash]D"), and
+    // it fell through unresolved, printing the literal escape text.
+    assert_eq!(interpret("\"\\[Backslash]\"").unwrap(), "\\");
+    assert_eq!(interpret("StringLength[\"\\[Backslash]\"]").unwrap(), "1");
+    assert_eq!(interpret("\"R\\[Backslash]D\"").unwrap(), "R\\D");
+  }
+
+  #[test]
   fn greek_alpha_omega() {
     assert_eq!(interpret("LetterNumber[\"α\", \"Greek\"]").unwrap(), "1");
     assert_eq!(interpret("LetterNumber[\"ω\", \"Greek\"]").unwrap(), "24");


### PR DESCRIPTION
## Summary

As part of the scheduled Woxi Studio compatibility check, I downloaded a random notebook from the Wolfram Demonstrations Project (["Blood Donation Protocols"](https://demonstrations.wolfram.com/BloodDonationProtocols/)) and checked whether Woxi Studio fully supports it. It mostly did, but rendering its `Manipulate` widget's `Graphics3D` scenes surfaced two real bugs:

- **`Graphics3D` dropped every `Inset[…]` label.** The notebook labels its 3D diagrams almost exclusively with `Inset[Text[Style[…]], pos]`, but `Graphics3D`'s primitive collector only recognized a bare `Text[…, pos]` call — `Inset[…]` fell through silently, so none of the diagram's text (blood group letters, +/- Rh markers) was drawn at all.
- **`\[Backslash]` had no entry in the named-character table.** A table header string used `"↓R\[Backslash]D→"`; since the escape wasn't recognized, it printed as the literal text `\[Backslash]` instead of decoding to the ASCII backslash character.

## Changes

- `src/functions/plot3d.rs`: `Graphics3D` now treats `Inset[obj, pos]` as a label placement, unwrapping a `Text[…]` wrapper (the overwhelmingly common case in the Demonstrations gallery) before typesetting through the same helper `Text[…]` already used. Factored the shared label-rendering logic into a `push_text3d_label` helper so `Text` and `Inset` don't duplicate it.
- `src/syntax.rs`: added `"Backslash" => "\\"` to `named_char_to_unicode` — unlike most named operator glyphs, `\[Backslash]` is not a private-use look-alike, it's literally the ASCII backslash.
- Added regression tests for both fixes in `tests/interpreter_tests.rs` and `tests/interpreter_tests/string.rs`.

No code from the downloaded notebook was copied verbatim; the fixes and their tests use minimal, original repro expressions.

## Test plan

- [x] `make test` (`cargo nextest run`) — 27823 tests passed, 0 failed
- [x] `make format`
- [x] New regression tests pass: `test_graphics3d_inset_text_draws_label`, `named_backslash_decodes_to_ascii_backslash`
- [x] Manually re-rendered the downloaded Demonstration's `Manipulate` body (both `Which` branches) via `woxi eval … Export[…, "PNG"]` before and after the fix; the after-render now matches the notebook's own embedded snapshot image (labels, colors, and the `↓R\D→` table header all correct)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PwNXokEQ1fxhSE7nhhGDdF)_