### PR TITLE
Fix NDSolve for two-argument indexed dependent variables

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -402,13 +402,28 @@ fn ndsolve_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let opts = &args[n_pos..];
   let event = parse_event_locator_option(opts);
 
-  // Unknowns written as compound expressions (`Subscript[c, 1]`) are keyed
-  // by a fresh symbol while integrating, then restored in the result.
-  let renames = compound_head_renamings(&args[1], &args[2]);
-  let positional: Vec<Expr> = if renames.is_empty() {
+  // A stage-indexed family (`Table[x[i, t], {i, 1, n}]` as the dependent
+  // variable spec — a discretized PDE or a staged process model) is keyed
+  // by a fresh single-argument symbol per index, the same way a compound
+  // head is below, so the rest of the solver only ever sees ordinary
+  // `f[t]`-shaped unknowns.
+  let idx_renames = indexed_family_renamings(&args[1], &args[2]);
+  let indexed: Vec<Expr> = if idx_renames.is_empty() {
     args[..3].to_vec()
   } else {
     args[..3]
+      .iter()
+      .map(|a| rename_indexed_vars(a, &idx_renames))
+      .collect()
+  };
+
+  // Unknowns written as compound expressions (`Subscript[c, 1]`) are keyed
+  // by a fresh symbol while integrating, then restored in the result.
+  let renames = compound_head_renamings(&indexed[1], &indexed[2]);
+  let positional: Vec<Expr> = if renames.is_empty() {
+    indexed.clone()
+  } else {
+    indexed
       .iter()
       .map(|a| rename_compound_heads(a, &renames))
       .collect()
@@ -421,7 +436,10 @@ fn ndsolve_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // `Sin[θ[t]]`) even though nothing about integrating it numerically
   // needs the equation to be linear.
   match ndsolve_system(&positional, event.as_ref()) {
-    Ok(Some(result)) => Ok(restore_compound_heads(&result, &renames)),
+    Ok(Some(result)) => {
+      let result = restore_compound_heads(&result, &renames);
+      Ok(restore_indexed_vars(&result, &idx_renames))
+    }
     Ok(None) => Ok(unevaluated("NDSolve", args)),
     Err(e) => Err(e),
   }
@@ -1739,6 +1757,152 @@ fn restore_compound_heads(expr: &Expr, renames: &[(Expr, String)]) -> Expr {
     };
   }
   map_children(expr, &|c| restore_compound_heads(c, renames))
+}
+
+/// One member of a stage-indexed dependent-variable family: `head[index,
+/// x_name]` (e.g. `x[3, t]`, the 3rd entry of `Table[x[i, t], {i, 1, n}]`)
+/// is keyed by `fresh`, a synthesized single-argument symbol name.
+struct IndexedRename {
+  head: String,
+  index: Expr,
+  fresh: String,
+}
+
+/// Find every `head[index, x]` entry in the dependent-variable spec — the
+/// idiom a discretized PDE or a staged process model (a distillation
+/// column's per-tray composition, a chain of coupled oscillators, …) uses
+/// to name its unknowns: `Table[x[i, t], {i, 1, n}]` rather than `n`
+/// separately named functions. `ndsolve_system` below only understands
+/// `f[t]`-shaped unknowns, so each concrete `head[index, x]` is assigned a
+/// fresh 1-argument symbol; [`rename_indexed_vars`]/[`restore_indexed_vars`]
+/// translate the system into and back out of that vocabulary.
+fn indexed_family_renamings(vars: &Expr, domain: &Expr) -> Vec<IndexedRename> {
+  let x_name = match domain {
+    Expr::List(items) => match items.first() {
+      Some(Expr::Identifier(x)) => x.clone(),
+      _ => return Vec::new(),
+    },
+    _ => return Vec::new(),
+  };
+  let entries: Vec<&Expr> = match vars {
+    Expr::List(items) => items.iter().collect(),
+    single => vec![single],
+  };
+  let mut renames: Vec<IndexedRename> = Vec::new();
+  for entry in entries {
+    let Expr::FunctionCall { name, args } = entry else {
+      continue;
+    };
+    if args.len() != 2 {
+      continue;
+    }
+    let Some(Expr::Identifier(a)) = args.get(1) else {
+      continue;
+    };
+    if *a != x_name {
+      continue;
+    }
+    let index = args[0].clone();
+    let index_key = crate::syntax::expr_to_string(&index);
+    if renames.iter().any(|r| {
+      r.head == *name && crate::syntax::expr_to_string(&r.index) == index_key
+    }) {
+      continue;
+    }
+    let fresh = format!("NDSolve$idx${name}${}", renames.len() + 1);
+    renames.push(IndexedRename {
+      head: name.clone(),
+      index,
+      fresh,
+    });
+  }
+  renames
+}
+
+/// Rewrite `head[index, other]` — bare, or under `Derivative[0, k][head]`
+/// (the parsed form of `D[head[index, x], {x, k}]`) — to the matching
+/// family member's fresh symbol applied to `other` alone: `fresh[other]`,
+/// respectively `Derivative[k][fresh][other]`.
+fn rename_indexed_vars(expr: &Expr, renames: &[IndexedRename]) -> Expr {
+  if renames.is_empty() {
+    return expr.clone();
+  }
+  // `Derivative[0, k][head][index, other]`, the parsed form of
+  // `D[head[index, x], {x, k}]`: the leading `0` says the derivative isn't
+  // taken with respect to the index slot, so it collapses away with it.
+  if let Expr::CurriedCall { func, args } = expr
+    && args.len() == 2
+    && let Expr::CurriedCall {
+      func: deriv_head,
+      args: fname_args,
+    } = func.as_ref()
+    && fname_args.len() == 1
+    && let Expr::Identifier(fname) = &fname_args[0]
+    && let Expr::FunctionCall {
+      name: deriv_name,
+      args: orders,
+    } = deriv_head.as_ref()
+    && deriv_name == "Derivative"
+    && orders.len() == 2
+    && matches!(orders[0], Expr::Integer(0))
+  {
+    let index_key = crate::syntax::expr_to_string(&args[0]);
+    if let Some(r) = renames.iter().find(|r| {
+      r.head == *fname && crate::syntax::expr_to_string(&r.index) == index_key
+    }) {
+      let other = rename_indexed_vars(&args[1], renames);
+      return Expr::CurriedCall {
+        func: Box::new(Expr::CurriedCall {
+          func: Box::new(call("Derivative", vec![orders[1].clone()])),
+          args: vec![Expr::Identifier(r.fresh.clone())],
+        }),
+        args: vec![other],
+      };
+    }
+  }
+  if let Expr::FunctionCall { name, args } = expr
+    && args.len() == 2
+  {
+    let index_key = crate::syntax::expr_to_string(&args[0]);
+    if let Some(r) = renames.iter().find(|r| {
+      r.head == *name && crate::syntax::expr_to_string(&r.index) == index_key
+    }) {
+      let other = rename_indexed_vars(&args[1], renames);
+      return Expr::FunctionCall {
+        name: r.fresh.clone(),
+        args: vec![other].into(),
+      };
+    }
+  }
+  map_children(expr, &|c| rename_indexed_vars(c, renames))
+}
+
+/// The inverse of [`rename_indexed_vars`], applied to the solution rules:
+/// `NDSolve$idx$x$1 -> InterpolatingFunction[…][t]` becomes
+/// `x[1, t] -> InterpolatingFunction[…][t]`.
+fn restore_indexed_vars(expr: &Expr, renames: &[IndexedRename]) -> Expr {
+  if renames.is_empty() {
+    return expr.clone();
+  }
+  if let Expr::FunctionCall { name, args } = expr
+    && args.len() == 1
+    && let Some(r) = renames.iter().find(|r| r.fresh == *name)
+  {
+    let other = restore_indexed_vars(&args[0], renames);
+    return Expr::FunctionCall {
+      name: r.head.clone(),
+      args: vec![r.index.clone(), other].into(),
+    };
+  }
+  if let Expr::Identifier(name) = expr
+    && let Some(r) = renames.iter().find(|r| r.fresh == *name)
+  {
+    return Expr::FunctionCall {
+      name: r.head.clone(),
+      args: vec![r.index.clone()].into(),
+    };
+  }
+  map_children(expr, &|c| restore_indexed_vars(c, renames))
 }
 
 // ─── The NDSolve integrator ────────────────────────────────────────────

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7592,6 +7592,43 @@ mod ndsolve {
     );
   }
 
