### PR TITLE
Add a draggable stand-in for a Manipulate's top-level LocatorPane

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -18104,6 +18104,57 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     }
   }
 
+  // A `LocatorPane[Dynamic[var], graphic]` drawn directly in the body — the
+  // Demonstrations "drag the point on the picture" pattern — gets its own
+  // draggable stand-in row here, alongside whatever row (if any) the
+  // Specifications already gave `var`; a `Locator`-type row for it already
+  // covers the same interaction, so only add one when none exists yet.
+  for (var, range_arg, graphic) in collect_body_locator_pane_vars(&args[0]) {
+    if controls.iter().any(|c| c.name() == var) {
+      // Already a visible row of some kind for it — unless that row is
+      // itself a draggable point, add another, independent one (the same
+      // "two rows, one binding" pattern a coarse/fine preset pair uses).
+      if controls.iter().any(|c| {
+        c.name() == var && matches!(c, ManipulateControl::Slider2D { .. })
+      }) {
+        continue;
+      }
+    } else if state.iter().any(|(n, _)| n == &var) {
+      // `ControlType -> None`: the author deliberately hid it, driving it
+      // through other visible controls instead (e.g. polar sliders writing
+      // a Cartesian locator back through the `Dynamic`'s callback) — respect
+      // that rather than surfacing a row they chose not to show.
+      continue;
+    }
+    // Only a variable whose default resolves to a plain `{x, y}` point is a
+    // fit for a single draggable stand-in slider — e.g. a `DynamicModule`
+    // local holding a list of several locators (a polygon's vertices) is
+    // left alone rather than showing a meaningless synthesized row for it.
+    let Some((x_initial, y_initial)) = crate::with_scoped_globals(
+      &initial_bindings,
+      || -> Option<(f64, f64)> {
+        let (_, code) = initial_bindings.iter().find(|(n, _)| *n == var)?;
+        let expr = crate::interpret_to_expr(code).ok()?;
+        list2_f64(&evaluate_expr_to_expr(&expr).ok()?)
+      },
+    ) else {
+      continue;
+    };
+    let ((x_min, y_min), (x_max, y_max)) =
+      pane_range(range_arg.as_ref(), &graphic);
+    controls.push(ManipulateControl::Slider2D {
+      name: var.clone(),
+      x_min,
+      x_max,
+      y_min,
+      y_max,
+      x_initial,
+      y_initial,
+      label: var,
+      write_callback: None,
+    });
+  }
+
   // A Manipulate with no controls or state at all (e.g. `Manipulate[x^2,
   // badspec]`, where `badspec` is neither a spec nor an option) isn't
   // renderable as an interactive widget — fall back to the plain path.
