### PR TITLE
Let Evaluate[...] escape the hold on Module/Block/With's local-var spec

### DIFF
--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -3,12 +3,32 @@ use super::*;
 
 /// Report a `With`/`Module`/`Block` whose local variable specification is not
 /// a List (`With[y, 3]`), and hand back the unevaluated call like Wolfram.
-fn non_list_local_spec(head: &str, args: &[Expr]) -> Expr {
+fn non_list_local_spec(head: &str, args: &[Expr], spec: &Expr) -> Expr {
   crate::emit_message(&format!(
     "{head}::lvlist: Local variable specification {} is not a List.",
-    crate::syntax::expr_to_string(&args[0])
+    crate::syntax::expr_to_string(spec)
   ));
   unevaluated(head, args)
+}
+
+/// `Evaluate[…]` escapes any surrounding `Hold` attribute, including the
+/// local-variable-specification argument of `Module`/`Block`/`With` (which
+/// is otherwise held unevaluated like the body). `Block[Evaluate[{f, g}],
+/// body]` is a common Wolfram Demonstrations idiom: it substitutes the
+/// *current values* of already-bound control variables — e.g. `f` holding
+/// `Sin` — before localizing those values' own symbols, which is what lets
+/// the body's `HoldForm` show an application like `Sin[…]` without
+/// simplifying it. Without unwrapping `Evaluate` here, that spec is passed
+/// through literally and rejected as "not a List".
+fn resolve_var_spec(vars_expr: &Expr) -> Result<Expr, InterpreterError> {
+  match vars_expr {
+    Expr::FunctionCall { name, args }
+      if name == "Evaluate" && args.len() == 1 =>
+    {
+      evaluate_expr_to_expr(&args[0])
+    }
+    _ => Ok(vars_expr.clone()),
+  }
 }
 
 /// One local of a scoping construct: the symbol it binds, its initializer
@@ -150,17 +170,18 @@ pub fn module_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let vars_expr = &args[0];
   let body_expr = &args[1];
+  let resolved_vars = resolve_var_spec(vars_expr)?;
 
   // Parse variable declarations from the first argument (should be a List)
-  let local_vars = match vars_expr {
+  let local_vars = match &resolved_vars {
     Expr::List(items) => match parse_local_vars(items, false) {
       Ok(vars) => vars,
       Err(err) => {
-        err.emit("Module", vars_expr);
+        err.emit("Module", &resolved_vars);
         return Ok(unevaluated("Module", args));
       }
     },
-    _ => return Ok(non_list_local_spec("Module", args)),
+    _ => return Ok(non_list_local_spec("Module", args, &resolved_vars)),
   };
 
   // Module scopes lexically: each local is renamed to a fresh var$n
@@ -232,17 +253,18 @@ pub fn block_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let vars_expr = &args[0];
   let body_expr = &args[1];
+  let resolved_vars = resolve_var_spec(vars_expr)?;
 
   // Parse variable declarations (same as Module)
-  let local_vars = match vars_expr {
+  let local_vars = match &resolved_vars {
     Expr::List(items) => match parse_local_vars(items, false) {
       Ok(vars) => vars,
       Err(err) => {
-        err.emit("Block", vars_expr);
+        err.emit("Block", &resolved_vars);
         return Ok(unevaluated("Block", args));
       }
     },
-    _ => return Ok(non_list_local_spec("Block", args)),
+    _ => return Ok(non_list_local_spec("Block", args, &resolved_vars)),
   };
 
   // Take every value each local stands for and set up the new ones.
@@ -1110,14 +1132,15 @@ pub fn with_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let vars_expr = &args[0];
   let body_expr = &args[1];
+  let resolved_vars = resolve_var_spec(vars_expr)?;
 
   // Parse variable declarations from the first argument (should be a List)
-  let bindings: Vec<(String, Expr)> = match vars_expr {
+  let bindings: Vec<(String, Expr)> = match &resolved_vars {
     Expr::List(items) => {
       let locals = match parse_local_vars(items, true) {
         Ok(vars) => vars,
         Err(err) => {
-          err.emit("With", vars_expr);
+          err.emit("With", &resolved_vars);
           return Ok(unevaluated("With", args));
         }
       };
@@ -1134,7 +1157,7 @@ pub fn with_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       vars
     }
-    _ => return Ok(non_list_local_spec("With", args)),
+    _ => return Ok(non_list_local_spec("With", args, &resolved_vars)),
   };
 
   // Substitute all bindings into the body simultaneously

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2250,6 +2250,59 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_evaluate_escapes_hold_in_block_var_spec() {
+    // `Evaluate[…]` escapes any surrounding Hold attribute, including the
+    // held local-variable-specification argument of Block/Module/With.
+    // `Block[Evaluate[{f, g}], …]` — a Wolfram Demonstrations idiom for
+    // localizing whichever built-in a control variable currently holds —
+    // must see the already-substituted list `{Sin, ArcSin}`, not the
+    // literal, un-evaluated `Evaluate[{f, g}]` expression.
+    clear_state();
+    interpret("f = Sin; g = ArcSin;").unwrap();
+    // Localizing Sin/ArcSin themselves strips their evaluation rules, so
+    // the application inside stays literal — this is what lets a
+    // Demonstration's caption show the un-simplified function call. The
+    // coefficients keep `g[…]`'s argument from directly nesting inside
+    // `f[…]`, which is the shape this idiom is actually used for.
+    assert_eq!(
+      interpret("Block[Evaluate[{f, g}], HoldForm @@ {f[3 g[2 x]]}]").unwrap(),
+      "HoldForm[Sin[3*ArcSin[2*x]]]"
+    );
+    // Outside the Block, Sin/ArcSin evaluate normally again (no special
+    // rule fires here, so the application just stays put either way — the
+    // point is that no error or stray substitution leaks out of the Block).
+    assert_eq!(
+      interpret("Sin[3 ArcSin[2 x]]").unwrap(),
+      "Sin[3*ArcSin[2*x]]"
+    );
+  }
+
+  #[test]
+  fn test_evaluate_escapes_hold_in_module_and_with_var_spec() {
+    // Same Evaluate-escapes-Hold rule for Module and With: the spec list
+    // is computed from other bindings before Module/With's own local-var
+    // parsing runs, rather than being handed the literal `Evaluate[…]`
+    // wrapper and rejected as "not a List".
+    clear_state();
+    // A variable holding the *name* of the symbol to localize (a bare
+    // symbol spec, which only Module and Block allow).
+    interpret("localName = counter;").unwrap();
+    assert_eq!(
+      interpret("Module[Evaluate[{localName}], counter = 10; counter]")
+        .unwrap(),
+      "10"
+    );
+    clear_state();
+    // A variable holding a whole `symbol -> value` binding (With requires
+    // every local to have a value).
+    interpret("binding = pivot -> 9;").unwrap();
+    assert_eq!(
+      interpret("With[Evaluate[{binding}], pivot + 1]").unwrap(),
+      "10"
+    );
+  }
+
+  #[test]
   fn test_condition_in_module_with_expression() {
     // Condition guard with non-trivial expression in Module
     clear_state();

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -22987,6 +22987,169 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 30, $CellContext`s$$ = 5}, \"
     );
   }
 
+  /// A randomly-sampled Wolfram Demonstrations Project notebook ("Algebraic
+  /// Values of Trigonometric Functions of Inverse Trigonometric Functions")
+  /// shows an equation whose left side is a chosen trig function applied to
+  /// a scaled inverse-trig function, and whose right side is that same
+  /// expression algebraically simplified. Two popups pick the outer and
+  /// inner function, two sliders set the integer scale factors, and a
+  /// checkbox toggles the display width. Independently written, not copied
+  /// from the original: this version uses different function choices
+  /// (`Cos`/`ArcSin` rather than the original's `Sin`/`ArcSin` defaults,
+  /// with a smaller three-entry menu), different variable names, a single
+  /// flat `Grid` row instead of the original's nested 3x3 layout, and
+  /// different ranges, defaults and labels throughout.
+  ///
+  /// The construct worth pinning down is `Block[Evaluate[{trig, arcfn}],
+  /// HoldForm @@ {trig[coefA arcfn[coefB y]]}]`: the control variables
+  /// `trig`/`arcfn` already hold the actual `Cos`/`ArcSin` symbols by the
+  /// time the body runs, and `Evaluate[…]` forces that substitution through
+  /// `Block`'s hold *before* `Block` localizes those very symbols — which
+  /// is what keeps the left side of the equation showing the un-simplified
+  /// application (via `HoldForm`) while `Quiet[Factor[TrigExpand[…]]]`
+  /// still fully simplifies the identical expression on the right.
+  #[test]
+  fn demonstration_trig_inverse_identity_manipulate_shows_equation() {
+    let code = r#"Manipulate[
+      Grid[{{
+        Pane[
+          Text[TraditionalForm[
+            Block[Evaluate[{trig, arcfn}],
+              HoldForm @@ {trig[coefA arcfn[coefB y]]}] ==
+            Quiet[Factor[TrigExpand[trig[coefA arcfn[coefB y]]]]]
+          ]],
+          {480, If[wide, 350, Automatic]},
+          Alignment -> {Left, Top}
+        ]
+      }}],
+      {{trig, Cos, "outer function"}, {Sin, Cos, Tan}},
+      {{arcfn, ArcSin, "inner function"}, {ArcSin, ArcCos, ArcTan}},
+      {{coefA, 2, "outer scale"}, -15, 15, 1},
+      {{coefB, 3, "inner scale"}, -15, 15, 1},
+      {{wide, True, "wide layout"}, {True, False}}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "two labeled popups, two labeled sliders, and a checkbox should build a widget",
+    );
+
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name: trig_name,
+          values: trig_values,
+          current_index: trig_idx,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: arcfn_name,
+          values: arcfn_values,
+          current_index: arcfn_idx,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: coef_a_name,
+          min: coef_a_min,
+          max: coef_a_max,
+          current: coef_a_now,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: coef_b_name,
+          min: coef_b_min,
+          max: coef_b_max,
+          current: coef_b_now,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: wide_name,
+          values: wide_values,
+          current_index: wide_idx,
+          ..
+        },
+      ] => {
+        assert_eq!(trig_name.as_str(), "trig");
+        assert_eq!(trig_values.as_slice(), ["Sin", "Cos", "Tan"]);
+        assert_eq!(*trig_idx, 1, "default outer function is Cos");
+        assert_eq!(arcfn_name.as_str(), "arcfn");
+        assert_eq!(arcfn_values.as_slice(), ["ArcSin", "ArcCos", "ArcTan"]);
+        assert_eq!(*arcfn_idx, 0, "default inner function is ArcSin");
+        assert_eq!(coef_a_name.as_str(), "coefA");
+        assert_eq!(*coef_a_min, -15.0);
+        assert_eq!(*coef_a_max, 15.0);
+        assert_eq!(*coef_a_now, 2.0);
+        assert_eq!(coef_b_name.as_str(), "coefB");
+        assert_eq!(*coef_b_min, -15.0);
+        assert_eq!(*coef_b_max, 15.0);
+        assert_eq!(*coef_b_now, 3.0);
+        assert_eq!(wide_name.as_str(), "wide");
+        assert_eq!(wide_values.as_slice(), ["True", "False"]);
+        assert_eq!(*wide_idx, 0);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    // The widget renders the body as a typeset picture (Grid/Pane/Text all
+    // being display constructs), so the equation's actual text content is
+    // checked by evaluating the same body+bindings directly, bypassing the
+    // SVG rendering layer.
+    let equation_text = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || woxi::interpret(&w.body))
+        .expect("body evaluates")
+    };
+
+    // The default `Cos[2 ArcSin[3 y]]` algebraically reduces to `1 - 18 y^2`
+    // (cos(2*ArcSin[3y]) = 1 - 2*sin(ArcSin[3y])^2 = 1 - 2*(3y)^2), and the
+    // un-simplified left side must still show the literal
+    // `Cos[2*ArcSin[3*y]]` application rather than that reduced form.
+    let text = equation_text(&state);
+    assert!(
+      text.contains("Cos[2*ArcSin[3*y]]"),
+      "left side must stay the un-simplified application: {text}"
+    );
+    assert!(
+      text.contains("1 - 18*y^2"),
+      "right side must be the fully simplified identity: {text}"
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the typeset equation must render as a picture"
+    );
+
+    // Switching the outer function to Sin must both keep the widget error-free
+    // and change what is displayed (a stale render would repeat the Cos case).
+    let Some(manipulate::ControlState::Discrete { current_index, .. }) =
+      state.controls.get_mut(0)
+    else {
+      panic!("first control must be the outer-function popup");
+    };
+    *current_index = 0; // Sin
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let sin_text = equation_text(&state);
+    assert!(
+      sin_text.contains("Sin[2*ArcSin[3*y]]"),
+      "left side must switch to the Sin application: {sin_text}"
+    );
+    assert_ne!(
+      text, sin_text,
+      "switching the popup from Cos to Sin must change the displayed equation"
+    );
+  }
+
   /// A randomly-sampled Wolfram Demonstrations Project notebook draws
   /// several overlapping curves around the origin, hue-colored by index,
   /// with a slider controlling how tightly each curve twists and a


### PR DESCRIPTION
## Summary

- Sampled a random Wolfram Demonstrations Project notebook ("Algebraic Values of Trigonometric Functions of Inverse Trigonometric Functions") and checked whether Woxi Studio fully supports it.
- Its `Manipulate` body used the idiom `Block[Evaluate[{f, g}], HoldForm @@ {f[...]}]` to show a control variable's currently-selected function (e.g. `Sin`) applied to its argument without simplifying it, while a separate branch of the same body fully simplifies the identical expression.
- Wolfram's `Evaluate` forces evaluation of its argument even through a surrounding `Hold` attribute. Woxi already implements this rule for `Function` bodies, but `Module`/`Block`/`With` matched their local-variable-specification argument directly against a `List` and rejected anything else — including an unevaluated `Evaluate[...]` wrapper — as `"not a List"`. That threw `Block::lvlist` instead of rendering, so the notebook's `Manipulate` failed to build a working widget.
- Added a shared `resolve_var_spec` helper in `src/evaluator/scoping.rs` that evaluates a top-level `Evaluate[...]` wrapper before the existing local-var parsing runs, applied consistently to `Module`, `Block`, and `With`.
- Verified end-to-end against the actual downloaded notebook body (not committed, since the notebook is copyrighted): with the fix, `Block[Evaluate[{f,g}], HoldForm @@ {f[n g[m x]]}] == Quiet[Factor[TrigExpand[f[n g[m x]]]]]` (`f=Sin, g=ArcSin, n=12, m=12`) now correctly evaluates to `HoldForm[Sin[12*ArcSin[12*x]]] == 144*x*(1 - 144*x^2)^(11/2) - ...` — literal left side, fully simplified right side — matching the notebook's intended display.

## Test plan

- [x] Added `test_evaluate_escapes_hold_in_block_var_spec` and `test_evaluate_escapes_hold_in_module_and_with_var_spec` unit tests in `tests/interpreter_tests.rs`.
- [x] Added an independently-written Woxi Studio regression test (`demonstration_trig_inverse_identity_manipulate_shows_equation`) in `woxi-studio/src/main.rs`, covering the same construct category as the sampled notebook (not copying any of its verbatim code), including control-panel structure and re-render-on-control-change behavior.
- [x] `make test` — 27902 tests passed.
- [x] `make test-studio` — 210 tests passed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXLowGM9Yqk65SvkGsERDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXLowGM9Yqk65SvkGsERDw)_