### PR TITLE
Fix Manipulate label and NDSolve domain bugs found via a random Demonstration

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -20194,6 +20194,22 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
     });
     return runs;
   }
+  // `Infinity`/`-Infinity`/`DirectedInfinity[…]` — a Demonstration's slider
+  // range endpoint (e.g. `Subscript[N, DirectedInfinity[1]]`) typesets as
+  // the single "∞" glyph, not the spelled-out word. Left to the generic
+  // `OutputForm` fallback below, the word "Infinity" would then run through
+  // `to_unicode_script` character-by-character when used as a sub-/
+  // superscript, producing a garbled mix of subscript letters and plain
+  // ones (Unicode has no subscript I, f, or y). Checked before the
+  // structural match so both a bare symbol and `DirectedInfinity[…]` reach
+  // here.
+  if let Some(glyph) = directed_infinity_glyph(expr) {
+    return vec![LabelRun {
+      text: glyph.to_string(),
+      italic: false,
+      ..Default::default()
+    }];
+  }
   // A square root — the notebook's `\[Sqrt]…` radical, which survives as the
   // `Sqrt` head inside a held expression and normalizes to `x^(1/2)`
   // elsewhere. Either spelling sets as the radical sign over its radicand, so
@@ -20409,6 +20425,38 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
     }
     _ => output_run(italic),
   }
+}
+
+/// The "∞"/"-∞" glyph for an infinity expression, in any of the shapes it
+/// can reach a held label as: the bare `Infinity` symbol, `-Infinity`
+/// (`Times[-1, Infinity]` or a unary minus), or `DirectedInfinity[±1]`.
+/// `None` when `expr` is not an infinity at all.
+fn directed_infinity_glyph(expr: &Expr) -> Option<&'static str> {
+  if !crate::functions::predicate_ast::is_directed_infinity(expr) {
+    return None;
+  }
+  let negative = match expr {
+    Expr::FunctionCall { name, args } if name == "DirectedInfinity" => {
+      matches!(args.first(), Some(Expr::Integer(n)) if *n < 0)
+    }
+    Expr::UnaryOp {
+      op: crate::syntax::UnaryOperator::Minus,
+      ..
+    } => true,
+    Expr::FunctionCall { name, args } if name == "Times" => {
+      args.iter().any(|a| matches!(a, Expr::Integer(-1)))
+    }
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Times,
+      left,
+      right,
+    } => {
+      matches!(left.as_ref(), Expr::Integer(-1))
+        || matches!(right.as_ref(), Expr::Integer(-1))
+    }
+    _ => false,
+  };
+  Some(if negative { "-\u{221E}" } else { "\u{221E}" })
 }
 
 /// The radicand of a square root written either way: as the `Sqrt[x]` head
@@ -23987,6 +24035,46 @@ mod manipulate_label_tests {
       vec![Expr::Integer(1), Expr::Identifier("y".into())],
     );
     assert_eq!(flatten_label_runs(&runs(&flat)), "y\u{2032}");
