### PR TITLE
Fix Integrate differential glyph overlapping in typeset SVG

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -7904,11 +7904,19 @@ impl BoxLayout {
     // missing-glyph box (▢). Substitute the public Unicode arrows so the
     // SVG output displays correctly everywhere. Each maps one char to one
     // char, so the width estimate below is unaffected.
+    // `\[DifferentialD]` (U+2146, the italic "ⅆ" used in `∫ … ⅆx`) is a rare
+    // Mathematical Alphanumeric Symbols codepoint most non-Mathematica fonts
+    // don't carry either — the SVG viewer's font-fallback glyph for it comes
+    // out a different width than the plain-ASCII advance computed below, so
+    // it overlaps the following variable (`ⅆx` renders as if it read "ddx").
+    // Map it to plain "d"; `is_math_italic_atom` below then italicizes the
+    // lone letter, giving the same look without depending on that glyph.
     let mapped: String = s
       .chars()
       .map(|c| match c {
         '\u{f522}' => '\u{2192}', // \[Rule] → →
         '\u{f51f}' => '\u{29f4}', // \[RuleDelayed] → ⧴
+        '\u{2146}' => 'd',        // \[DifferentialD] → d (italicized below)
         other => other,
       })
       .collect();

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1141,6 +1141,34 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_traditional_form_integrate_differential_svg_uses_plain_d() {
+    // Regression: `TraditionalForm[HoldForm[Integrate[…]]]` typesets the
+    // closing differential as the literal box glyph `\[DifferentialD]`
+    // (U+2146, "ⅆ"). That Mathematical Alphanumeric Symbols codepoint has no
+    // glyph in most non-Mathematica fonts, so the Playground/Studio SVG
+    // viewer's font-fallback substitute renders at a different width than
+    // the plain-ASCII advance the layout computed, overlapping the following
+    // variable (`ⅆx` reads as if it were "ddx"). The SVG must instead emit
+    // plain "d" (italicized like any other math variable), which every font
+    // has, so the two glyphs never overlap.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "TraditionalForm[HoldForm[Integrate[x^2, {x, -1, 1}]]]",
+    )
+    .unwrap()
+    .output_svg
+    .expect("expected output SVG for TraditionalForm[HoldForm[Integrate[…]]]");
+    assert!(
+      !svg.contains('\u{2146}'),
+      "Integrate differential SVG must not contain the raw U+2146 glyph:\n{svg}"
+    );
+    assert!(
+      svg.contains(">d<"),
+      "Integrate differential SVG must render the differential as plain \"d\":\n{svg}"
+    );
+  }
+
+  #[test]
   fn test_scientific_real_output_svg_uses_superscript() {
     // Regression: a machine Real in scientific notation (`10.^10` → `1.*^10`)
     // must be typeset as `1. × 10^10` in the Playground/Studio SVG — a `×`

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -4660,7 +4660,19 @@ mod high_level_functions {
       .unwrap();
       assert!(svg.starts_with("<svg"), "should be SVG markup: {svg}");
       assert!(svg.contains('\u{222B}'), "∫ rendered: {svg}");
-      assert!(svg.contains('\u{2146}'), "ⅆ differential rendered: {svg}");
+      // The differential renders as plain (italicized) "d" rather than the
+      // literal `\[DifferentialD]` glyph (U+2146, "ⅆ"): that Mathematical
+      // Alphanumeric Symbols codepoint has no glyph in most non-Mathematica
+      // fonts, so an SVG viewer's font-fallback substitute comes out a
+      // different width than the plain-ASCII advance the layout computed,
+      // overlapping the following variable (`ⅆx` reading as if it were
+      // "ddx"). See `test_traditional_form_integrate_differential_svg_uses_plain_d`
+      // in tests/interpreter_tests.rs for the focused regression test.
+      assert!(
+        !svg.contains('\u{2146}'),
+        "no raw U+2146 differential glyph: {svg}"
+      );
+      assert!(svg.contains(">d<"), "d differential rendered: {svg}");
       assert!(!svg.contains("Integrate["), "no literal head: {svg}");
       assert!(!svg.contains("TagBox"), "no box-wrapper dump: {svg}");
     }


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration ("Cauchy-Schwarz Inequality for Integrals") and checked whether Woxi Studio fully supports its notebook.
- The notebook's `Manipulate` widget builds and renders correctly (all 10 sliders, the `Plot`, and the live-updating integral displays), but the two `TraditionalForm[HoldForm[Integrate[...]]]` displays rendered their closing differential as `ddx` instead of `dx`.
- Root cause: `TraditionalForm`/`HoldForm` typesetting emits the differential as the literal `\[DifferentialD]` box glyph (U+2146, "ⅆ"). That Mathematical Alphanumeric Symbols codepoint has no glyph in most non-Mathematica fonts, so the SVG viewer's font-fallback substitute renders at a different width than the plain-ASCII advance the layout computed, causing it to overlap the following variable.
- Fix: map `\[DifferentialD]` to plain `"d"` in `BoxLayout::text`'s glyph-substitution table (the same place `\[Rule]`/`\[RuleDelayed]` are already substituted for the same reason) — it's then italicized automatically like any other single-letter math variable, so `dx` renders cleanly everywhere without depending on a rare glyph.

## Test plan

- [x] Added `test_traditional_form_integrate_differential_svg_uses_plain_d` regression test in `tests/interpreter_tests.rs`.
- [x] Updated the pre-existing `test_export_string_traditional_form_integral_svg` test, which asserted the old (buggy) raw `ⅆ` glyph was present, to assert the fixed plain-`d` rendering instead.
- [x] `make test` — all 27,822 tests pass.
- [x] `make format`.
- [x] Manually verified the fix by rasterizing the Demonstration's `Manipulate` widget SVG before and after the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvFb5g5LmwQLgrAMmvSuFF)_