@@ -18336,6 +18387,56 @@ fn collect_body_locator_callbacks(
         {
           let callback = dargs.get(1).map(crate::syntax::expr_to_input_form);
           found.push((var.clone(), callback));
+        }
+        for a in args {
+          walk(a, found);
+        }
+      }
+      Expr::List(items) => {
+        for it in items {
+          walk(it, found);
+        }
+      }
+      Expr::CompoundExpr(items) => {
+        for it in items {
+          walk(it, found);
+        }
+      }
+      _ => {}
+    }
+  }
+  let mut found = Vec::new();
+  walk(expr, &mut found);
+  found
+}
+
+/// Every `LocatorPane[Dynamic[var], graphic, range…]` drawn directly in a
+/// Manipulate's body: `(var, explicit range arg, graphic)`. Unlike the
+/// `Locator[…]` primitive (see `collect_body_locator_callbacks`), a
+/// `LocatorPane` is the pane itself rather than a marker placed inside one —
+/// its variable normally has its own row in the Specifications (e.g. a
+/// `SetterBar` of presets), so it is never hidden `ControlType -> None`
+/// state waiting to be promoted. It still needs a draggable stand-in control
+/// of its own, added alongside whatever row the Specifications already gave
+/// the variable — the same "two independent rows for one binding" pattern
+/// Wolfram itself uses for a coarse/fine preset pair on one variable.
+fn collect_body_locator_pane_vars(
+  expr: &Expr,
+) -> Vec<(String, Option<Expr>, Expr)> {
+  fn walk(expr: &Expr, found: &mut Vec<(String, Option<Expr>, Expr)>) {
+    match expr {
+      Expr::FunctionCall { name, args } => {
+        if name == "LocatorPane"
+          && args.len() >= 2
+          && let Expr::FunctionCall {
+            name: dname,
+            args: dargs,
+          } = &args[0]
+          && dname == "Dynamic"
+          && let Some(Expr::Identifier(var)) = dargs.first()
+          && !found.iter().any(|(n, _, _)| n == var)
+        {
+          found.push((var.clone(), args.get(2).cloned(), args[1].clone()));
         }
         for a in args {
           walk(a, found);
@@ -19492,17 +19593,66 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
 }
 
 /// Interpret an optional trailing `{{xmin, ymin}, {xmax, ymax}}` range
-/// argument, defaulting to the unit square when absent or malformed. Shared by
-/// the `LocatorPane`/`ClickPane` pane extractors.
-fn pane_range(arg: Option<&Expr>) -> ((f64, f64), (f64, f64)) {
-  match arg {
-    Some(Expr::List(corners)) if corners.len() == 2 => {
-      match (list2_f64(&corners[0]), list2_f64(&corners[1])) {
-        (Some(lo), Some(hi)) => (lo, hi),
-        _ => ((0.0, 0.0), (1.0, 1.0)),
+/// argument. When absent or malformed, Wolfram takes a `LocatorPane`'s (or
+/// `ClickPane`'s) coordinate system from the `PlotRange` of the graphic it
+/// wraps, so `graphic` is searched for the first one before giving up and
+/// falling back to the unit square. Shared by the `LocatorPane`/`ClickPane`
+/// pane extractors.
+fn pane_range(arg: Option<&Expr>, graphic: &Expr) -> ((f64, f64), (f64, f64)) {
+  if let Some(Expr::List(corners)) = arg
+    && corners.len() == 2
+    && let (Some(lo), Some(hi)) =
+      (list2_f64(&corners[0]), list2_f64(&corners[1]))
+  {
+    return (lo, hi);
+  }
+  find_plot_range(graphic).unwrap_or(((0.0, 0.0), (1.0, 1.0)))
+}
+
+/// The first `PlotRange -> {{xmin, xmax}, {ymin, ymax}}` option found
+/// anywhere inside `expr`, searched depth-first. Used to infer a pane's
+/// coordinate system from the plot it displays when nothing states it
+/// explicitly.
+fn find_plot_range(expr: &Expr) -> Option<((f64, f64), (f64, f64))> {
+  if let Expr::Rule {
+    pattern,
+    replacement,
+  } = expr
+    && let Expr::Identifier(key) = pattern.as_ref()
+    && key == "PlotRange"
+    && let Expr::List(axes) = replacement.as_ref()
+    && axes.len() == 2
+    && let (Some((x_min, x_max)), Some((y_min, y_max))) =
+      (list2_f64(&axes[0]), list2_f64(&axes[1]))
+  {
+    return Some(((x_min, y_min), (x_max, y_max)));
+  }
+  match expr {
+    Expr::FunctionCall { args, .. } => {
+      for a in args {
+        if let Some(range) = find_plot_range(a) {
+          return Some(range);
+        }
       }
+      None
     }
-    _ => ((0.0, 0.0), (1.0, 1.0)),
+    Expr::List(items) => {
+      for it in items {
+        if let Some(range) = find_plot_range(it) {
+          return Some(range);
+        }
+      }
+      None
+    }
+    Expr::CompoundExpr(items) => {
+      for it in items {
+        if let Some(range) = find_plot_range(it) {
+          return Some(range);
+        }
+      }
+      None
+    }
+    _ => None,
   }
 }
 
@@ -19533,7 +19683,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     pt => ("p".to_string(), Some(list2_f64(pt)?)),
   };
   let body_code = crate::syntax::expr_to_input_form(&args[1]);
-  let ((x_min, y_min), (x_max, y_max)) = pane_range(args.get(2));
+  let ((x_min, y_min), (x_max, y_max)) = pane_range(args.get(2), &args[1]);
   // Start the locator at the given point, else the range centre.
   let (x_initial, y_initial) = explicit_init
     .unwrap_or((f64::midpoint(x_min, x_max), f64::midpoint(y_min, y_max)));
@@ -19585,7 +19735,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
   // coordinate range in the middle.
   let func = args.last()?;
   let range_arg = if args.len() >= 3 { args.get(1) } else { None };
-  let ((x_min, y_min), (x_max, y_max)) = pane_range(range_arg);
+  let ((x_min, y_min), (x_max, y_max)) = pane_range(range_arg, &args[0]);
   // Bind the click position `pos` and show the handler applied to it; the body
   // re-evaluates `func[pos]` on every pad move.
   let func_code = crate::syntax::expr_to_input_form(func);

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -22624,4 +22624,75 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ 
       widget.error
     );
   }
+
+  #[test]
+  fn locator_pane_body_variable_gets_a_draggable_stand_in_beside_its_setter_bar()
+   {
+    // A Manipulate whose body is a bare `LocatorPane[Dynamic[var], graphic]`
+    // wrapping the whole picture (the Demonstrations "drag the marker on the
+    // picture" pattern): Wolfram lets the point be set either by dragging it
+    // directly on the graphic or, here, by one of two `SetterBar` presets
+    // the Specifications also give the same variable. This app has no raw
+    // canvas dragging — every Locator-style interaction becomes an X/Y
+    // slider pair instead — so without a synthesized stand-in row for the
+    // LocatorPane's own variable, the marker could only ever sit on one of
+    // the two presets, never anywhere else on the picture.
+    let code = "Manipulate[\
+      LocatorPane[Dynamic[mark], \
+        Graphics[{Blue, Disk[mark, .3]}, PlotRange -> {{-5, 5}, {-2, 2}}]], \
+      {{mark, {2, 0}, \"\"}, \
+       {{2, 0} -> \"east post\", {-2, 0} -> \"west post\"}, \
+       ControlType -> SetterBar}]";
+    let state = instantiate_stored_manipulate(code, "")
+      .expect("the LocatorPane Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+
+    let setter_bar = state
+      .controls
+      .iter()
+      .find(|c| {
+        c.name() == "mark"
+          && matches!(
+            c,
+            manipulate::ControlState::Discrete {
+              setter_bar: true,
+              ..
+            }
+          )
+      })
+      .expect("the SetterBar preset row must still be there");
+    if let manipulate::ControlState::Discrete { value_labels, .. } = setter_bar
+    {
+      assert_eq!(
+        value_labels,
+        &["east post".to_string(), "west post".to_string()]
+      );
+    }
+
+    let stand_in = state
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Slider2D {
+          name,
+          x_min,
+          x_max,
+          y_min,
+          y_max,
+          x,
+          y,
+          ..
+        } if name == "mark" => Some((*x_min, *x_max, *y_min, *y_max, *x, *y)),
+        _ => None,
+      })
+      .expect("a draggable stand-in row for `mark` must be added");
+    // Bounds come from the wrapped graphic's own `PlotRange` (LocatorPane
+    // gives none of its own); the initial position is the SetterBar's
+    // default choice, `{2, 0}`.
+    assert_eq!(stand_in, (-5.0, 5.0, -2.0, 2.0, 2.0, 0.0));
+  }
 }


### PR DESCRIPTION
## Summary

- Found while checking whether Woxi Studio fully supports the Wolfram Demonstration "How to Catch a Standing Wave" (downloaded via the Demonstrations Project's random-resource API). Its `Manipulate` wraps the whole body in `LocatorPane[Dynamic[pt], ...]`, with `pt` also given a `SetterBar` preset row in the Specifications.
- In real Wolfram, a `LocatorPane` wrapping a `Manipulate`'s body lets the point be dragged directly on the displayed graphic, independent of whatever other control the Specifications give the same variable. Woxi Studio has no raw canvas dragging, so this interaction was silently dropped — the variable could only ever be set through its other control (here, one single preset button), never explored freely.
- `extract_manipulate_spec` now detects a bare `LocatorPane[Dynamic[var], graphic]` in the body and adds a synthesized X/Y slider row for `var`, alongside whatever other row the Specifications already give it (the same "two independent rows, one binding" pattern Wolfram itself uses for a coarse/fine preset pair). The bounds come from the wrapped graphic's own `PlotRange` when no explicit range is given, matching Wolfram's own fallback behavior; a variable that is deliberately hidden (`ControlType -> None`, driven only through other controls) or already has its own Locator-style control is left alone.

## Test plan

- [x] Added `locator_pane_body_variable_gets_a_draggable_stand_in_beside_its_setter_bar` in `woxi-studio/src/main.rs`, covering a `LocatorPane` body variable that also has a `SetterBar` preset row.
- [x] Verified no regression against the two existing `LocatorPane`-in-body tests (`argand_diagram_manipulate_draws_its_locator_pane`, whose `ControlType -> None` variable must stay hidden, and `integer_grid_triangle_manipulate_draws_its_locators`, whose `DynamicModule`-local multi-point variable must not get a bogus single-point slider) and the `ClickPane` test.
- [x] `make test` — all 27,821 tests pass.
- [x] `make format`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE5dcqHoane3NcB332LwMz)_