+  }
+
+  /// A slider's asymptote parameter labeled `Subscript[N, DirectedInfinity[1]]`
+  /// (what a `Manipulate` body's held `Subscript[N, Infinity]` evaluates to)
+  /// must typeset as "N∞", not spell "Infinity" out letter by letter through
+  /// the subscript-glyph table.
+  #[test]
+  fn subscript_of_directed_infinity_renders_the_infinity_glyph() {
+    let label = call(
+      "Subscript",
+      vec![
+        Expr::Identifier("N".into()),
+        call1("DirectedInfinity", Expr::Integer(1)),
+      ],
+    );
+    assert_eq!(flatten_label_runs(&runs(&label)), "N\u{221E}");
+  }
+
+  /// The negative-infinity variant, reaching the label as a `Superscript`
+  /// argument. The sign folds to its superscript form like any other
+  /// `to_unicode_script`-mapped character; only the letters of "Infinity"
+  /// itself have no such mapping, which is what this glyph shortcut avoids.
+  #[test]
+  fn superscript_of_negative_infinity_renders_the_signed_glyph() {
+    let label = call(
+      "Superscript",
+      vec![
+        Expr::Identifier("x".into()),
+        call1("DirectedInfinity", Expr::Integer(-1)),
+      ],
+    );
+    assert_eq!(flatten_label_runs(&runs(&label)), "x\u{207B}\u{221E}");
+  }
+
+  /// A bare `Infinity` symbol as a top-level label (e.g. a picker's own
+  /// choice text) also renders as the glyph rather than the word.
+  #[test]
+  fn bare_infinity_symbol_renders_the_glyph() {
+    let label = Expr::Identifier("Infinity".into());
+    assert_eq!(flatten_label_runs(&runs(&label)), "\u{221E}");
   }
 }
 

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -2188,7 +2188,15 @@ fn ndsolve_system(
   }
   let Some(x0) = x0 else { return Ok(None) };
   let (x_min, x_max) = if let Some(min) = x_min_given {
-    (min, x_max)
+    // The initial condition may sit just outside the requested output
+    // range — a Demonstration commonly states `y[0] == n0` at the natural
+    // reference point but plots from a tiny epsilon (`{t, 0.00001, 200}`)
+    // to dodge a singularity (a fractional power of `y`, a `LogPlot`, …)
+    // exactly at that point. The integrator still has to start at the
+    // initial condition, so the solved range extends to include it rather
+    // than rejecting the system outright — matching the `{x, xmax}`
+    // shorthand below, which already integrates from x0 unconditionally.
+    (min.min(x0), x_max.max(x0))
   } else {
     // {x, xmax} shorthand: integrate from x0 to xmax, in whichever
     // direction that is — x0 always lands on one edge of the range. An
@@ -2201,9 +2209,6 @@ fn ndsolve_system(
     }
     (x0.min(target), x0.max(target))
   };
