### PR TITLE
Fix PlotLabel fraction grouping and ParametricPlot3D Show merging

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -9321,7 +9321,17 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
             && matches!(&rargs[0], Expr::Integer(1))
             && matches!(&rargs[1], Expr::Integer(d) if *d > 0)
           {
+            // `stacked_fraction_svg` joins its arguments with a literal
+            // `/`, not a vinculum, so a `Plus`/`Minus` numerator needs its
+            // own parens here — otherwise `1/2*(tau^2 - sigma^2)` prints as
+            // `-sigma^2 + tau^2/2` (only the last term divided) instead of
+            // `(-sigma^2 + tau^2)/2`.
             let num_markup = expr_to_svg_markup(&args[1]);
+            let num_markup = if is_additive_expr(&args[1]) {
+              format!("({num_markup})")
+            } else {
+              num_markup
+            };
             let den_markup = expr_to_svg_markup(&rargs[1]);
             let num_w = estimate_display_width(&args[1]);
             let den_w = estimate_display_width(&rargs[1]);

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -9779,8 +9779,34 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       Expr::List(complexes.into())
     };
+    // `ParametricPlot3D` draws axes and squats its box the same way
+    // `Plot3D` does (see the analogous block above), where a bare
+    // `Graphics3D` does neither: both defaults are spelled out so a
+    // surface shown inside another graphic — with `ParametricPlot3D`
+    // itself first in the `Show` — keeps the shape it was drawn with.
     let mut structure_args = vec![content];
     structure_args.extend(args[3..].iter().cloned());
+    let names = |opt: &str| {
+      structure_args.iter().any(|o| {
+        matches!(o, Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. }
+          if matches!(pattern.as_ref(), Expr::Identifier(n) if n == opt))
+      })
+    };
+    let (names_axes, names_ratios) = (names("Axes"), names("BoxRatios"));
+    if !names_axes {
+      structure_args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("Axes".to_string())),
+        replacement: Box::new(Expr::Identifier("True".to_string())),
+      });
+    }
+    if !names_ratios {
+      structure_args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("BoxRatios".to_string())),
+        replacement: Box::new(Expr::List(
+          vec![Expr::Integer(1), Expr::Integer(1), Expr::Real(Z_SCALE)].into(),
+        )),
+      });
+    }
     call("Graphics3D", structure_args)
   };
 

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -9688,6 +9688,102 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     gz_max - gz_min
   };
 
+  // ── Symbolic structure: Graphics3D[GraphicsComplex[points, {…}]] ──
+  // `Show` merges the *primitives* of the graphics it is given, so a
+  // surface that exists only as a rendering is dropped when it is shown
+  // together with a `Graphics3D`. Emitting the sampled surface in world
+  // coordinates — coloured by height, the way the standalone render
+  // colours it — lets `Show[ParametricPlot3D[…], Graphics3D[…]]` draw both.
+  let structure = {
+    let complexes: Vec<Expr> = all_surface_points
+      .iter()
+      .enumerate()
+      .map(|(surface_idx, sg)| {
+        let mut index_of: Vec<Vec<Option<usize>>> =
+          vec![vec![None; GRID_N + 1]; GRID_N + 1];
+        let mut point_exprs: Vec<Expr> = Vec::new();
+        for (i, row) in sg.iter().enumerate() {
+          for (j, p) in row.iter().enumerate() {
+            if let Some((x, y, z)) = p {
+              index_of[i][j] = Some(point_exprs.len());
+              point_exprs.push(Expr::List(
+                vec![Expr::Real(*x), Expr::Real(*y), Expr::Real(*z)].into(),
+              ));
+            }
+          }
+        }
+        let mut content: Vec<Expr> = Vec::new();
+        if !matches!(mesh_mode, MeshMode::All) {
+          content.push(call0("EdgeForm"));
+        }
+        for i in 0..GRID_N {
+          for j in 0..GRID_N {
+            let (Some(a), Some(b), Some(c), Some(d)) = (
+              index_of[i][j],
+              index_of[i + 1][j],
+              index_of[i + 1][j + 1],
+              index_of[i][j + 1],
+            ) else {
+              continue;
+            };
+            let avg_z =
+              [sg[i][j], sg[i + 1][j], sg[i + 1][j + 1], sg[i][j + 1]]
+                .iter()
+                .filter_map(|p| p.map(|(_, _, z)| z))
+                .sum::<f64>()
+                / 4.0;
+            let avg_z_norm = (avg_z - gz_min) / rz;
+            let default_color = height_color(avg_z_norm);
+            let (cr, cg, cb) =
+              match plot_style_for_surface(&plot_styles, surface_idx) {
+                Some(style) => style.color.unwrap_or(default_color),
+                None => default_color,
+              };
+            content.push(Expr::List(
+              vec![
+                call(
+                  "RGBColor",
+                  vec![
+                    Expr::Real(cr as f64 / 255.0),
+                    Expr::Real(cg as f64 / 255.0),
+                    Expr::Real(cb as f64 / 255.0),
+                  ],
+                ),
+                call1(
+                  "Polygon",
+                  Expr::List(
+                    [a, b, c, d]
+                      .iter()
+                      .map(|&k| Expr::Integer(k as i128 + 1))
+                      .collect::<Vec<_>>()
+                      .into(),
+                  ),
+                ),
+              ]
+              .into(),
+            ));
+          }
+        }
+        Expr::FunctionCall {
+          name: "GraphicsComplex".to_string(),
+          args: vec![
+            Expr::List(point_exprs.into()),
+            Expr::List(content.into()),
+          ]
+          .into(),
+        }
+      })
+      .collect();
+    let content = if complexes.len() == 1 {
+      complexes.into_iter().next().expect("one complex")
+    } else {
+      Expr::List(complexes.into())
+    };
+    let mut structure_args = vec![content];
+    structure_args.extend(args[3..].iter().cloned());
+    call("Graphics3D", structure_args)
+  };
+
   // Phase 2: Build triangles
   let mut all_triangles: Vec<Triangle> = Vec::new();
 
