### PR TITLE
Add PolyhedronData support for the triangular orthobicupola

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -637,7 +637,7 @@ PlotLabels,Option for labeling plot curves,✅,none,10.4,597
 Scale,Scales a graphics object,✅,pure,6.0,597
 Log10,Returns the base-10 logarithm of a number,✅,pure,7.0,598
 EndPackage,Ends a package and puts its context on $ContextPath so its exports become visible,✅,effectful,1.0,599
-PolyhedronData,Properties of named polyhedra (Platonic solids; the icosahedral and cubic Archimedean solids and their duals; and the rhombic hexecontahedron stellation),🚧,pure,6.0,601
+PolyhedronData,Properties of named polyhedra (Platonic solids; the icosahedral and cubic Archimedean solids and their duals; the rhombic hexecontahedron stellation; and the triangular orthobicupola),🚧,pure,6.0,601
 PolyhedronOperations`Truncate,Corner-cuts each Polygon face of a graphics expression to a ratio (default 3/10) of its edge length; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
 PolyhedronOperations`Stellate,Replaces each Polygon face of a graphics expression with a pyramid to a ratio (default 2) of the face's centroid distance; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
 Nearest,Find the nearest elements in a list to a given value (numbers/vectors by Euclidean distance; strings by edit distance) — DistanceFunction supplies another metric; empty or non-list data reports ::near1,✅,pure,6.0,602

--- a/src/functions/polyhedron_data.rs
+++ b/src/functions/polyhedron_data.rs
@@ -1306,6 +1306,44 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
       {\"Amphichiral\", \"Equilateral\", \"Isohedron\", \
       \"Zonohedron\"}",
   },
+  PolyhedronInfo {
+    name: "TriangularOrthobicupola",
+    vertex_count: 12,
+    edge_count: 24,
+    face_count: 14,
+    // Two triangular cupolas glued hexagon-to-hexagon without a twist
+    // (Johnson solid J27): 8 equilateral triangles (area Sqrt[3]/4 each)
+    // plus 6 unit squares.
+    volume: "5*Sqrt[2]/3",
+    surface_area: "6 + 2*Sqrt[3]",
+    // All 12 vertices lie on the unit sphere (a consequence of the cupola
+    // being half of a cuboctahedron, whose own circumradius equals its
+    // edge length), but the triangle and square faces sit at different
+    // distances from the center, so there is no single inscribed sphere.
+    circumradius: "1",
+    inradius: "Missing[\"NotApplicable\"]",
+    // Hexagonal ring at z = 0 (radius 1, the shared "equator" of the two
+    // cupolas) plus the two triangular cupola caps at z = +-Sqrt[2/3]
+    // (radius 1/Sqrt[3], unrotated relative to each other, which is what
+    // makes this the "ortho" rather than "gyro" bicupola). z is the C3
+    // symmetry axis. Verified against the edge (all 1), circumradius (all
+    // vertices at distance 1 from the origin), Volume, and SurfaceArea
+    // above by direct computation from these coordinates.
+    vertices_src: "{\
+      {1, 0, 0}, {1/2, Sqrt[3]/2, 0}, {-1/2, Sqrt[3]/2, 0}, \
+      {-1, 0, 0}, {-1/2, -Sqrt[3]/2, 0}, {1/2, -Sqrt[3]/2, 0}, \
+      {1/2, Sqrt[3]/6, Sqrt[2/3]}, {-1/2, Sqrt[3]/6, Sqrt[2/3]}, \
+      {0, -Sqrt[3]/3, Sqrt[2/3]}, {1/2, Sqrt[3]/6, -Sqrt[2/3]}, \
+      {-1/2, Sqrt[3]/6, -Sqrt[2/3]}, {0, -Sqrt[3]/3, -Sqrt[2/3]}}",
+    faces_src: "{\
+      {7, 1, 2}, {8, 3, 4}, {9, 5, 6}, \
+      {7, 2, 3, 8}, {8, 4, 5, 9}, {9, 6, 1, 7}, {7, 8, 9}, \
+      {10, 2, 1}, {11, 4, 3}, {12, 6, 5}, \
+      {11, 3, 2, 10}, {12, 5, 4, 11}, {10, 1, 6, 12}, {10, 12, 11}}",
+    classes_src: "\
+      {\"Amphichiral\", \"Convex\", \"Equilateral\", \"Johnson\", \
+      \"Nonuniform\", \"Rigid\", \"Simple\"}",
+  },
 ];
 
 fn find_polyhedron(name: &str) -> Option<&'static PolyhedronInfo> {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -21870,9 +21870,9 @@ mod manipulate {
       ManipulateControl::Discrete { name, values, .. } => {
         assert_eq!(name, "g");
         // The five Platonic solids, the Archimedean solids (and their
-        // duals) with icosahedral or cubic symmetry, and the rhombic
-        // hexecontahedron stellation.
-        assert_eq!(values.len(), 19, "every known solid");
+        // duals) with icosahedral or cubic symmetry, the rhombic
+        // hexecontahedron stellation, and the triangular orthobicupola.
+        assert_eq!(values.len(), 20, "every known solid");
         assert!(values.contains(&"\"Cube\"".to_string()));
         assert!(values.contains(&"\"TruncatedIcosahedron\"".to_string()));
       }

