### PR TITLE
Fix LocatorPane rendering and control promotion for Dynamic-wrapped pictures

### DIFF
--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -4799,13 +4799,35 @@ fn locator_pane_graphic(args: &[Expr]) -> Option<Expr> {
     other => other,
   };
   let body = crate::evaluator::evaluate_expr_to_expr(held).ok()?;
+  let appearance = args[2..].iter().find_map(|o| match o {
+    Expr::Rule { pattern, replacement }
+      if matches!(pattern.as_ref(), Expr::Identifier(p) if p == "Appearance") =>
+    {
+      crate::evaluator::evaluate_expr_to_expr(replacement).ok()
+    }
+    _ => None,
+  });
   let (body_prims, body_opts) = match &body {
     Expr::FunctionCall { name, args }
       if name == "Graphics" && !args.is_empty() =>
     {
       (args[0].clone(), args[1..].to_vec())
     }
-    _ => return None,
+    // A body that evaluates straight to a rendered picture instead of
+    // staying the symbolic `Graphics[prims, opts]` above — `Show[…]`,
+    // `ContourPlot[…]`, or a `Which`/`If` switching between such plots
+    // (a Demonstration toggling between several plotted methods over
+    // the same locator) — can't have its marker spliced into a
+    // primitive list that doesn't exist here. Draw it via `Epilog`
+    // instead.
+    _ => {
+      return locator_pane_graphic_via_epilog(
+        held,
+        &body,
+        &points,
+        appearance.as_ref(),
+      );
+    }
   };
 
   // The default marker is sized against the plot range, so it stays a small
@@ -4834,15 +4856,6 @@ fn locator_pane_graphic(args: &[Expr]) -> Option<Expr> {
     })
     .unwrap_or(1.0);
 
