### PR TITLE
Implement MathieuC and MathieuCPrime

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1841,7 +1841,7 @@ BeckmannDistribution,Beckmann distribution,,unevaluated,8.0,1849
 CoordinateTransformData,,🚫,,9.0,1849
 FirstCase,First element matching a pattern,✅,pure,10.0,1849
 EndOfFile,Symbol returned by Read at end of file,✅,pure,1.0,1852
-MathieuC,Mathieu C function,,unevaluated,3.0,1852
+MathieuC,Even Mathieu function (Floquet ODE integration; Woxi's q-to-zero normalisation differs from wolframscript's for q != 0),✅,pure,3.0,1852
 WeierstrassSigma,Weierstrass sigma function,,unevaluated,3.0,1852
 StringReplacePart,Replace a span of a string — a bare index means the span from the start and an unavailable span reports ::repart,✅,pure,3.0,1853
 KeyMap,Maps a function over the keys of an association; supports the operator form KeyMap[f][assoc],✅,pure,10.0,1855
@@ -2291,7 +2291,7 @@ WordSeparators,text processing option,🚫,None,2.0,2305
 ClockGauge,dynamic gauge display,🚫,None,9.0,2311
 DeleteDirectory,file system operation,✅,None,2.0,2311
 FunctionPeriod,symbolic period analysis (complex),🚫,None,10.0,2311
-MathieuCPrime,Mathieu function derivative (special function),🚫,None,3.0,2311
+MathieuCPrime,Derivative of the even Mathieu function with characteristic value a and parameter q,✅,pure,3.0,2311
 PartialCorrelationFunction,time series,🚫,None,9.0,2311
 Skip,Skip n values from a stream while reading,✅,None,2.0,2311
 DocumentNotebook,notebook creation,🚫,None,6.0,2317

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -108,6 +108,8 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "BesselJ" => Some((2, 2)),
     "MathieuS" => Some((3, 3)),
     "MathieuSPrime" => Some((3, 3)),
