### PR TITLE
Fix ContourPlot/DensityPlot color scale flattened by a domain pole

### DIFF
--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -515,6 +515,47 @@ fn scaled_color(t: f64, color_function: Option<&str>) -> (u8, u8, u8) {
   }
 }
 
+/// Robust value range over a set of function samples — an IQR fence
+/// excludes extreme outliers so a singularity in the sampled domain (e.g. a
+/// pole in the plotted function) can't collapse the color scale and contour
+/// levels onto a handful of pixels around it, leaving the rest of the plot a
+/// single flat color. Mirrors `plot::sampled_y_range`'s approach for `Plot`'s
+/// y-range, applied here to a 2D function's sampled values.
+fn robust_value_range(values: &[f64]) -> (f64, f64) {
+  let mut vs: Vec<f64> =
+    values.iter().copied().filter(|v| v.is_finite()).collect();
+  if vs.is_empty() {
+    return (f64::INFINITY, f64::NEG_INFINITY);
+  }
+  vs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+  let n = vs.len();
+  if n == 1 {
+    return (vs[0], vs[0]);
+  }
+
+  let q1 = vs[n / 4];
+  let q3 = vs[3 * n / 4];
+  let iqr = q3 - q1;
+
+  // If IQR is negligible, no outliers — use the full min/max.
+  if iqr < 1e-10 {
+    return (vs[0], vs[n - 1]);
+  }
+
+  let fence_lo = q1 - 3.0 * iqr;
+  let fence_hi = q3 + 3.0 * iqr;
+
+  let v_min = vs.iter().copied().find(|&v| v >= fence_lo).unwrap_or(vs[0]);
+  let v_max = vs
+    .iter()
+    .rev()
+    .copied()
+    .find(|&v| v <= fence_hi)
+    .unwrap_or(vs[n - 1]);
+
+  (v_min, v_max)
+}
+
 /// Scale a value into [0,1] over [v_min, v_max] (0.5 for a flat range).
 fn scale_value(v: f64, v_min: f64, v_max: f64) -> f64 {
   let range = v_max - v_min;
@@ -1218,8 +1259,7 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Sample grid
   let mut grid = vec![vec![f64::NAN; FIELD_GRID]; FIELD_GRID];
-  let mut v_min = f64::INFINITY;
-  let mut v_max = f64::NEG_INFINITY;
+  let mut samples = Vec::with_capacity(FIELD_GRID * FIELD_GRID);
 
   for i in 0..FIELD_GRID {
     let x = x_min + (i as f64 + 0.5) / FIELD_GRID as f64 * (x_max - x_min);
@@ -1229,11 +1269,11 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && v.is_finite()
       {
         grid[i][j] = v;
-        v_min = v_min.min(v);
-        v_max = v_max.max(v);
+        samples.push(v);
       }
     }
   }
+  let (v_min, v_max) = robust_value_range(&samples);
 
   // Use plotters for axes, then overlay the density image
   let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
@@ -1337,8 +1377,7 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Sample grid
   let mut grid = vec![vec![f64::NAN; n]; n];
-  let mut v_min = f64::INFINITY;
-  let mut v_max = f64::NEG_INFINITY;
+  let mut samples = Vec::with_capacity(n * n);
 
   for i in 0..n {
     let x = x_min + i as f64 / FIELD_GRID as f64 * (x_max - x_min);
@@ -1348,11 +1387,11 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && v.is_finite()
       {
         grid[i][j] = v;
-        v_min = v_min.min(v);
-        v_max = v_max.max(v);
+        samples.push(v);
       }
     }
   }
