### PR TITLE
Support a bare-number PlotRange in 2D plots and Graphics

### DIFF
--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -7929,6 +7929,8 @@ pub(crate) fn parse_style_directives(value: &Expr) -> Option<SeriesStyle> {
 ///
 /// Supported forms:
 /// - `All` / `Automatic` / `Full` → (None, None)
+/// - `r` (a bare number) → (Some((-r, r)), Some((-r, r))) — "r in all
+///   directions from the origin", equivalent to `{{-r, r}, {-r, r}}`
 /// - `{ymin, ymax}` → (None, Some((ymin, ymax)))
 /// - `{{xmin, xmax}, {ymin, ymax}}` → (Some(x), Some(y))
 /// - `{All, {ymin, ymax}}` / `{{xmin,xmax}, All}` → only the specified axis
@@ -7942,6 +7944,14 @@ pub(crate) fn parse_plot_range(
   if matches!(&val, Expr::Identifier(s) if s == "All" || s == "Automatic" || s == "Full")
   {
     return (None, None);
+  }
+
+  // A bare positive number `r` sets a square window centered at the
+  // origin on both axes.
+  if let Some(r) = try_eval_to_f64(&val)
+    && r > 0.0
+  {
+    return (Some((-r, r)), Some((-r, r)));
   }
 
   let parse_pair = |e: &Expr| -> Option<(f64, f64)> {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1743,6 +1743,33 @@ mod graphics {
       ));
     }
 
+    // `PlotRange -> r` (a bare number) means "r in all directions from the
+    // origin", equivalent to `{{-r, r}, {-r, r}}` — found via a
+    // Demonstration's polar-curve viewer, whose "zoom" slider shrinks the
+    // window by feeding a smaller number into a plain `PlotRange -> n`.
+    // `Graphics[…, PlotRange -> n]` alone is already covered by
+    // `test_plot_range_single_number` in miscellaneous_tests; this checks
+    // the same parsing reaches `PolarPlot`, which shares it.
+    #[test]
+    fn plot_range_scalar_bounds_a_polar_plot_on_both_axes() {
+      let tick_labels = |code: &str| -> Vec<f64> {
+        export_svg(code)
+          .split("<text ")
+          .skip(1)
+          .filter_map(|t| t.split_once('>'))
+          .filter_map(|(_, r)| r.split_once("</text>"))
+          .filter_map(|(v, _)| v.trim().parse::<f64>().ok())
+          .collect()
+      };
+      let ticks =
+        tick_labels("PolarPlot[Cos[t], {t, 0, 2 Pi}, PlotRange -> 20]");
+      assert!(
+        ticks.iter().any(|&v| v >= 15.0),
+        "an explicit scalar range must reach out to it on the x axis too, \
+         ticks: {ticks:?}"
+      );
+    }
+
     // `PlotRange -> All` shows every sampled value. The automatic range drops
     // extreme values as outliers, which for a steep curve cut the top off and
     // let it run out of the frame.

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -8560,6 +8560,88 @@ Cell[BoxData[
     }
   }
 
+  /// A polar-curve viewer Demonstration downloaded the same way (a bare
+  /// widget dump, no Input cell): its body reassigns a control variable
+  /// with `If[…, var = …]` before the plot that reads it, and its "zoom"
+  /// slider drives `PlotRange -> n - zoom$$` — a bare number, not a pair,
+  /// which has to frame the window `{-n, n}` square on *both* axes rather
+  /// than fall back to the automatic (and here wildly varying) data range.
+  #[test]
+  fn polar_curve_dump_with_a_zoom_slider_opens_live() {
+    let nb_src = r##"Notebook[{
+Cell[BoxData[
+ DynamicModuleBox[{$CellContext`b$$ = -2., $CellContext`c$$ = 5.,
+   $CellContext`zoom$$ = 0.},
+  DynamicBox[Manipulate`ManipulateBoxes[
+   1, StandardForm,
+   "Variables" :> {$CellContext`b$$ = -2., $CellContext`c$$ = 5.,
+     $CellContext`zoom$$ = 0.},
+   "Body" :> (If[$CellContext`b$$ == 0, $CellContext`b$$ = 0.001];
+    PolarPlot[($CellContext`c$$^$CellContext`b$$
+        Cos[$CellContext`b$$ $CellContext`\[Phi]])^(1/$CellContext`b$$), \
+{$CellContext`\[Phi], -2 Pi, 2 Pi},
+     PlotRange -> 50 - $CellContext`zoom$$, AspectRatio -> 1]),
+   "Specifications" :> {{{$CellContext`b$$, -2.}, -8, 8,
+      Appearance -> "Labeled"}, {{$CellContext`c$$, 5.}, 0.1, 50,
+      Appearance -> "Labeled"}, {{$CellContext`zoom$$, 0.}, 0, 45,
+      Appearance -> "Labeled"}},
+   "Options" :> {}],
+   DynamicModuleValues:>{}]]], "Output"]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let mut widget =
+      editors.into_iter().find_map(|e| e.manipulate_state).expect(
+        "a standalone widget dump with no Input cell must still \
+         instantiate on load",
+      );
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the polar curve must render at its initial (nonzero) b$$"
+    );
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous { name: b, .. },
+        manipulate::ControlState::Continuous { name: c, .. },
+        manipulate::ControlState::Continuous {
+          name: zoom,
+          min: zoom_min,
+          max: zoom_max,
+          current: zoom_now,
+          ..
+        },
+      ] => {
+        assert_eq!(
+          (b.as_str(), c.as_str(), zoom.as_str()),
+          ("b$$", "c$$", "zoom$$")
+        );
+        assert_eq!((*zoom_min, *zoom_max, *zoom_now), (0.0, 45.0, 0.0));
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    // Dragging zoom$$ to its max (45) shrinks the `PlotRange -> 50 - zoom$$`
+    // window down to a 5-wide square; re-rendering must not error out just
+    // because the window got tight.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut widget.controls[2]
+    {
+      *current = 45.0;
+    }
+    widget.reevaluate();
+    assert!(
+      widget.error.is_none(),
+      "re-render at max zoom failed: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some());
+  }
+
   /// A Demonstration whose `Initialization :> (Get["HypothesisTesting`"];)`
   /// loads the legacy `Statistics`HypothesisTests`` compatibility package
   /// and whose body extracts a named property with


### PR DESCRIPTION
## Summary

- Found via a random Wolfram Demonstration (a polar-curve viewer) whose "zoom" slider drives `PlotRange -> n - zoom`: a bare-number `PlotRange` was silently ignored by `parse_plot_range` (only `All`/`Automatic`/`Full` and list forms were handled), so the plot fell back to an automatic, data-driven range instead of the documented `{{-n, n}, {-n, n}}` square window centered on the origin — the zoom slider had no visible effect.
- `parse_plot_range` is the single shared parser behind `Graphics`, `Plot`, `ParametricPlot`, and `PolarPlot`, so the fix applies uniformly across all of them.
- Confirmed against the official Wolfram documentation: "`PlotRange->1` means 1 in all directions from the origin, and is equivalent to `PlotRange->{{-1,1},{-1,1}}`."
- Also fixes a previously-failing pre-existing test (`test_plot_range_single_number` in `tests/miscellaneous_tests/high_level_functions.rs`) that already asserted this exact behavior for `Graphics[]`.

## Test plan

- [x] Added `plot_range_scalar_bounds_a_polar_plot_on_both_axes` in `tests/interpreter_tests/graphics.rs`, verifying a scalar `PlotRange` reaches `PolarPlot`.
- [x] Added `polar_curve_dump_with_a_zoom_slider_opens_live` in `woxi-studio/src/main.rs`, an end-to-end regression for a Demonstration-style notebook dump (no Input cell) combining an `If[…, var = …]` body mutation with a `PlotRange -> n - zoom$$` slider.
- [x] `make test` — 27895 tests passed.
- [x] `make test-studio` — 208 tests passed.
- [x] `make format` — no changes needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UiQoV9Fxq5vfmGP8s7Rw6D)_