### PR TITLE
Support \[Piecewise]{{...}} special-character syntax

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3655,6 +3655,18 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         args: vec![operand].into(),
       }
     }
+    // `\[Piecewise]{{v1,c1},{v2,c2},…}` is the special-character input form
+    // for `Piecewise[{{v1,c1},{v2,c2},…}]` (the way the front end writes the
+    // piecewise brace notation). It binds to the following factor like a
+    // prefix function application.
+    Rule::PiecewisePrefix => {
+      let inners: Vec<_> = pair.into_inner().collect();
+      let operand = pair_to_expr(inners[1].clone());
+      Expr::FunctionCall {
+        name: "Piecewise".to_string(),
+        args: vec![operand].into(),
+      }
+    }
     Rule::Increment => {
       // x++ -> Increment[x]; chained `x++++` -> Increment[Increment[x]].
       // Grammar emits one base pair followed by N `IncrementOp` pairs

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -173,7 +173,7 @@ LetterlikeSymbolChar = _{
 // handling in notebook.rs and the glyph list in graphics.rs.
 BigOperatorChar = _{ "\u{2211}" | "\u{220F}" }
 
-NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]" | "\\[Rule]" | "\\[RuleDelayed]" | "\\[Equal]" | "\\[NotEqual]" | "\\[LessEqual]" | "\\[GreaterEqual]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" | LetterlikeSymbolChar | BigOperatorChar }
+NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Piecewise]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]" | "\\[Rule]" | "\\[RuleDelayed]" | "\\[Equal]" | "\\[NotEqual]" | "\\[LessEqual]" | "\\[GreaterEqual]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" | LetterlikeSymbolChar | BigOperatorChar }
 // Adjacent `\[Name]` segments (or named char + identifier chars)
 // concatenate into a single identifier — `\[CapitalGamma]\[Beta]` → `Γβ`,
 // `\[Angle]XYZ` → `∠XYZ`, `i\[Ellipsis]j` (when `i` then `\[Ellipsis]j`
@@ -636,6 +636,7 @@ Term = _{
   | ImplicitTimes
   | RadicalPrefix
   | DifferentialPrefix
+  | PiecewisePrefix
   | Unset
   | ApplyToOp
   | AddTo
@@ -684,6 +685,12 @@ RadicalPrefix = { RadicalOp ~ SimpleTerm ~ PartIndexSuffix? ~ ImplicitPowerSuffi
 // the prefix has to be tried before `Identifier` or `ⅆarea` reads as one name.
 DifferentialOp = { "\\[DifferentialD]" | "\u{2146}" | "\u{F74C}" }
 DifferentialPrefix = { DifferentialOp ~ SimpleTerm ~ PartIndexSuffix? ~ ImplicitPowerSuffix? }
+// `\[Piecewise]{{v1,c1},{v2,c2},…}` is the special-character input form for
+// `Piecewise[{{v1,c1},{v2,c2},…}]` — the notation front ends use for the
+// piecewise brace notebooks reconstruct from a `GridBox`. It binds like a
+// prefix function application to the following factor (normally a list).
+PiecewiseOp = { "\\[Piecewise]" }
+PiecewisePrefix = { PiecewiseOp ~ SimpleTerm }
 PrefixApplySimple = { (FunctionCall | Identifier) ~ "@" ~ SimpleTerm }
 SimpleTerm = _{
   // Increment/Decrement come first so a postfix `++` binds to its operand
@@ -693,6 +700,7 @@ SimpleTerm = _{
   | Decrement
   | RadicalPrefix
   | DifferentialPrefix
+  | PiecewisePrefix
   | UnsignedNumericValue
   | PrefixApplySimple
   | FunctionCall
@@ -715,6 +723,7 @@ SimpleTerm = _{
 TermNoImplicit = _{
     FunctionCallExtended
   | ImplicitTimes
+  | PiecewisePrefix
   | Unset
   | ApplyToOp
   | AddTo

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -11140,6 +11140,42 @@ mod radical_prefix_operators {
   }
 }
 
+// `\[Piecewise]{{v1,c1},{v2,c2},…}` is the special-character input form for
+// `Piecewise[{{v1,c1},{v2,c2},…}]` that notebooks reconstruct from a
+// `GridBox` for the piecewise brace notation. Regression: a downloaded
+// Wolfram Demonstration ("Pulse Fourier Approximation") defines a function
+// body this way, and it used to parse as the bare symbol `Piecewise`
+// implicitly multiplied by the following list — silently dropping the
+// whole piecewise definition — instead of a `Piecewise[...]` call.
+mod piecewise_prefix_operator {
+  use super::*;
+
+  #[test]
+  fn piecewise_prefix_parses_as_a_function_call() {
+    assert_eq!(
+      interpret(r"\[Piecewise]{{1, x < 0}, {2, True}}").unwrap(),
+      "Piecewise[{{1, x < 0}}, 2]"
+    );
+    assert_eq!(
+      interpret(r"\[Piecewise]{{1, 0 < 1}, {2, True}}").unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret(r"\[Piecewise]{{1, 5 < 1}, {2, True}}").unwrap(),
+      "2"
+    );
+  }
+
+  #[test]
+  fn piecewise_prefix_works_in_a_function_definition() {
+    assert_eq!(
+      interpret(r"f[t_] := \[Piecewise]{{1, t < 1}, {2, True}}; {f[0], f[5]}")
+        .unwrap(),
+      "{1, 2}"
+    );
+  }
+}
+
 // An applied anonymous function may carry `/.` / `//.`, which replace in the
 // *result* of the application. Regression: `f & [x] /. rules` did not parse.
 mod replace_after_applied_anonymous_function {


### PR DESCRIPTION
## Summary
- Checked Woxi Studio against a real Wolfram Demonstration notebook downloaded from `demonstrations.wolfram.com` ("Pulse Fourier Approximation")
- Its `Manipulate` body defines a function via `x0[t_,τ_] := \[Piecewise]{{...}}` — the special-character form front ends use to write the piecewise brace notation
- Woxi's grammar had no rule for this prefix form, so `\[Piecewise]` parsed as the bare symbol `Piecewise` and got implicitly multiplied by the following list, silently dropping the whole definition — which meant only one of the two plotted curves rendered in the notebook's `Manipulate` widget (the piecewise reference curve silently vanished)
- Added `PiecewisePrefix` as a prefix-application grammar rule alongside the existing `\[Sqrt]`/`\[CubeRoot]` radical and `\[DifferentialD]` prefixes, and excluded `\[Piecewise]` from the generic named-character identifier match so it can't be swallowed as a bare symbol first

## Test plan
- [x] Added regression tests in `tests/interpreter_tests/syntax.rs` (`piecewise_prefix_operator` module) covering direct evaluation and use inside a function definition
- [x] `cargo nextest run` — all 27,902 tests pass
- [x] `make format`
- [x] Verified with the downloaded notebook via `woxi-studio`'s `dump_manipulate`/`rasterize_svg` example harnesses: both curves (the Fourier approximation and the reference pulse train) now render correctly in the `Manipulate` widget's SVG output, where previously only one did

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0179hcQuWMAsabRgadoTkmxH)_