### PR TITLE
Fix unary minus binding tighter than Apply/Map in the parser

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5778,9 +5778,12 @@ fn operator_precedence(op: &str) -> u8 {
     "." => 40,                           // Dot (higher than the ring ops)
     "\\[CircleDot]" | "\u{2299}" => 43,  // above Cross, below SmallCircle
     "\\[SmallCircle]" | "\u{2218}" => 44, // above CircleDot, below Apply
-    "@@@" | "@@" => 45,                  // Apply/MapApply
-    "/@" => 46,                          // Map (higher than Apply)
-    "NEGATE" => 47, // Unary minus (PreMinus): between Times/Dot and Power
+    "NEGATE" => 45, // Unary minus (PreMinus): between Times/Dot and Apply/Map,
+    // so `-f @@ list` reads as `-(f @@ list)` and `-f /@ list` as
+    // `-(f /@ list)`, matching Wolfram (Apply/Map bind tighter than a
+    // leading unary minus).
+    "@@@" | "@@" => 46,  // Apply/MapApply
+    "/@" => 47,          // Map (higher than Apply)
     "^" | "^_NEG" => 50, // Power (`^_NEG` is `a^-b` with negated right operand)
     s if s.starts_with('~') && s.ends_with('~') && s.len() > 2 => 53, // Tilde infix: a ~f~ b (higher than ^, lower than @)
     "@" => 56, // Prefix application
@@ -7959,8 +7962,8 @@ fn printed_infix_precedence(e: &Expr) -> Option<u8> {
     Expr::CompoundExpr(_) => Some(1),
     // `body &` binds looser than every operator shorthand.
     Expr::Function { .. } => Some(5),
-    Expr::Map { .. } => Some(44),
-    Expr::Apply { .. } | Expr::MapApply { .. } => Some(43),
+    Expr::Map { .. } => Some(47),
+    Expr::Apply { .. } | Expr::MapApply { .. } => Some(46),
     // ` !x` sits between `&&` and the application shorthands.
     Expr::UnaryOp {
       op: UnaryOperator::Not,
@@ -11450,13 +11453,13 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
       )
     }
     Expr::Map { func, list } => {
-      format_map_apply_shorthand(func, list, "/@", 44)
+      format_map_apply_shorthand(func, list, "/@", 47)
     }
     Expr::Apply { func, list } => {
-      format_map_apply_shorthand(func, list, "@@", 43)
+      format_map_apply_shorthand(func, list, "@@", 46)
     }
     Expr::MapApply { func, list } => {
-      format_map_apply_shorthand(func, list, "@@@", 43)
+      format_map_apply_shorthand(func, list, "@@@", 46)
     }
     Expr::PrefixApply { func, arg } => {
       // f @ g is displayed as f[g] (Wolfram converts @ to function call notation)

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -100,6 +100,14 @@ $ wo 'Length[{a, b}] f /@ {x, y}'
 {2*f[x], 2*f[y]}
 ```
 
+A leading unary minus binds looser than `@@`, `@@@` and `/@`, so `-Plus @@
+list` negates the whole applied result rather than negating just `Plus`:
+
+```scrut
+$ wo '-Plus @@ {1, 2, 3}'
+-6
+```
+
 
 ## Rule (`->`) and RuleDelayed (`:>`) as general operators
 

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -399,6 +399,34 @@ mod unary_minus_parsing {
       "{-I*a, -b, I*c}"
     );
   }
+
+  // Regression: `-Plus @@ list` parsed as `(-Plus) @@ list` instead of
+  // `-(Plus @@ list)` because NEGATE had higher precedence than Apply/Map in
+  // the climbing algorithm. This is a common Wolfram idiom for negating a
+  // sum or mapped result — e.g. the "Stress Distribution in a Circular
+  // Plate with Concentrated Radial Loadings" Demonstration computes a force
+  // resultant as `-Plus @@ (component & /@ points)`, which silently
+  // produced an unevaluated `(-Plus)[…]` head instead of the negated sum.
+  #[test]
+  fn negated_apply_and_map_bind_outside_the_shorthand() {
+    assert_eq!(interpret("-Plus @@ {1, 2, 3}").unwrap(), "-6");
+    assert_eq!(interpret("-Times @@ {2, 3, 4}").unwrap(), "-24");
+    assert_eq!(interpret("-(#*2) & /@ {1, 2, 3}").unwrap(), "{-2, -4, -6}");
+    assert_eq!(
+      interpret("Hold[-Plus @@ {1, 2, 3}]").unwrap(),
+      "Hold[-Plus @@ {1, 2, 3}]"
+    );
+    assert_eq!(
+      interpret("Hold[-f @@@ {{1, 2}}]").unwrap(),
+      "Hold[-f @@@ {{1, 2}}]"
+    );
+    // Still combines correctly with other operators: the minus binds the
+    // whole shorthand before multiplying.
+    assert_eq!(interpret("2 * -Plus @@ {1, 2, 3}").unwrap(), "-12");
+    // Power still binds tighter than the negated shorthand's operand:
+    // `{1, 2}^2` becomes `{1, 4}` before Apply and the negation run.
+    assert_eq!(interpret("-Plus @@ {1, 2}^2").unwrap(), "-5");
+  }
 }
 
 mod implicit_times_with_strings {
@@ -615,6 +643,30 @@ mod operator_shorthand_parens {
     // Higher-precedence operands stay unparenthesized.
     assert_eq!(interpret("Hold[f /@ a + b]").unwrap(), "Hold[f /@ a + b]");
     assert_eq!(interpret("Hold[f @@ a^2]").unwrap(), "Hold[f @@ a^2]");
+  }
+
+  // A leading unary minus binds looser than `@@`/`@@@`/`/@` (see
+  // `negated_apply_and_map_bind_outside_the_shorthand`), so a negated
+  // *function head* needs explicit parens to round-trip, while a negated
+  // whole-shorthand doesn't.
+  #[test]
+  fn held_negated_apply_map_round_trips() {
+    assert_eq!(
+      interpret("Hold[(-f) @@ {1, 2}]").unwrap(),
+      "Hold[(-f) @@ {1, 2}]"
+    );
+    assert_eq!(
+      interpret("Hold[(-f) /@ {1, 2}]").unwrap(),
+      "Hold[(-f) /@ {1, 2}]"
+    );
+    assert_eq!(
+      interpret("Hold[-f @@ {1, 2}]").unwrap(),
+      "Hold[-f @@ {1, 2}]"
+    );
+    assert_eq!(
+      interpret("Hold[-f /@ {1, 2}]").unwrap(),
+      "Hold[-f /@ {1, 2}]"
+    );
   }
 
   // An implicit product (`2 f`) is `Times` at multiplicative precedence, so


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random official Wolfram Demonstration ("Stress Distribution in a Circular Plate with Concentrated Radial Loadings"), I found that its force-resultant computation silently produced wrong results and a degenerate `ContourPlot`.

Root cause: the notebook uses the common Wolfram idiom `-Plus @@ list` to negate a summed result. Woxi's precedence-climbing parser gave the synthetic unary-minus operator (`NEGATE`) a *higher* precedence than `Apply` (`@@`) and `Map` (`/@`), so `-Plus @@ list` parsed as `(-Plus) @@ list` instead of the correct `-(Plus @@ list)`. In real Wolfram Language, `Apply`/`Map` bind tighter than a leading unary minus.

This silently corrupted the Demonstration's physics computation (a list of two `Abs[...]` terms instead of a single summed scalar), which in turn made `ContourPlot` render a near-empty graphic (46-byte SVG) instead of the real plot (~198 KB SVG after the fix).

- `src/syntax.rs`: moved `NEGATE` below `@@`/`@@@`/`/@` in `operator_precedence`, and updated the matching printer-side precedence tables (`printed_infix_precedence` and the `format_map_apply_shorthand` call sites) so `InputForm` output still round-trips correctly in both directions (e.g. `-f @@ list` prints bare, `(-f) @@ list` keeps its parens).
- `tests/interpreter_tests/syntax.rs`: added regression tests for evaluation (`-Plus @@ {1,2,3}` → `-6`, etc.) and for `Hold[...]`/`InputForm` round-tripping in both directions.
- `tests/cli/syntax.md`: added a short illustrative doc example.

## Test plan

- [x] `make test` — all 27,823 unit tests pass (no regressions)
- [x] `make format`
- [x] Verified the downloaded Demonstration notebook: `Mymap`/`MaxShear` computation now reduces to a single scalar and `ContourPlot` renders a real SVG (previously 46 bytes, now ~198 KB)
- [x] `woxi run` on the notebook still exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013yKM1BhnqFpZYjjbvdKAWT)_