+  /// Unknowns are also written as a single function of two arguments —
+  /// `x[i, t]` rather than `Subscript[x, i][t]` — the idiom a discretized
+  /// PDE or a staged process model (a chain of tanks, a distillation
+  /// column's per-tray composition) uses: `Table[x[i, t], {i, 1, n}]` as
+  /// the dependent-variable spec, with the equations themselves generated
+  /// the same way (`Join[{eq[1]}, Table[eq[i], {i, 2, n - 1}], {eq[n]}]`).
+  /// Each `x[k, t]` is keyed by a fresh single-argument symbol while
+  /// integrating and restored in the solution rules.
+  #[test]
+  fn two_argument_indexed_unknowns_are_solved_and_restored() {
+    // Three well-mixed tanks in a row, each exchanging with its neighbors:
+    // x[1]' = x[2]-x[1], x[2]' = x[1]-2x[2]+x[3], x[3]' = x[2]-x[3]. Total
+    // mass x[1]+x[2]+x[3] is conserved, so all three relax to 1/3.
+    let system = "eq[1] = D[x[1, t], {t, 1}] == x[2, t] - x[1, t]; \
+       eq[i_] := D[x[i, t], {t, 1}] == x[i - 1, t] - 2 x[i, t] + x[i + 1, t]; \
+       eq[3] = D[x[3, t], {t, 1}] == x[2, t] - x[3, t]; \
+       sol = NDSolve[Join[{eq[1]}, Table[eq[i], {i, 2, 2}], {eq[3]}, \
+       Table[x[i, 0] == If[i == 1, 1, 0], {i, 1, 3}]], \
+       Table[x[i, t], {i, 1, 3}], {t, 0, 20}]; ";
+    assert_eq!(
+      interpret(&format!("{system}sol[[1]][[All, 1]]")).unwrap(),
+      "{x[1, t], x[2, t], x[3, t]}",
+      "the indexed unknowns come back verbatim, not the fresh solver symbol"
+    );
+    for i in 1..=3 {
+      let value: f64 =
+        interpret(&format!("{system}First[x[{i}, t] /. sol] /. t -> 20.0"))
+          .unwrap()
+          .parse()
+          .expect("should be a number");
+      assert!(
+        (value - 1.0 / 3.0).abs() < 1e-3,
+        "x[{i}] should have relaxed to 1/3 by t=20, got {value}"
+      );
+    }
+  }
+
   /// A forcing term that is nonzero only on a very narrow interval — an
   /// injected tracer pulse — must not be integrated as though it lasted a
   /// whole grid step, which would inflate the solution by the ratio of the