+    "MathieuC" => Some((3, 3)),
+    "MathieuCPrime" => Some((3, 3)),
     "BesselJZero" => Some((2, 3)),
     "BesselK" => Some((2, 2)),
     "BesselY" => Some((2, 2)),

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1142,6 +1142,12 @@ pub fn dispatch_math_functions(
     "MathieuSPrime" if args.len() == 3 => {
       return Some(crate::functions::math_ast::mathieu_s_prime_ast(args));
     }
+    "MathieuC" if args.len() == 3 => {
+      return Some(crate::functions::math_ast::mathieu_c_ast(args));
+    }
+    "MathieuCPrime" if args.len() == 3 => {
+      return Some(crate::functions::math_ast::mathieu_c_prime_ast(args));
+    }
     "BesselY" if args.len() == 2 => {
       return Some(crate::functions::math_ast::bessel_y_ast(args));
     }

--- a/src/functions/math_ast/mathieu.rs
+++ b/src/functions/math_ast/mathieu.rs
@@ -1,19 +1,22 @@
 //! Mathieu function numerical evaluation.
 //!
 //! For real `(a, q, z)` we provide a Floquet-based numerical solver.
-//! Wolfram's MathieuS / MathieuSPrime use a specific (a, q)-dependent
+//! Wolfram's Mathieu functions use a specific (a, q)-dependent
 //! normalisation tied to the Hill tridiagonal eigenvalue problem; that
-//! normalisation is not reproduced here. Instead the solution is
-//! anchored by the boundary condition that matches the `q → 0` limit
-//! (`MathieuS(a, 0, z) = sin(√a · z)` and
-//! `MathieuSPrime(a, 0, z) = √a · cos(√a · z)`).
+//! normalisation is not reproduced here. Instead each solution is
+//! anchored by the boundary condition that matches its `q → 0` limit:
+//! `MathieuS(a, 0, z) = sin(√a · z)`, `MathieuSPrime(a, 0, z) = √a ·
+//! cos(√a · z)`, `MathieuC(a, 0, z) = cos(√a · z)`, and
+//! `MathieuCPrime(a, 0, z) = -√a · sin(√a · z)`.
 //!
 //! For `q = 0` the closed forms above are exact; for `q ≠ 0` the result
-//! is the analytic continuation under the BC `y(0) = 0`, `y'(0) = √a`
-//! — which differs from wolframscript's specific numerical scaling by
-//! a smooth (a, q)-dependent factor. Users who need exact wolframscript
-//! agreement should compare ratios `MathieuSPrime(a, q, z) /
-//! MathieuSPrime(a, q, 0)` (these match to numerical precision).
+//! is the analytic continuation under the respective boundary condition
+//! (`y(0) = 0, y'(0) = √a` for the S family; `y(0) = 1, y'(0) = 0` for
+//! the C family) — which differs from wolframscript's specific
+//! numerical scaling by a smooth (a, q)-dependent factor. Users who
+//! need exact wolframscript agreement should compare ratios such as
+//! `MathieuSPrime(a, q, z) / MathieuSPrime(a, q, 0)` (these match to
+//! numerical precision).
 
 #[allow(unused_imports)]
 use super::*;
@@ -112,5 +115,44 @@ pub fn mathieu_s_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let yp0 = a.sqrt();
   let (_, yp) = integrate_mathieu(a, q, z, 0.0, yp0);
+  Ok(Expr::Real(yp))
+}
+
+/// MathieuC[a, q, z] — even Mathieu function, normalised to match
+/// `cos(√a · z)` at q = 0 (BC `y(0) = 1`, `y'(0) = 0`).
+pub fn mathieu_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() != 3 {
+    return Ok(unevaluated("MathieuC", args));
+  }
+  let (Some(a), Some(q), Some(z)) = (
+    try_real_f64(&args[0]),
+    try_real_f64(&args[1]),
+    try_real_f64(&args[2]),
+  ) else {
+    return Ok(unevaluated("MathieuC", args));
+  };
+  if a < 0.0 {
+    return Ok(unevaluated("MathieuC", args));
+  }
+  let (y, _) = integrate_mathieu(a, q, z, 1.0, 0.0);
+  Ok(Expr::Real(y))
+}
+
+/// MathieuCPrime[a, q, z] — derivative of MathieuC w.r.t. z.
+pub fn mathieu_c_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() != 3 {
+    return Ok(unevaluated("MathieuCPrime", args));
+  }
+  let (Some(a), Some(q), Some(z)) = (
+    try_real_f64(&args[0]),
+    try_real_f64(&args[1]),
+    try_real_f64(&args[2]),
+  ) else {
+    return Ok(unevaluated("MathieuCPrime", args));
+  };
+  if a < 0.0 {
+    return Ok(unevaluated("MathieuCPrime", args));
+  }
+  let (_, yp) = integrate_mathieu(a, q, z, 1.0, 0.0);
   Ok(Expr::Real(yp))
 }

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -1984,13 +1984,15 @@ mod unimplemented_warnings {
   #[test]
   fn multiple_unimplemented_calls_consolidated_into_single_warning() {
     clear_state();
-    // MathieuS now has a numerical implementation; use MathieuC which
-    // is still unimplemented to exercise the multi-call warning path.
+    // MathieuS/MathieuC now have numerical implementations; use
+    // MathieuCharacteristicA, which is still unimplemented, to exercise
+    // the multi-call warning path.
     let result =
-      interpret_with_stdout("{CityData[1], MathieuC[1, 1, 1.0]}").unwrap();
+      interpret_with_stdout("{CityData[1], MathieuCharacteristicA[1, 1.0]}")
+        .unwrap();
     assert_eq!(result.warnings.len(), 1);
     assert!(result.warnings[0].contains("CityData[1]"));
-    assert!(result.warnings[0].contains("MathieuC[1, 1, 1.]"));
+    assert!(result.warnings[0].contains("MathieuCharacteristicA[1, 1.]"));
     assert!(
       result.warnings[0].contains("are built-in Wolfram Language functions")
     );

--- a/tests/interpreter_tests/math/special_functions.rs
+++ b/tests/interpreter_tests/math/special_functions.rs
@@ -10411,6 +10411,60 @@ mod mathieu_s {
       "MathieuSPrime[a, q, z]"
     );
   }
+
+  #[test]
+  fn mathieu_c_q_zero_matches_cosine() {
+    let val = parse_real(&interpret("MathieuC[2, 0, 1.5]").unwrap());
+    let expected = (2.0_f64.sqrt() * 1.5).cos();
+    assert!(
+      (val - expected).abs() < 1e-9,
+      "MathieuC(2, 0, 1.5): got {val}, expected {expected}"
+    );
+  }
+
+  #[test]
+  fn mathieu_c_prime_q_zero_at_origin() {
+    let val = parse_real(&interpret("MathieuCPrime[3, 0, 0]").unwrap());
+    assert!(
+      val.abs() < 1e-9,
+      "MathieuCPrime(3, 0, 0): got {val}, expected 0"
+    );
+  }
+
+  #[test]
+  fn mathieu_c_prime_q_zero_matches_derivative() {
+    let val = parse_real(&interpret("MathieuCPrime[2, 0, 1.5]").unwrap());
+    let sa = 2.0_f64.sqrt();
+    let expected = -sa * (sa * 1.5).sin();
+    assert!(
+      (val - expected).abs() < 1e-9,
+      "MathieuCPrime(2, 0, 1.5): got {val}, expected {expected}"
+    );
+  }
+
+  #[test]
+  fn mathieu_c_one_at_origin() {
+    let val = parse_real(&interpret("MathieuC[2, 1, 0]").unwrap());
+    assert!(
+      (val - 1.0).abs() < 1e-12,
+      "MathieuC(2, 1, 0) should be 1, got {val}"
+    );
+  }
+
+  #[test]
+  fn mathieu_c_prime_finite_for_nonzero_q() {
+    let val = parse_real(&interpret("MathieuCPrime[2, 1, 3.2]").unwrap());
+    assert!(val.is_finite(), "expected a finite real, got {val}");
+  }
+
+  #[test]
+  fn mathieu_c_symbolic_passthrough() {
+    assert_eq!(interpret("MathieuC[a, q, z]").unwrap(), "MathieuC[a, q, z]");
+    assert_eq!(
+      interpret("MathieuCPrime[a, q, z]").unwrap(),
+      "MathieuCPrime[a, q, z]"
+    );
+  }
 }
 
 mod riemann_siegel_z {


### PR DESCRIPTION
## Summary

While checking a randomly sampled Wolfram Demonstration notebook ("Motion of Single Ion in a Linear Paul Trap") for Woxi Studio compatibility, I found that the notebook's `IonPath` helper function calls `MathieuC`, `MathieuCPrime`, `MathieuS`, and `MathieuSPrime`, but only the S-family (`MathieuS`/`MathieuSPrime`) was actually implemented — `MathieuC`/`MathieuCPrime` were completely unevaluated symbols.

- Implemented `MathieuC` and `MathieuCPrime` in `src/functions/math_ast/mathieu.rs`, following the same Floquet-ODE numerical integration pattern already used for `MathieuS`/`MathieuSPrime`. The even-family solution is anchored at the boundary condition `y(0)=1, y'(0)=0`, matching `cos(√a·z)` at `q=0` (mirroring how the S-family matches `sin(√a·z)`).
- Wired up dispatch (`src/evaluator/dispatch/math_functions.rs`) and arg-count validation (`src/evaluator/dispatch/arg_count.rs`).
- Updated `functions.csv` to mark both functions as implemented.
- Added unit tests in `tests/interpreter_tests/math/special_functions.rs` mirroring the existing `MathieuS`/`MathieuSPrime` test coverage (q=0 closed-form checks, boundary-value checks, symbolic passthrough for non-numeric args).
- Fixed a pre-existing test (`tests/interpreter_tests/io.rs`) that used `MathieuC` as an example of a still-unimplemented function for its multi-warning-consolidation test; it now uses `MathieuCharacteristicA` instead, which remains genuinely unimplemented.

## Known follow-up (not addressed here)

The notebook's `IonPath` function always calls these with characteristic value `a=0`. With Woxi's existing normalization for the S-family (boundary condition `y(0)=0, y'(0)=√a`), that boundary condition degenerates to the trivial zero solution at `a=0` (by ODE uniqueness), which makes `IonPath` return `Indeterminate` (0/0) for typical inputs. This is inherited from the pre-existing `MathieuS`/`MathieuSPrime` design, which already documents (in code comments and tests) that its normalization is an accepted approximation and diverges from wolframscript's exact Hill-determinant-based scaling for `q != 0`. Matching Wolfram's exact normalization precisely would be a much larger undertaking and is out of scope for this fix.

## Test plan

- [x] `cargo test mathieu` — all Mathieu unit tests (existing + new) pass
- [x] `make test` — full suite passes (27827/27827)
- [x] `make format`
- [x] Verified via `woxi-studio`'s `dump_manipulate` diagnostic example that the notebook's `Manipulate` still builds a working interactive widget (12 controls, graphics rendered, no error) for its default branch
- [x] Verified via CLI that `IonPath` (previously fully symbolic due to unimplemented `MathieuC`/`MathieuCPrime`) now evaluates numerically

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgSew27xLaEgHCHkkfGQ2T)_