### PR TITLE
Fix infinite recursion in Solve's multi-variable Reduce fallback

### DIFF
--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2063,7 +2063,16 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // wrapped. The conjunction spelling of the same system goes down the
       // single-expression path, which does handle those, so retry there
       // rather than hand back a `ToRules[Reduce[...]]` nobody asked for.
+      //
+      // But when every constraint is a plain equality, solve_ast's own
+      // And-to-List pre-pass (above) immediately folds that conjunction
+      // back into the identical `{eqs}, {vars}` pair this branch just
+      // failed on, landing right back here with the same unreduced
+      // `Reduce[...]` and recursing forever. Only retry when at least one
+      // constraint isn't a plain equality, so the retry actually reaches a
+      // different code path instead of looping back to this one.
       if matches!(&rules, Expr::FunctionCall { name, .. } if name == "ToRules")
+        && !all_equalities(&constraints)
       {
         let conjunction =
           constraints

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -4421,6 +4421,32 @@ mod solve {
     );
   }
 
+  // A nonlinear two-variable system of plain equalities that Reduce's
+  // multi-variable elimination can't fully resolve (here because it embeds
+  // an unevaluated `{}[[1]]`/`{}[[2]]` Part-on-empty-list rather than a
+  // solvable value) used to hang and eventually crash: the elimination
+  // fallback re-spells the equation list as a conjunction and retries
+  // `Solve` on it, expecting the single-expression path to handle what the
+  // list path couldn't — but Solve's own And-to-List pre-pass immediately
+  // folds a conjunction of plain equalities straight back into the
+  // identical equation list, so the retry lands on the exact same
+  // unresolved system and recurses into itself forever. Found via a random
+  // Wolfram Demonstrations Project notebook (independently constructed
+  // here, not copied from it) whose Manipulate solved an equivalent
+  // two-equation system for two draggable points' coordinates.
+  #[test]
+  fn unresolved_multi_var_reduce_does_not_recurse_forever() {
+    assert_eq!(
+      interpret(
+        "Solve[{(-1 + y)*(-1 + {}[[1]]) == (-1 + x)*(-1 + {}[[2]]), \
+         (1 + y)*(1 + {}[[1]]) == (1 + x)*(1 + {}[[2]])}, {x, y}]"
+      )
+      .unwrap(),
+      "ToRules[Reduce[(-1 + y)*(-1 + {}[[1]]) == (-1 + x)*(-1 + {}[[2]]) && \
+       (1 + y)*(1 + {}[[1]]) == (1 + x)*(1 + {}[[2]]), {x, y}]]"
+    );
+  }
+
   // Generalized variables: an applied function `y[x]` is a valid unknown and
   // is solved for as a whole, matching wolframscript.
   #[test]


### PR DESCRIPTION
## Summary

- Sampled a random Wolfram Demonstrations Project notebook ("The Nagel Point"): a Manipulate with three draggable triangle vertices whose body calls `Solve` on a small nonlinear system to locate an intersection point.
- Dragging one of the vertices to certain positions crashed Woxi Studio outright (`SIGSEGV`), traced with `gdb` to unbounded stack growth (~2000 frames deep) alternating between `solve_ast` and `solve_core`.
- Root cause: when `Reduce`'s multi-variable elimination can't fully resolve a system of plain equalities, `Solve` reshapes the equation list into a conjunction and retries, expecting the single-expression path to succeed where the list path didn't. But `Solve`'s own And-to-List pre-pass immediately folds a conjunction of plain equalities back into the identical equation list, landing on the exact same unresolved system and recursing forever.
- Fix: only retry when at least one constraint isn't a plain equality, so the retry actually reaches different logic instead of looping back into itself.
- Once the crash was fixed, the notebook's Manipulate already worked correctly (sliders, graphics, and the derived construction all render and update as expected), so no further Studio-side changes were needed.

## Test plan

- [x] Added `unresolved_multi_var_reduce_does_not_recurse_forever` in `tests/interpreter_tests/algebra.rs`, an independently constructed minimal repro (not copied from the notebook) that previously hung/crashed and now terminates instantly with the correct unevaluated `ToRules[Reduce[...]]` fallback.
- [x] `make test` — all 27,910 tests pass.
- [x] `make format` — no changes needed beyond the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqEXoru3tB2VoeZoSNqhpM


---
_Generated by [Claude Code](https://claude.ai/code/session_01CqEXoru3tB2VoeZoSNqhpM)_