@@ -9805,5 +9901,5 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A `PlotLabel` sets a title above the finished picture.
   let svg = with_plot_label(svg, args, svg_width, svg_height);
 
-  Ok(crate::graphics3d_result(svg))
+  Ok(crate::graphics3d_result_with_structure(svg, structure))
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -27238,3 +27238,42 @@ fn manipulate_module_which_affine_prolog_checkbox_and_traditional_plot_label() {
     "Epilog's \"A\" label must not draw when labels is False: {without_label}"
   );
 }
+
+#[test]
+fn test_plot_label_fraction_of_difference_keeps_numerator_grouped() {
+  // Regression: `expr_to_svg_markup`'s `Times[Rational[1, d], expr]` case
+  // joins the numerator and denominator with a literal `/`, not a real
+  // vinculum, so an additive numerator needs its own parens — otherwise
+  // `1/2 (p^2 - r^2)` rendered as `p^2 - r^2/2` (only the last term
+  // divided) instead of `(p^2 - r^2)/2`.
+  clear_state();
+  let svg = export_svg(
+    "Graphics[{Point[{0, 0}]}, PlotLabel -> Row[{q == 1/2 (p^2 - r^2)}]]",
+  );
+  assert!(
+    svg.contains(")/2"),
+    "expected the whole numerator grouped in parens before the /2: {svg}"
+  );
+  assert!(
+    !svg.contains("font-size=\"70%\">2</tspan>/2"),
+    "the /2 must not attach directly to the last squared term alone: {svg}"
+  );
+}
+
+#[test]
+fn test_show_merges_parametric_plot3d_surface_with_graphics3d() {
+  // Regression: ParametricPlot3D returned an opaquely pre-rendered
+  // Graphics3D with no symbolic `structure` (unlike Plot3D/ListPlot3D,
+  // which expose a GraphicsComplex structure for exactly this purpose), so
+  // `Show[Graphics3D[...], ParametricPlot3D[...]]` silently dropped the
+  // parametric surface and kept only the raw Graphics3D primitives.
+  clear_state();
+  let svg = export_svg(
+    "Show[Graphics3D[{Point[{0, 0, 0}]}], \
+     ParametricPlot3D[{u, v, 0}, {u, -1, 1}, {v, -1, 1}]]",
+  );
+  assert!(
+    svg.contains("<polygon") || svg.contains("<path"),
+    "expected the parametric surface's geometry in the merged render: {svg}"
+  );
+}

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -27277,3 +27277,31 @@ fn test_show_merges_parametric_plot3d_surface_with_graphics3d() {
     "expected the parametric surface's geometry in the merged render: {svg}"
   );
 }
+
+#[test]
+fn test_show_parametric_plot3d_first_keeps_default_axes_and_box_ratios() {
+  // Regression: the `structure` block that lets ParametricPlot3D merge
+  // into `Show` (previous test) initially left out the `Axes -> True` /
+  // `BoxRatios -> {1, 1, Z_SCALE}` defaults that the analogous Plot3D
+  // block fills in. `Show` takes its merged options from the *first*
+  // graphic's own structure, so with ParametricPlot3D listed first the
+  // merged picture would silently lose axes and get a different aspect
+  // ratio than ParametricPlot3D's own standalone default.
+  clear_state();
+  let expr = woxi::interpret_to_expr(
+    "Show[ParametricPlot3D[{u, v, 0}, {u, -1, 1}, {v, -1, 1}], \
+     Graphics3D[{Point[{0, 0, 0}]}]]",
+  )
+  .unwrap();
+  let debug = format!("{expr:?}");
+  assert!(
+    debug.contains(
+      r#"pattern: Identifier("Axes"), replacement: Identifier("True")"#
+    ),
+    "expected the merged structure to default to Axes -> True: {debug}"
+  );
+  assert!(
+    debug.contains(r#"pattern: Identifier("BoxRatios")"#),
+    "expected the merged structure to default BoxRatios: {debug}"
+  );
+}


### PR DESCRIPTION
## Summary

Found while checking Woxi Studio's compatibility with a downloaded Wolfram Demonstrations Project notebook.

- **`expr_to_svg_markup`'s `Times[Rational[1, d], Plus[...]]` case** joined the numerator and denominator with a literal `/` but never parenthesized an additive numerator. A `PlotLabel`/`Row` expression like `1/2 (a^2 - b^2)` rendered as `a^2 - b^2/2` (only the last addend divided by 2) instead of `(a^2 - b^2)/2`.
- **`ParametricPlot3D`** returned an opaquely pre-rendered `Graphics3D` with no symbolic `structure` field, unlike `Plot3D`/`ListPlot3D`, which already expose a `GraphicsComplex`-based structure for exactly this reason. As a result, `Show[Graphics3D[...], ParametricPlot3D[...]]` silently dropped the parametric surface, keeping only the other graphic's primitives. Fixed by sampling the surface into a world-coordinate `GraphicsComplex` (mirroring `Plot3D`'s existing structure-building code) and returning it via `graphics3d_result_with_structure`.

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/graphics.rs` for both bugs (using original, non-verbatim test expressions)
- [x] `make test` passes (27887/27887)
- [x] `make format` run
- [x] Manually verified against the demonstration notebook that triggered these bugs: the `PlotLabel` now shows correctly grouped fractions and the parametric surface now renders when combined with other `Graphics3D` primitives via `Show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZUNb9ToWp9kV2M1oXP8pp)_