-  let appearance = args[2..].iter().find_map(|o| match o {
-    Expr::Rule { pattern, replacement }
-      if matches!(pattern.as_ref(), Expr::Identifier(p) if p == "Appearance") =>
-    {
-      crate::evaluator::evaluate_expr_to_expr(replacement).ok()
-    }
-    _ => None,
-  });
-
   let mut prims = vec![body_prims];
   for (i, point) in points.iter().enumerate() {
     if let Some(marker) = locator_marker(appearance.as_ref(), i, point, span) {
@@ -4852,6 +4865,190 @@ fn locator_pane_graphic(args: &[Expr]) -> Option<Expr> {
   let mut graphics_args = vec![Expr::List(prims.into())];
   graphics_args.extend(body_opts);
   Some(call("Graphics", graphics_args))
+}
+
+/// The data-space extent a `LocatorPane` marker's default size is scaled
+/// against, for a body that only exists as a rendered picture (so there is
+/// no `PlotRange` option lying around in a primitive list to read, as
+/// `locator_pane_graphic` reads for the symbolic-`Graphics` case). Falls
+/// back to `1.0` — matching that case's own fallback — when the picture
+/// carries no source range (a plain `Graphics[…]` with no plot data, or a
+/// picture kind that keeps none).
+fn rendered_graphic_span(body: &Expr) -> f64 {
+  if let Expr::Graphics {
+    source: Some(src), ..
+  } = body
+  {
+    let x_extent = (src.x_range.1 - src.x_range.0).abs();
+    let y_extent = (src.y_range.1 - src.y_range.0).abs();
+    let span = x_extent.max(y_extent);
+    if span > 0.0 {
+      return span;
+    }
+  }
+  1.0
+}
+
+/// Whether `name` is a graphics-producing head known to accept an
+/// `Epilog -> {…}` option — extra primitives drawn on top of the picture,
+/// in the same data coordinates, without changing the call's arity the
+/// way appending a plain positional argument would.
+fn accepts_epilog_option(name: &str) -> bool {
+  name == "Show" || crate::functions::graphics::is_graphics_producing_head(name)
+}
+
+/// Add `Epilog -> markers` (merging with any `Epilog` already there) to a
+/// `FunctionCall` with a head [`accepts_epilog_option`] recognizes.
+fn with_epilog(name: &str, args: &[Expr], markers: &Expr) -> Expr {
+  let mut new_args: crate::ExprList = args.to_vec().into();
+  let existing = new_args.iter().position(|a| {
+    matches!(a, Expr::Rule { pattern, .. }
+      if matches!(pattern.as_ref(), Expr::Identifier(n) if n == "Epilog"))
+  });
+  match existing {
+    Some(pos) => {
+      let merged = match &new_args[pos] {
+        Expr::Rule { replacement, .. } => match replacement.as_ref() {
+          Expr::List(items) => {
+            let mut v = items.to_vec();
+            v.push(markers.clone());
+            Expr::List(v.into())
+          }
+          other => Expr::List(vec![other.clone(), markers.clone()].into()),
+        },
+        _ => markers.clone(),
+      };
+      new_args[pos] = Expr::Rule {
+        pattern: Box::new(Expr::Identifier("Epilog".to_string())),
+        replacement: Box::new(merged),
+      };
+    }
+    None => {
+      new_args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("Epilog".to_string())),
+        replacement: Box::new(markers.clone()),
+      });
+    }
+  }
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: new_args,
+  }
+}
+
+/// Recursively add `Epilog -> markers` to every graphics-producing call
+/// reachable through pure control-flow wrappers (`If`, `Which`, `Switch`,
+/// `With`, `Module`, `Block`, the trailing statement of a
+/// `CompoundExpr`) — without evaluating anything, so whichever branch such
+/// a body picks at evaluation time already draws the given markers. A
+/// `LocatorPane` body written `Which[cond1, Show[…], cond2, Show[…], …]`
+/// (a Demonstration switching between plotted methods over the same
+/// locator) is the motivating case: only the branch a `Which`/`If`
+/// actually selects is ever evaluated, so touching the others here is
+/// inert — they are never run at all. Anything else is returned
+/// unchanged, including a call whose head [`accepts_epilog_option`]
+/// does not recognize (appending an option to those could break their
+/// arity).
+fn inject_epilog_through_control_flow(expr: &Expr, markers: &Expr) -> Expr {
+  match expr {
+    Expr::FunctionCall { name, args } if name == "If" && args.len() >= 2 => {
+      let mut new_args = args.clone();
+      for branch in new_args.iter_mut().skip(1) {
+        *branch = inject_epilog_through_control_flow(branch, markers);
+      }
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: new_args,
+      }
+    }
+    Expr::FunctionCall { name, args } if name == "Which" && args.len() >= 2 => {
+      let mut new_args = args.clone();
+      let mut i = 1;
+      while i < new_args.len() {
+        new_args[i] = inject_epilog_through_control_flow(&new_args[i], markers);
+        i += 2;
+      }
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: new_args,
+      }
+    }
+    Expr::FunctionCall { name, args }
+      if name == "Switch" && args.len() >= 3 =>
+    {
+      let mut new_args = args.clone();
+      let mut i = 2;
+      while i < new_args.len() {
+        new_args[i] = inject_epilog_through_control_flow(&new_args[i], markers);
+        i += 2;
+      }
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: new_args,
+      }
+    }
+    Expr::FunctionCall { name, args }
+      if matches!(name.as_str(), "With" | "Module" | "Block")
+        && args.len() == 2 =>
+    {
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: vec![
+          args[0].clone(),
+          inject_epilog_through_control_flow(&args[1], markers),
+        ]
+        .into(),
+      }
+    }
+    Expr::CompoundExpr(items) if !items.is_empty() => {
+      let mut new_items = items.clone();
+      let last = new_items.len() - 1;
+      new_items[last] =
+        inject_epilog_through_control_flow(&new_items[last], markers);
+      Expr::CompoundExpr(new_items)
+    }
+    Expr::FunctionCall { name, args } if accepts_epilog_option(name) => {
+      with_epilog(name, args, markers)
+    }
+    other => other.clone(),
+  }
+}
+
+/// [`locator_pane_graphic`]'s fallback for a body that evaluates straight
+/// to a rendered picture — `Show[…]`, `ContourPlot[…]`, or a `Which`/`If`
+/// switching between such plots — rather than staying the symbolic
+/// `Graphics[prims, opts]` the primitive-splicing path needs. Re-runs the
+/// body once more with the locator markers spliced in as an `Epilog` (see
+/// `inject_epilog_through_control_flow`), so they are drawn by the same
+/// renderer that drew the rest of the picture, in the same data
+/// coordinates. Falls back to the unmarked picture — still far better
+/// than the typeset-text fallback `evaluated_wrapper_svg`'s caller uses
+/// otherwise — when `body` is not a picture at all, or no graphics call
+/// is found to draw the markers on.
+fn locator_pane_graphic_via_epilog(
+  held: &Expr,
+  body: &Expr,
+  points: &[Expr],
+  appearance: Option<&Expr>,
+) -> Option<Expr> {
+  if !lays_out_a_graphic(body) {
+    return None;
+  }
+  let span = rendered_graphic_span(body);
+  let markers: Vec<Expr> = points
+    .iter()
+    .enumerate()
+    .filter_map(|(i, p)| locator_marker(appearance, i, p, span))
+    .collect();
+  if markers.is_empty() {
+    return Some(body.clone());
+  }
+  let augmented =
+    inject_epilog_through_control_flow(held, &Expr::List(markers.into()));
+  Some(
+    crate::evaluator::evaluate_expr_to_expr(&augmented)
+      .unwrap_or_else(|_| body.clone()),
+  )
 }
 
 /// A string shown through `Text` loses the quotation marks its own

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -14489,7 +14489,7 @@ fn compute_per_cell_width(n: usize, explicit_total: Option<f64>) -> i128 {
 /// honor the `ImageSize` option. Used to avoid injecting `ImageSize`
 /// into arbitrary user functions (which might error or behave oddly on
 /// unknown options) while still catching the common plot/chart cases.
-fn is_graphics_producing_head(name: &str) -> bool {
+pub(crate) fn is_graphics_producing_head(name: &str) -> bool {
   matches!(
     name,
     // Core graphics primitives
@@ -18023,7 +18023,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         {
           let promoted: Vec<Expr> = items
             .iter()
-            .filter(|it| !is_control_type_rule(it))
+            .filter(|it| !is_control_type_marker(it))
             .cloned()
             .chain(std::iter::once(Expr::Identifier("Locator".to_string())))
             .collect();
@@ -18316,16 +18316,36 @@ fn is_control_type_rule(item: &Expr) -> bool {
   )
 }
 
-/// The variables driven by `Locator[Dynamic[var, cb], …]` markers inside a
-/// Manipulate body, each with the InputForm of its write-back callback (the
-/// Dynamic's second argument), in first-seen order.
+/// Whether a control-spec item picks or hides the control's own type —
+/// either the `ControlType -> …` option, or the bare shorthand for it in
+/// the control-type slot after the bounds (`{{v, init}, min, max, None}`
+/// hides the control the same way `ControlType -> None` does). A
+/// promotion that swaps this marker for `Locator` (see
+/// `collect_body_locator_callbacks`'s callers) must strip both forms:
+/// leaving a bare `None` behind alongside the appended `Locator` marker
+/// makes the re-parsed spec hidden all over again, so the promotion
+/// silently loses the control instead of making it draggable.
+fn is_control_type_marker(item: &Expr) -> bool {
+  is_control_type_rule(item)
+    || matches!(item, Expr::Identifier(s) if s == "None")
+}
+
+/// The variables driven by `Locator[Dynamic[var, cb], …]` markers or a
+/// `LocatorPane[Dynamic[var, cb], …]` pane inside a Manipulate body, each
+/// with the InputForm of its write-back callback (the Dynamic's second
+/// argument), in first-seen order. `LocatorPane` is the whole-picture form
+/// (a Demonstration switching which plot it drags a point over draws the
+/// picture itself as `Dynamic`, with the pane wrapping that); `Locator` is
+/// the bare graphics primitive placed among ordinary primitives in a
+/// `Graphics[…]` list. Both drive their variable interactively the same
+/// way, so both promote it to a visible control below.
 fn collect_body_locator_callbacks(
   expr: &Expr,
 ) -> Vec<(String, Option<String>)> {
   fn walk(expr: &Expr, found: &mut Vec<(String, Option<String>)>) {
     match expr {
       Expr::FunctionCall { name, args } => {
-        if name == "Locator"
+        if (name == "Locator" || name == "LocatorPane")
           && let Some(Expr::FunctionCall {
             name: dname,
             args: dargs,

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11968,6 +11968,84 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       assert!(!svg.contains("<ellipse"), "no marker was asked for: {svg}");
     }
 
+    // `LocatorPane[locators, Dynamic[picture]]` — the picture is itself
+    // `Dynamic`-wrapped, as it is once it depends on something besides the
+    // locators (a Demonstration whose plot also reacts to a slider).
+    // `Show[…]` (like every other plot head) evaluates straight to a
+    // rendered picture rather than staying the symbolic
+    // `Graphics[prims, opts]` a marker can be spliced into, so this body
+    // shape used to fail that check and the whole pane exported as a
+    // strip of its own unevaluated source instead of a picture.
+    #[test]
+    fn locator_pane_draws_a_dynamic_wrapped_show_picture() {
+      let svg = export_svg(
+        "LocatorPane[{{0.5, 0.5}}, \
+         Dynamic[Show[Graphics[{Line[{{0, 0}, {1, 1}}]}, \
+         PlotRange -> {{0, 1}, {0, 1}}, ImageSize -> 200]]]]",
+      );
+      assert!(!svg.contains("LocatorPane"), "not the source: {svg}");
+      assert!(
+        svg.contains("<polyline") || svg.contains("<line"),
+        "the wrapped picture must still be drawn: {svg}"
+      );
+      assert_eq!(
+        svg.matches("<ellipse").count(),
+        1,
+        "the locator marker must still be drawn on top: {svg}"
+      );
+    }
+
+    // A body that picks its picture with `Which` (a Demonstration
+    // switching between plotted methods over the same locator, e.g.
+    // choosing which optimization algorithm's path to plot) only ever
+    // evaluates the branch it selects — the marker only has to reach that
+    // one branch, and never touches the others, which are never run.
+    #[test]
+    fn locator_pane_draws_the_which_branch_its_body_selects() {
+      let body = |mode: &str| {
+        format!(
+          "mode = \"{mode}\"; \
+           LocatorPane[{{{{0.5, 0.5}}}}, \
+           Dynamic[Which[mode == \"circle\", \
+             Show[Graphics[{{Disk[]}}, PlotRange -> {{{{0, 1}}, {{0, 1}}}}, \
+               ImageSize -> 200]], \
+             mode == \"square\", \
+             Show[Graphics[{{Rectangle[]}}, PlotRange -> {{{{0, 1}}, {{0, 1}}}}, \
+               ImageSize -> 200]]]]]"
+        )
+      };
+
+      let circle_svg = export_svg(&body("circle"));
+      assert!(
+        !circle_svg.contains("LocatorPane"),
+        "not the source: {circle_svg}"
+      );
+      assert_eq!(
+        circle_svg.matches("<ellipse").count(),
+        2,
+        "the selected disk plus the locator marker: {circle_svg}"
+      );
+      assert!(
+        !circle_svg.contains("<rect"),
+        "the other branch: {circle_svg}"
+      );
+
+      let square_svg = export_svg(&body("square"));
+      assert!(
+        !square_svg.contains("LocatorPane"),
+        "not the source: {square_svg}"
+      );
+      assert!(
+        square_svg.contains("<rect"),
+        "the selected square: {square_svg}"
+      );
+      assert_eq!(
+        square_svg.matches("<ellipse").count(),
+        1,
+        "just the locator marker this time: {square_svg}"
+      );
+    }
+
     // A primitive whose argument is `Dynamic[…]` draws the value that
     // argument has now — the shape a Demonstration's draggable points make.
     // The content arrives unexpanded (`Dynamic` is HoldFirst), and without
@@ -18651,6 +18729,61 @@ mod manipulate {
         assert_eq!((*y_min, *y_max), (-2.0, 2.0));
       }
       _ => panic!("expected 2D control"),
+    }
+  }
+
+  // A hidden variable's control-type slot can spell `None` as a bare
+  // identifier after the bounds (`{{v, init}, min, max, None}`) instead of
+  // the `ControlType -> None` option rule — both mean the same thing, and
+  // a Demonstration is free to use either. A body-level `Locator[Dynamic[…]]`
+  // or `LocatorPane[Dynamic[…], …]` driving such a variable promotes it to a
+  // visible, draggable control either way: re-parsing the spec with its
+  // control-type marker swapped for `Locator` must actually strip the bare
+  // `None`, not just the `ControlType -> …` rule form, or the re-parsed spec
+  // reads as hidden all over again and the promotion silently loses the
+  // control instead of making it draggable. Regression: with only the rule
+  // form stripped, this variable disappeared from the spec entirely — not
+  // a control, not even hidden state.
+  #[test]
+  fn spec_body_locator_promotes_a_bare_none_control_type() {
+    let expr = interpret_to_expr(
+      "Manipulate[Graphics[{Locator[Dynamic[pt], Point[pt]]}], \
+       {{pt, {0.2, 1}}, {-1, -1}, {1, 1}, None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Slider2D {
+        name,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        ..
+      } => {
+        assert_eq!(name, "pt");
+        assert_eq!((*x_min, *x_max), (-1.0, 1.0));
+        assert_eq!((*y_min, *y_max), (-1.0, 1.0));
+      }
+      other => panic!("expected a draggable 2D control, got {other:?}"),
+    }
+  }
+
+  // The same bare-`None` shorthand, but driven by a whole-picture
+  // `LocatorPane[Dynamic[…], …]` (the "toggle between plotted methods"
+  // Demonstration pattern) rather than a bare `Locator[…]` primitive
+  // inside a `Graphics[…]` list.
+  #[test]
+  fn spec_body_locator_pane_promotes_a_bare_none_control_type() {
+    let expr = interpret_to_expr(
+      "Manipulate[LocatorPane[Dynamic[pt], Graphics[{Point[pt]}]], \
+       {{pt, {0.2, 1}}, {-1, -1}, {1, 1}, None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Slider2D { name, .. } => assert_eq!(name, "pt"),
+      other => panic!("expected a draggable 2D control, got {other:?}"),
     }
   }
 


### PR DESCRIPTION
## Summary

Found while checking whether Woxi Studio fully supports a random Wolfram Demonstration ("Optimization of the Rosenbrock Banana Function"). Its `Manipulate` combines two bugs that each independently break the widget:

- **`LocatorPane` rendering**: `LocatorPane[locators, body]` only drew its marker when `body` evaluated to a symbolic `Graphics[prims, opts]` call. A body that renders straight to a picture instead — `Show[...]`, `ContourPlot[...]`, or (as in this Demonstration) a `Which`/`If` choosing between such plots — fell back to typesetting the whole unevaluated `LocatorPane[...]` as text instead of drawing the picture. Fixed by drawing the markers via an `Epilog` spliced into whichever graphics call the body's control-flow wrappers (`If`/`Which`/`Switch`/`With`/`Module`/`Block`/a trailing `CompoundExpr` statement) actually evaluate — the same renderer that draws the rest of the picture, so it works for any plot head without duplicating primitive-drawing logic.
- **Control promotion**: a hidden Manipulate control's domain can spell `None` as a bare identifier after the bounds (`{{v, init}, min, max, None}`) instead of the `ControlType -> None` rule — both mean the same thing. Promoting such a variable to a draggable Locator control (because an in-body `Locator[...]`/`LocatorPane[...]` drives it) re-parses the spec with the control-type marker swapped for `Locator`, but only stripped the `ControlType -> ...` rule form, not the bare `None`. With both markers present the re-parsed spec read as hidden all over again, so the variable silently vanished from the spec entirely — not a control, not even hidden state.

Also extended the locator-callback detector to recognize a whole-picture `LocatorPane[Dynamic[var, cb], ...]`, not just the bare `Locator[Dynamic[var, cb], ...]` graphics primitive, so a Demonstration that drags a point over an entire dynamically-switched plot (rather than a fixed marker inside a `Graphics[...]` list) gets the same promotion.

## Test plan

- Added `locator_pane_draws_a_dynamic_wrapped_show_picture` and `locator_pane_draws_the_which_branch_its_body_selects` in `tests/interpreter_tests/graphics.rs`, covering the rendering fix directly at the `ExportString[..., "SVG"]` level.
- Added `spec_body_locator_promotes_a_bare_none_control_type` and `spec_body_locator_pane_promotes_a_bare_none_control_type`, covering the control-promotion fix at the `extract_manipulate_spec` level.
- `make test` — 27825 passed, 0 failed.
- `make format`.
- Manually verified against the downloaded Demonstration notebook with `woxi-studio`'s `dump_manipulate` example: the locator point is now a draggable `Slider2D` control, and the widget renders the contour plot + optimization-path picture (previously a 5428×15 strip of raw source text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmqWVjovUKKcEp3ddkKG8W)_