--- a/tests/interpreter_tests/polyhedron_data.rs
+++ b/tests/interpreter_tests/polyhedron_data.rs
@@ -379,8 +379,9 @@ mod polyhedron_data_tests {
        Icosidodecahedron, Octahedron, PentakisDodecahedron, \
        RhombicDodecahedron, RhombicHexecontahedron, \
        RhombicTriacontahedron, SmallRhombicosidodecahedron, \
-       SmallRhombicuboctahedron, Tetrahedron, TruncatedDodecahedron, \
-       TruncatedIcosahedron, TruncatedOctahedron, TruncatedTetrahedron}"
+       SmallRhombicuboctahedron, Tetrahedron, TriangularOrthobicupola, \
+       TruncatedDodecahedron, TruncatedIcosahedron, TruncatedOctahedron, \
+       TruncatedTetrahedron}"
     );
   }
 
@@ -706,6 +707,67 @@ mod polyhedron_data_tests {
       )
       .unwrap(),
       "True"
+    );
+  }
+
+  // Johnson solid J27: two triangular cupolas joined hexagon-to-hexagon
+  // without a twist. Unlike the Platonic/Archimedean/Catalan solids above,
+  // it is not face-transitive, so it has no inscribed sphere.
+  #[test]
+  fn polyhedron_data_triangular_orthobicupola() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "VertexCount"]"#)
+        .unwrap(),
+      "12"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "EdgeCount"]"#)
+        .unwrap(),
+      "24"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "FaceCount"]"#)
+        .unwrap(),
+      "14"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "Volume"]"#)
+        .unwrap(),
+      "(5*Sqrt[2])/3"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "SurfaceArea"]"#)
+        .unwrap(),
+      "6 + 2*Sqrt[3]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "Circumradius"]"#)
+        .unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["TriangularOrthobicupola", "Inradius"]"#)
+        .unwrap(),
+      "Missing[NotApplicable]"
+    );
+    // Every vertex lies on the unit circumsphere.
+    assert_eq!(
+      interpret(
+        r#"Union[Round[Norm /@
+             N[PolyhedronData["TriangularOrthobicupola",
+               "VertexCoordinates"]], 10^-10]]"#
+      )
+      .unwrap(),
+      "{1}"
+    );
+    // 8 triangular faces and 6 square faces.
+    assert_eq!(
+      interpret(
+        r#"Sort[Length /@
+             PolyhedronData["TriangularOrthobicupola", "FaceIndices"]]"#
+      )
+      .unwrap(),
+      "{3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4}"
     );
   }
 }


### PR DESCRIPTION
## Summary

- This scheduled routine fetched a random Wolfram Demonstration (`https://www.wolframcloud.com/obj/resourcesystem/api/1.0/RandomResourcePage?ResourceTypes=Demonstration` → ["Hexagonal Close Packing and Triangular Orthobicupola"](https://demonstrations.wolfram.com/HexagonalClosePackingAndTriangularOrthobicupola/)) and checked whether Woxi Studio fully supports its source `.nb` file.
- The demo's `Manipulate` calls `PolyhedronData["TriangularOrthobicupola", "VertexCoordinates"/"FaceIndices"]`, a Johnson solid (J27) that wasn't in the polyhedron table (`PolyhedronData::notent`), so the notebook's Input cell failed to evaluate.
- Adds `"TriangularOrthobicupola"` to the `PolyhedronData` table: exact vertex/face data derived from the "two triangular cupolas glued at their hexagonal face without a twist" construction, plus `Volume`, `SurfaceArea`, `Circumradius`, and `Classes`.
- The geometry was cross-checked by direct symbolic computation from the stored coordinates (not copied from the notebook, which is copyrighted): all 24 edges come out to length 1, all 12 vertices lie at distance 1 from the origin (circumradius), all faces are planar with consistent outward-facing normals, `Volume` simplifies to `(5*Sqrt[2])/3`, and `SurfaceArea` to `6 + 2*Sqrt[3]` — matching 8 unit-edge equilateral triangles plus 6 unit squares.
- Confirmed against the actual downloaded notebook: the demo's Input cell now evaluates successfully end-to-end through `woxi-studio`'s notebook test harness (0 errors, was previously an unevaluated `PolyhedronData::notent` error).

## Test plan

- [x] `cargo test --test interpreter_tests polyhedron_data` — 26 passed, including a new `polyhedron_data_triangular_orthobicupola` test (vertex/edge/face counts, `Volume`, `SurfaceArea`, `Circumradius`, `Inradius`, circumsphere check, face-type histogram)
- [x] Updated two pre-existing tests with hardcoded solid counts/lists (`polyhedron_data_all_lists_every_entity`, `graphics::manipulate::spec_discrete_from_expression`) to include the new solid
- [x] `make test` — full suite, 27844/27844 passed
- [x] `make format`
- [x] `cargo run -p woxi-studio --example test_notebook -- <downloaded .nb>` — the demonstration's Manipulate cell evaluates with `STATUS: OK`, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhziumUsfzMsPTghEqtqKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhziumUsfzMsPTghEqtqKr)_