### PR TITLE
Fix ParametricPlot3D surface form with a multi-surface list wrapped in ReplaceAll

### DIFF
--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -9470,26 +9470,35 @@ fn resolve_parametric_triples(
       "ParametricPlot3D: first argument must be {fx, fy, fz}".into(),
     )
   };
+  // A single `{fx, fy, fz}` triple, or a list of such triples (each item
+  // possibly still needing its own resolution, e.g. a held `helper[u, v]`
+  // call or a `{fx, fy, fz} /. rules` substitution).
+  let resolve_items =
+    |items: &[Expr]| -> Result<Vec<(Expr, Expr, Expr)>, InterpreterError> {
+      if items.len() == 3 && !matches!(&items[0], Expr::List(_)) {
+        return Ok(vec![(
+          items[0].clone(),
+          items[1].clone(),
+          items[2].clone(),
+        )]);
+      }
+      if items.is_empty() {
+        return Err(err());
+      }
+      items
+        .iter()
+        .map(|item| {
+          resolve_one_parametric_triple(item, shadow_vars).ok_or_else(err)
+        })
+        .collect()
+    };
   match body {
-    Expr::List(items)
-      if items.len() == 3 && !matches!(&items[0], Expr::List(_)) =>
-    {
-      Ok(vec![(items[0].clone(), items[1].clone(), items[2].clone())])
-    }
-    Expr::List(items) if !items.is_empty() => items
-      .iter()
-      .map(|item| {
-        resolve_one_parametric_triple(item, shadow_vars).ok_or_else(err)
-      })
-      .collect(),
-    Expr::List(_) => Err(err()),
+    Expr::List(items) => resolve_items(items),
     other => {
       let resolved =
         crate::functions::plot::eval_body_vars_symbolic(other, shadow_vars);
-      match &resolved {
-        Expr::List(items) if items.len() == 3 => {
-          Ok(vec![(items[0].clone(), items[1].clone(), items[2].clone())])
-        }
+      match unwrap_singleton_list(&resolved) {
+        Expr::List(items) => resolve_items(items),
         _ => Err(err()),
       }
     }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17751,6 +17751,36 @@ mod parametric_plot3d {
     assert!(svg.contains("<svg"));
   }
 
+  /// Regression (Wolfram Demonstration "Torsion of an Elastic Beam with
+  /// Rectangular Cross Section"): the 2-iterator (surface) form's first
+  /// argument can be a whole list of `{fx, fy, fz}` triples wrapped in one
+  /// outer `ReplaceAll`, e.g. `ReplaceAll[{helper1[u, v], helper2[u, v]},
+  /// rules]`, so it overlays several surfaces from one call — the same
+  /// multi-surface idiom `body_from_function_call` covers for a single
+  /// helper call. `HoldAll` leaves the whole `ReplaceAll` unevaluated, and
+  /// evaluating it once (with `u`/`v` cleared) used to produce a 2-element
+  /// list of 3-lists that only matched the single-triple `items.len() == 3`
+  /// case, so it failed with "first argument must be {fx, fy, fz}" even
+  /// though each element was itself a valid triple.
+  #[test]
+  fn surface_list_from_replace_all() {
+    clear_state();
+    interpret(
+      "lower[a_, b_] := {Sin[a], Cos[a], b}; \
+               upper[a_, b_] := {Sin[a] + 2, Cos[a] + 2, b};",
+    )
+    .unwrap();
+    let svg = export_svg(
+      "ParametricPlot3D[ReplaceAll[{lower[u, v], upper[u, v]}, {}], \
+       {u, 0, 2 Pi}, {v, 0, 1}]",
+    );
+    assert!(svg.contains("<svg"));
+    assert!(
+      svg.matches("<polygon").count() > 1,
+      "expected polygon fills for both overlaid surfaces"
+    );
+  }
+
   /// Every `<polygon>` fill colour in the SVG, as `(r, g, b)` triples — see
   /// the identical helper documented in `plot3d::options`.
   fn fill_colors(svg: &str) -> Vec<(u32, u32, u32)> {


### PR DESCRIPTION
## Summary
- Found via a randomly sampled Wolfram Demonstrations Project notebook ("Torsion of an Elastic Beam with Rectangular Cross Section") that Woxi Studio failed to render.
- The 2-iterator (surface) form of `ParametricPlot3D` can take a whole list of `{fx, fy, fz}` triples wrapped in one outer expression, e.g. `ReplaceAll[{helper1[u, v], helper2[u, v]}, rules]`, overlaying several surfaces from a single call. `HoldAll` leaves that `ReplaceAll` unevaluated, and `resolve_parametric_triples` only accepted an evaluated result of exactly 3 top-level items (a single triple), so it failed with `"ParametricPlot3D: first argument must be {fx, fy, fz}"` even though each element was itself a valid triple.
- Unified both branches (already-a-literal-`List` vs. a held expression that evaluates to one) to resolve a list of triples the same way in either case.

## Test plan
- [x] Added an independently-written regression test (`surface_list_from_replace_all`) covering the same construct category (not copied from the notebook)
- [x] `cargo test parametric_plot3d` — all 17 tests pass
- [x] `cargo nextest run` (full suite) — 27910 tests pass
- [x] `make test-studio` — 211 tests pass
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSyTGQZgNgdc3NTLzFpDXi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSyTGQZgNgdc3NTLzFpDXi)_