-  if x0 < x_min - 1e-12 || x0 > x_max + 1e-12 {
-    return Ok(None);
-  }
 
   // Determine each function's order from the equations.
   for ode in &odes {

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7951,7 +7951,10 @@ mod ndsolve {
        (y /. sol[[1]])[\"Domain\"]",
     )
     .unwrap();
-    assert_eq!(below, "{{0., 200.}}", "the IC at 0 must pull xmin down to 0");
+    assert_eq!(
+      below, "{{0., 200.}}",
+      "the IC at 0 must pull xmin down to 0"
+    );
     assert_eq!(
       above, "{{-5., 10.}}",
       "the IC at 10 must push xmax up to 10"

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7937,21 +7937,25 @@ mod ndsolve {
   fn ndsolve_domain_extends_past_a_far_initial_condition_too() {
     // Same as above, but with the initial condition well outside the
     // requested domain on either side (not just by a tiny epsilon) — the
-    // extension isn't a special case for "close" gaps.
-    let far = interpret(
+    // extension isn't a special case for "close" gaps. Checked via the
+    // InterpolatingFunction's own reported `"Domain"` rather than by
+    // sampling near the far edge, which an adaptive step size can overshoot
+    // slightly and trigger an extrapolation warning for.
+    let below = interpret(
       "sol = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 50, 200}]; \
-       y[10.] /. sol[[1]]",
+       (y /. sol[[1]])[\"Domain\"]",
     )
     .unwrap();
     let above = interpret(
       "sol = NDSolve[{y'[t] == -y[t], y[10] == 1}, y, {t, -5, 5}]; \
-       y[20.] /. sol[[1]]",
+       (y /. sol[[1]])[\"Domain\"]",
     )
     .unwrap();
-    let far_val: f64 = far.parse().expect("should be a number");
-    let above_val: f64 = above.parse().expect("should be a number");
-    assert!((far_val - (-10.0_f64).exp()).abs() < 1e-3);
-    assert!((above_val - (-10.0_f64).exp()).abs() < 1e-3);
+    assert_eq!(below, "{{0., 200.}}", "the IC at 0 must pull xmin down to 0");
+    assert_eq!(
+      above, "{{-5., 10.}}",
+      "the IC at 10 must push xmax up to 10"
+    );
   }
 
   #[test]

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7909,6 +7909,52 @@ mod ndsolve {
   }
 
   #[test]
+  fn ndsolve_domain_extends_to_an_initial_condition_outside_it() {
+    // Regression: a Demonstration commonly states its initial condition at
+    // the natural reference point (`y[0] == n0`) but requests the solution
+    // from a tiny epsilon onward (`{t, 0.00001, 200}`) to dodge a
+    // singularity — a fractional power of `y`, a `LogPlot` — sitting right
+    // at that point. NDSolve used to require the initial condition to fall
+    // within the given domain and bailed out unevaluated otherwise, even
+    // though the integrator has to start at the initial condition regardless
+    // — it must extend the solved range to include it, exactly like the
+    // `{x, xmax}` shorthand already does.
+    // y' = -y, y(0) = 1 → y(t) = E^-t, so y(10) ≈ E^-10.
+    let result = interpret(
+      "sol = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0.00001, 200}]; \
+       y[10.] /. sol[[1]]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    let expected = (-10.0_f64).exp();
+    assert!(
+      (val - expected).abs() < 1e-3 * expected,
+      "Expected {expected}, got {val}"
+    );
+  }
+
+  #[test]
+  fn ndsolve_domain_extends_past_a_far_initial_condition_too() {
+    // Same as above, but with the initial condition well outside the
+    // requested domain on either side (not just by a tiny epsilon) — the
+    // extension isn't a special case for "close" gaps.
+    let far = interpret(
+      "sol = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 50, 200}]; \
+       y[10.] /. sol[[1]]",
+    )
+    .unwrap();
+    let above = interpret(
+      "sol = NDSolve[{y'[t] == -y[t], y[10] == 1}, y, {t, -5, 5}]; \
+       y[20.] /. sol[[1]]",
+    )
+    .unwrap();
+    let far_val: f64 = far.parse().expect("should be a number");
+    let above_val: f64 = above.parse().expect("should be a number");
+    assert!((far_val - (-10.0_f64).exp()).abs() < 1e-3);
+    assert!((above_val - (-10.0_f64).exp()).abs() < 1e-3);
+  }
+
+  #[test]
   fn interpolating_function_input_form_has_no_placeholder() {
     // Regression: InterpolatingFunction's `<>` data placeholder — meant
     // only to keep display output short — was also applied under


### PR DESCRIPTION
## Summary

Following the scheduled routine of pulling a random Wolfram Demonstration
and checking Woxi Studio's support for it, this run downloaded
"Generalized Logistic (Verhulst) Isothermal Microbial Growth" from
`demonstrations.wolfram.com` and found two real bugs when running its
`Manipulate` through Woxi Studio's `dump_manipulate` diagnostic harness
(`cargo run -p woxi-studio --example dump_manipulate`).

- **Garbled label for `Subscript[N, DirectedInfinity[1]]`.** A slider
  labelled `Subscript[N, Infinity]` (the asymptote parameter, N∞) was
  falling through to the generic label-rendering path, which spells the
  value out as the word "Infinity" and then runs it character-by-character
  through the subscript-glyph table. Since Unicode has no subscript I, f,
  or y, the label came out as `NIₙfᵢₙᵢₜy` instead of `N∞`.
  `Subscript`/`Superscript`/`Power` of any infinity shape (`Infinity`,
  `-Infinity`, `DirectedInfinity[±1]`) now renders the `∞` glyph directly.

- **`NDSolve` silently failing to solve, producing a blank plot.** The
  Demonstration states its initial condition at the natural reference
  point (`y[0] == n0`) but requests the solution starting from a tiny
  epsilon (`{t, 0.00001, 200}`) to dodge a singularity at exactly `t = 0`
  (a fractional power of `y` here; a `LogPlot` would have the same issue).
  `NDSolve` required the initial condition to fall within the given
  `{t, tmin, tmax}` domain and bailed out unevaluated otherwise — even
  though the integrator has to start at the initial condition regardless.
  The `GraphicsColumn[{Plot[...], LogPlot[...]}]` body then rendered as an
  empty `<svg>` since the underlying solve never happened. The solved
  range now extends to include the initial condition, the same way the
  `{x, xmax}` domain shorthand already did.

No verbatim code from the Demonstration notebook is included — the tests
use fresh, minimal equations chosen to exercise the same code paths.

## Test plan
- [x] Added unit tests for `Subscript`/`Superscript` of `DirectedInfinity`
  in `src/functions/graphics.rs` (`manipulate_label_tests`)
- [x] Added regression tests for the `NDSolve` domain-extension fix in
  `tests/interpreter_tests/calculus.rs` (`ndsolve` module)
- [x] `cargo test --workspace` — full suite passes, 0 failures
- [x] Manually verified against the real downloaded Demonstration notebook
  via `cargo run -p woxi-studio --example dump_manipulate`: the label now
  reads `N∞` and the `GraphicsColumn` plot renders a proper (non-empty)
  sigmoid growth curve in both linear and semi-log coordinates
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BYuqw9sECUnYkRcUqbMd2r)_