### PR DESCRIPTION
## Summary

- Picked a random Wolfram Demonstration ("Dynamics of a Binary Distillation Column") and tested it against Woxi Studio's notebook parsing/evaluation pipeline.
- The notebook's `.nb` file parsed fine, and its `Input` cell's box data reconstructed to valid `InputForm` (`Manipulate[Module[...]]`), but evaluating the body failed: `NDSolve` returned completely **unevaluated** instead of solving.
- Root cause: the notebook's 32-stage ODE system names its unknowns `x[i, t]` (a single function of two arguments — index and time) rather than as separately named functions, with the dependent-variable spec written `Table[x[i, t], {i, 1, n}]`. This is the natural way to write a discretized PDE or a staged process model in Wolfram Language (a distillation column's per-tray composition, a chain of coupled tanks/oscillators, …). `NDSolve`'s system solver only recognized `f[t]`-shaped unknowns (a bare symbol, or a function of exactly the independent variable), so any equation using the `f[i, t]` idiom silently bailed out unevaluated — a minimal repro is a plain 2-equation linear system:
  ```
  NDSolve[{D[x[1,t],{t,1}]==-x[1,t]+x[2,t], D[x[2,t],{t,1}]==x[1,t]-x[2,t],
    x[1,0]==0.5, x[2,0]==0.5}, {x[1,t],x[2,t]}, {t,0,10}]
  ```

## Fix

Each concrete `x[k, t]` (and its `Derivative[0, m][x][k, t]` form, from `D[x[k,t],{t,m}]`) is now keyed to a fresh single-argument symbol before solving — the same technique already used for compound heads like `Subscript[c, 1]` — and the solution rules are translated back to `x[k, t] -> ...` form afterward. This generalizes to any index expression, any function name, and any system size.

Per the repo's guidance not to copy verbatim code from the (copyrighted) Demonstration notebook, the regression test uses an original example (three exchanging tanks) rather than the distillation-column equations themselves.

## Test plan

- [x] Added `two_argument_indexed_unknowns_are_solved_and_restored` in `tests/interpreter_tests/calculus.rs`, covering both the reconstructed-symbol check and numeric convergence.
- [x] `cargo test --release --test interpreter_tests calculus::ndsolve` — all 58 NDSolve tests pass (no regressions).
- [x] `make test` — full suite passes: 27910/27910.
- [x] `make format`.

## Known remaining limitation (out of scope here)

The distillation-column Demonstration's actual system (32 stages, genuinely stiff, integrated to `t = 20000`) still doesn't complete in practical time even with this fix — Woxi's `NDSolve` uses an adaptive but *explicit* RK4 integrator, whose stable step size is bounded by the system's stiffness regardless of the adaptivity. That's a separate, much larger project (an implicit/stiff solver) and is not addressed by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QeuaAE7spjh2kSQmBTncwv)_