+  let (v_min, v_max) = robust_value_range(&samples);
 
   if !v_min.is_finite() || !v_max.is_finite() {
     return Ok(crate::graphics_result(
@@ -2238,9 +2277,8 @@ pub fn stream_density_plot_ast(
   let grid_n = 60;
 
   // Compute magnitude field for density background
-  let mut v_min = f64::INFINITY;
-  let mut v_max = f64::NEG_INFINITY;
   let mut mag_grid = vec![vec![f64::NAN; grid_n]; grid_n];
+  let mut mag_samples = Vec::with_capacity(grid_n * grid_n);
 
   for i in 0..grid_n {
     let x = x_min + (i as f64 + 0.5) / grid_n as f64 * (x_max - x_min);
@@ -2250,12 +2288,12 @@ pub fn stream_density_plot_ast(
         let mag = (vx * vx + vy * vy).sqrt();
         if mag.is_finite() {
           mag_grid[i][j] = mag;
-          v_min = v_min.min(mag);
-          v_max = v_max.max(mag);
+          mag_samples.push(mag);
         }
       }
     }
   }
+  let (v_min, v_max) = robust_value_range(&mag_samples);
 
   // Use plotters for axes
   let area = generate_axes_only(
@@ -3430,4 +3468,47 @@ pub fn complex_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result(svg))
+}
+
+#[cfg(test)]
+mod robust_range_tests {
+  use super::robust_value_range;
+
+  #[test]
+  fn robust_value_range_ignores_a_pole() {
+    // A handful of samples near a singularity (huge magnitude, like a
+    // function blowing up at one grid point) shouldn't drag v_max out to
+    // where the rest of the well-behaved samples all scale to the same
+    // color. Mirrors the shape of a `ContourPlot`/`DensityPlot` grid sample
+    // set for a function like `1/Sqrt[x^2 + y^2]`.
+    let mut samples: Vec<f64> = (0..96).map(|i| i as f64 * 0.1).collect();
+    samples.extend([1.0e6, 2.0e6, 5.0e6, 1.0e7]);
+
+    let (v_min, v_max) = robust_value_range(&samples);
+
+    assert!(v_min <= 0.0, "got v_min={v_min}");
+    // The pole samples must be fenced off — the reported max should stay
+    // close to the well-behaved bulk, not jump to the outliers.
+    assert!(
+      v_max < 100.0,
+      "expected the pole samples to be excluded, got v_max={v_max}"
+    );
+  }
+
+  #[test]
+  fn robust_value_range_keeps_full_span_without_outliers() {
+    // A smooth, well-behaved sample set (no huge gap between the bulk and
+    // the extremes) should keep its literal min/max — nothing to fence off.
+    let samples: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
+    let (v_min, v_max) = robust_value_range(&samples);
+    assert_eq!(v_min, 0.0);
+    assert_eq!(v_max, 9.9);
+  }
+
+  #[test]
+  fn robust_value_range_empty_is_non_finite() {
+    let (v_min, v_max) = robust_value_range(&[]);
+    assert!(!v_min.is_finite());
+    assert!(!v_max.is_finite());
+  }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -10790,6 +10790,29 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    /// Regression: a pole in the sampled domain (`1/Sqrt[x^2 + y^2]` blows
+    /// up at the origin) used to dominate the raw min/max of the grid
+    /// samples, which fed both the color scale and the automatic contour
+    /// levels. That collapsed the entire rest of the plot into a single
+    /// flat color with no visible contour lines — everything except a
+    /// handful of pixels around the singularity scaled to the same end of
+    /// the range. The IQR-fenced `robust_value_range` keeps the pole from
+    /// swamping the well-behaved bulk of the domain, so multiple contour
+    /// lines should still be drawn away from it.
+    #[test]
+    fn contour_plot_pole_does_not_flatten_contour_levels() {
+      let svg = export_svg(
+        "ContourPlot[1/Sqrt[x^2 + y^2], {x, -2, 2}, {y, -2, 2}, \
+         ContourStyle -> {Dashed}]",
+      );
+      let polyline_count = svg.matches("<polyline").count();
+      assert!(
+        polyline_count > 1,
+        "expected multiple contour polylines away from the pole, got {polyline_count}: {}",
+        &svg[..svg.len().min(300)]
+      );
+    }
+
     /// `ContourStyle` colours and thickens the contour lines. Both the
     /// function form and the equation form draw through it — the equation
     /// form is how a Demonstration draws a stability boundary.


### PR DESCRIPTION
## Summary

- Found while checking whether Woxi Studio fully supports a random Wolfram Demonstration notebook ("Lagrange Points" — a gravitational two-body potential with poles at both point masses): its `Manipulate`'s `ContourPlot[potential[...], ContourStyle -> {Dashed}, ColorFunction -> "Rainbow", ...]` rendered as a solid flat-colored rectangle instead of the potential's contours.
- Root cause: `ContourPlot`, `DensityPlot`, and `StreamDensityPlot`'s density background all computed the value range fed to `ColorFunction` scaling and automatic contour-level placement as the literal min/max of the sampled grid. A pole in the sampled function (finite but huge values right next to the singularity) dominated that range, so every other sample scaled to the same end of the color gradient — collapsing the whole plot into one flat color with no visible bands or contour lines.
- Fix: added `robust_value_range`, an IQR-fenced range helper (mirroring the existing `sampled_y_range` used for `Plot`'s y-axis), and used it in place of the raw min/max in these three grid-sampling code paths, so a handful of extreme outlier samples near a singularity no longer swamp the well-behaved bulk of the domain.
- No verbatim content from the Demonstration notebook is included anywhere in this change — the regression tests use a generic `1/Sqrt[x^2 + y^2]` reproduction instead.

Before / after (rendering the notebook's actual `Manipulate` body through Woxi Studio's widget pipeline):

| Before | After |
| --- | --- |
| Solid flat-colored rectangle, no contours | Correct contour bands with both point-mass wells and all 5 Lagrange points visible |

## Test plan

- [x] `make test` — full suite (27,913 tests) passes
- [x] Added unit tests for `robust_value_range` in `src/functions/field_plot.rs`
- [x] Added `contour_plot_pole_does_not_flatten_contour_levels` regression test in `tests/interpreter_tests/graphics.rs`
- [x] `make format`
- [x] Manually re-rendered the actual Demonstration notebook's `Manipulate` widget through Woxi Studio's pipeline (`dump_manipulate` example) before and after the fix to confirm the visual regression is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSMMDwhUm2e2R2zYgsKw61


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSMMDwhUm2e2R2zYgsKw61)_