### PR TITLE
Fix CompressedData integer-array decoding and Manipulate NumberForm captions

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -23488,6 +23488,16 @@ fn assign_checkbox_state(
 
 /// Render an unrecognized display leaf by evaluating it in scope and
 /// capturing its SVG (graphics) or text output.
+///
+/// `NumberForm`/`PaddedForm`/`AccountingForm` are display wrappers: the
+/// evaluated value stays symbolic (matching wolframscript's plain-text
+/// `OutputForm`, which `r.result` already renders correctly for a bare
+/// script-mode echo), but a live notebook typesets it into formatted
+/// digits — the common `Dynamic[NumberForm[…]]` control-caption readout a
+/// `Manipulate` uses to show its current value. `graphics_text_content`
+/// already does this for a label inside a picture; a leaf here is the same
+/// typeset context (a control panel caption, not a terminal), so it gets
+/// the same treatment before falling back to the plain OutputForm text.
 fn static_leaf_node(expr: &Expr, bindings: &[(String, String)]) -> DisplayNode {
   let code =
     manipulate_block_code(&crate::syntax::expr_to_input_form(expr), bindings);
@@ -23497,6 +23507,19 @@ fn static_leaf_node(expr: &Expr, bindings: &[(String, String)]) -> DisplayNode {
         DisplayNode::Static {
           svg: Some(svg),
           text: String::new(),
+        }
+      } else if let Some(Expr::FunctionCall { name, args }) = &r.expr
+        && matches!(
+          name.as_str(),
+          "NumberForm" | "PaddedForm" | "AccountingForm"
+        )
+        && !args.is_empty()
+        && let Some(formatted) =
+          crate::functions::string_ast::number_form_family_to_string(name, args)
+      {
+        DisplayNode::Static {
+          svg: None,
+          text: formatted.replace('\n', " ").trim().to_string(),
         }
       } else {
         let text = r
@@ -24308,6 +24331,41 @@ mod manipulate_display_pane_selector_tests {
     match node {
       DisplayNode::Row(children) => assert_eq!(children.len(), 2),
       other => panic!("expected a row node, got {other:?}"),
+    }
+  }
+}
+
+#[cfg(test)]
+mod manipulate_display_number_form_tests {
+  use super::*;
+
+  /// Regression: a `Dynamic[NumberForm[…]]` control-caption readout — the
+  /// idiom a `Manipulate` uses to show a live formatted value next to its
+  /// sliders (e.g. a speed-ratio readout) — leaked the literal
+  /// `NumberForm[…]` call as its displayed text instead of the formatted
+  /// digits. Bare script-mode echo of `NumberForm[…]` correctly stays
+  /// symbolic (wolframscript's own plain-text `OutputForm` does not
+  /// typeset it), but a control caption is rendered the way a live
+  /// notebook would typeset it, the same as a `NumberForm` inside a
+  /// graphic's `Text` label already is.
+  #[test]
+  fn dynamic_numberform_caption_renders_formatted_digits() {
+    let node = build_manipulate_display("Dynamic[NumberForm[1., {3, 2}]]", &[]);
+    match node {
+      DisplayNode::Static { text, svg: None } => assert_eq!(text, "1.00"),
+      other => panic!("expected a static text node, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn dynamic_paddedform_caption_renders_formatted_digits() {
+    // The leading padding is trimmed, matching how a `NumberForm`/`PaddedForm`
+    // label inside a graphic is rendered (`graphics_text_content`) — a
+    // caption widget shouldn't carry leading whitespace into its layout.
+    let node = build_manipulate_display("Dynamic[PaddedForm[7, 3]]", &[]);
+    match node {
+      DisplayNode::Static { text, svg: None } => assert_eq!(text, "7"),
+      other => panic!("expected a static text node, got {other:?}"),
     }
   }
 }

--- a/src/functions/wl_serialize.rs
+++ b/src/functions/wl_serialize.rs
@@ -14,7 +14,7 @@
 //! | `S` | string: `<i32 len><len UTF-8 bytes>`                                |
 //! | `s` | symbol (used as a head): `<i32 len><len UTF-8 bytes>`               |
 //! | `f` | normal expression: `<i32 nargs><head expr><arg expr>*nargs`         |
-//! | `n` | integer raw array: `<i32 type><i32 rank><i32 dims><packed ints>`    |
+//! | `n` | integer raw array: `<i32 type>?<i32 rank><i32 dims><packed ints>`  |
 //! | `e` | real packed array: `<i32 rank><i32 dims><packed f64>`               |
 //! | `b` | byte raw array: `<i32 rank><i32 dims><raw u8>`                      |
 //!
@@ -155,7 +155,16 @@ fn nest(dims: &[usize], leaves: &mut std::vec::IntoIter<Expr>) -> Expr {
 }
 
 fn read_dims(data: &[u8], pos: &mut usize, rank: i32) -> Option<Vec<usize>> {
-  if rank < 0 {
+  // A real WL array is never more than a handful of dimensions deep; a
+  // rank outside that range means a field got misread (garbage data, or —
+  // since `read_integer_array` now tries the `n` token's type-field and
+  // type-less layouts against the same bytes — the wrong layout landing on
+  // a small value from the other one and reading it as an enormous rank).
+  // Rejecting it here, before `Vec::with_capacity(rank as usize)`, avoids
+  // an allocation request large enough to abort the process outright
+  // (`Vec::with_capacity` aborts on allocation failure; it does not
+  // return an `Err` the caller could recover from).
+  if !(0..=64).contains(&rank) {
     return None;
   }
   let mut dims = Vec::with_capacity(rank as usize);
@@ -179,18 +188,54 @@ fn dims_product(dims: &[usize]) -> Option<usize> {
   dims.iter().try_fold(1usize, |acc, &d| acc.checked_mul(d))
 }
 
-/// `n` token — raw integer array. The element width is taken from the trailing
-/// payload (signed little-endian ints of 1/2/4/8 bytes), which makes the reader
-/// independent of the exact element-type code.
+/// `n` token — raw integer array. Two layouts have both been observed in
+/// real Wolfram output: `<i32 type><i32 rank><i32 dims><packed ints>` (a
+/// `TemporalData`/`TimeSeries` packed array — `type` disambiguating the
+/// element width when the trailing-bytes inference below is ambiguous) and
+/// `<i32 rank><i32 dims><packed ints>` with no type field at all (a
+/// `GraphicsComplex` face-index list saved by `Manipulate[…,
+/// SaveDefinitions -> True]`). Nothing in the token distinguishes which
+/// layout a given payload uses up front, so both are tried: the type-field
+/// layout first (it's the one the reader has always assumed, and the one a
+/// tie goes to), falling back to the type-less layout only when the first
+/// attempt's dimensions don't validate — e.g. reading a real rank as a type
+/// and a real first dimension as an absurd rank overflowed `dims_product`
+/// or failed the remaining-bytes check, so `deserialize` gave up and the
+/// caller's UTF-8 fallback failed too (the payload is binary, not text): a
+/// `SaveDefinitions` capture with such an array anywhere in it silently
+/// lost its whole `Initialization`, leaving every symbol it defines
+/// undefined and any `Graphics3D`/`Manipulate` built from them blank.
 fn read_integer_array(data: &[u8], pos: &mut usize) -> Option<Expr> {
-  let _typ = read_i32(data, pos)?;
-  let rank = read_i32(data, pos)?;
-  let dims = read_dims(data, pos, rank)?;
+  if let Some((expr, end)) = try_read_integer_array(data, *pos, true) {
+    *pos = end;
+    return Some(expr);
+  }
+  let (expr, end) = try_read_integer_array(data, *pos, false)?;
+  *pos = end;
+  Some(expr)
+}
+
+/// One attempt at reading the `n` token's rank/dims/data, optionally
+/// preceded by a 4-byte type field it discards. Returns the parsed
+/// expression and the position just past the consumed bytes, without
+/// mutating the caller's cursor — `read_integer_array` commits whichever
+/// attempt validates.
+fn try_read_integer_array(
+  data: &[u8],
+  start: usize,
+  with_type_field: bool,
+) -> Option<(Expr, usize)> {
+  let mut pos = start;
+  if with_type_field {
+    let _typ = read_i32(data, &mut pos)?;
+  }
+  let rank = read_i32(data, &mut pos)?;
+  let dims = read_dims(data, &mut pos, rank)?;
   let count: usize = dims_product(&dims)?;
   let values = if count == 0 {
     Vec::new()
   } else {
-    let rest = data.len().checked_sub(*pos)?;
+    let rest = data.len().checked_sub(pos)?;
     if rest % count != 0 {
       return None;
     }
@@ -201,17 +246,17 @@ fn read_integer_array(data: &[u8], pos: &mut usize) -> Option<Expr> {
     let mut vals = Vec::with_capacity(count);
     for _ in 0..count {
       let mut buf = [0u8; 8];
-      buf[..width].copy_from_slice(&data[*pos..*pos + width]);
+      buf[..width].copy_from_slice(&data[pos..pos + width]);
       // Sign-extend a little-endian signed integer of `width` bytes.
       let raw = u64::from_le_bytes(buf);
       let shift = 64 - width * 8;
       let signed = ((raw << shift) as i64) >> shift;
       vals.push(Expr::Integer(signed as i128));
-      *pos += width;
+      pos += width;
     }
     vals
   };
-  Some(nest(&dims, &mut values.into_iter()))
+  Some((nest(&dims, &mut values.into_iter()), pos))
 }
 
 /// `b` token — packed unsigned byte array: `<i32 rank><i32 dims><raw u8>`.
@@ -313,10 +358,21 @@ mod tests {
   // text (see `decompress_to_expr`).
   #[test]
   fn integer_array_with_overflowing_dims_does_not_panic() {
-    // n token: type 0, rank 3, dims {i32::MAX, i32::MAX, i32::MAX} — the
-    // product vastly exceeds usize::MAX on multiplication.
-    let data = b"!boRn\x00\x00\x00\x00\x03\x00\x00\x00\xff\xff\xff\x7f\xff\xff\xff\x7f\xff\xff\xff\x7f";
+    // n token: rank 3, dims {i32::MAX, i32::MAX, i32::MAX} — the product
+    // vastly exceeds usize::MAX on multiplication.
+    let data =
+      b"!boRn\x03\x00\x00\x00\xff\xff\xff\x7f\xff\xff\xff\x7f\xff\xff\xff\x7f";
     assert!(deserialize(data).is_none());
+  }
+
+  #[test]
+  fn reads_integer_array_token() {
+    // n token: rank 2, dims {2, 3}, signed 32-bit little-endian ints — the
+    // layout real Wolfram output uses for a GraphicsComplex face-index
+    // list, with no leading element-type field (unlike what an earlier,
+    // never-verified-against-real-output version of this reader assumed).
+    let data = b"!boRn\x02\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00";
+    assert_eq!(render(data), "{{1, 2, 3}, {4, 5, 6}}");
   }
 
   #[test]


### PR DESCRIPTION
## Context

This was found while running a scheduled task that checks whether Woxi Studio fully supports a random Wolfram Demonstration. The task fetched a random notebook from the Wolfram Cloud `RandomResourcePage` API, which landed on "Continuously Variable Planetary Transmission" (a tilting-ball planetary transmission mechanism, rendered as an interactive `Manipulate` with a `Graphics3D` body). Opening it in Woxi Studio surfaced two real bugs.

No verbatim content from the downloaded notebook was copied into the repository — all tests use minimal synthetic reproductions.

## Bug 1: `CompressedData`/`Uncompress` integer-array decoding

`src/functions/wl_serialize.rs`'s binary deserializer for the `n` (integer packed array) token assumed a fixed `<i32 type><i32 rank><i32 dims><packed ints>` layout. That layout is correct for one real Wolfram-generated payload (an existing, wolframscript-verified `TimeSeries` test), but a **different** real payload — this notebook's `GraphicsComplex` face-index array, captured by `Manipulate[..., SaveDefinitions -> True]` — uses `<i32 rank><i32 dims><packed ints>` with **no** type field. Reading the type field for that payload misaligned every subsequent field, turning the real rank into a bogus dimension and the real first dimension into an unrepresentable rank (1397). That failed `dims_product`/remaining-bytes validation, so `deserialize` gave up, and the caller's UTF-8 fallback failed too (the payload is binary) — producing `Uncompress decode failed: invalid utf-8 sequence...`.

The fix tries both layouts against the same bytes (type-field first, since that's the layout the reader has always assumed and existing tests rely on), falling back to the type-less layout only when the first attempt's dimensions fail to validate. A rank sanity bound (`0..=64`) was also added in `read_dims`, since a misread field could now plausibly land on a large bogus rank, which would otherwise attempt a `Vec::with_capacity` allocation large enough to abort the process.

**Verified**: with debug instrumentation (since removed), confirmed the notebook's `SaveDefinitions`-captured `Initialization` now completes without error, and the `Manipulate` body evaluates to a correct, non-degenerate ~3.5MB SVG — independently rasterized with `rsvg-convert` to confirm it shows the correct tilting-ball mechanism.

**Known follow-up (out of scope here)**: that large SVG still doesn't display in Woxi Studio's live GUI viewport — it stays blank. This is a separate issue isolated to iced's SVG widget rendering pipeline for very large/complex SVGs, not a decode or evaluation bug, and is left for a future fix.

## Bug 2: `Manipulate` `Dynamic[NumberForm[...]]` control captions

`NumberForm`/`PaddedForm`/`AccountingForm` are display wrappers — the value stays symbolic, and bare top-level echo / `Print` correctly leave it that way (confirmed against existing wolframscript-verified tests, e.g. `NumberForm[N[Pi], 10]` prints literally as `NumberForm[3.141592653589793, 10]`). But a `Manipulate`'s control-caption row — the common `Dynamic[NumberForm[...]]` idiom for a live formatted readout next to a slider (this notebook's "speed ratio" caption) — is a notebook-rendering context, not a terminal echo, and should show the formatted digits the way `ToString` already did.

`src/functions/graphics.rs`'s `static_leaf_node` (used to render `Manipulate` display leaves) now special-cases `NumberForm`/`PaddedForm`/`AccountingForm` results the same way `graphics_text_content` already does for `Text` labels inside a graphic, routing through the same `number_form_family_to_string` helper `ToString` uses.

**Verified visually**: the notebook's "speed ratio" readout now shows `1.00` instead of the literal `NumberForm[1., {3, 2}]`.

An earlier, broader attempt at this fix (formatting `NumberForm` at the general top-level/`Print` output layer) was tried and reverted, since it broke existing wolframscript-verified tests (`number_form_1/2/3` in `tests/interpreter_tests/math/numeric.rs`) — those confirm the symbolic form is correct there. This fix is scoped to the notebook control-caption display-leaf path only.

## Testing

- `make test` — all 27,912 tests pass, including new regression tests: `reads_integer_array_token`, `integer_array_with_overflowing_dims_does_not_panic` (`src/functions/wl_serialize.rs`), and `dynamic_numberform_caption_renders_formatted_digits`, `dynamic_paddedform_caption_renders_formatted_digits` (`src/functions/graphics.rs`).
- `make format` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lb6AbiAy2dxbBZv1p7YF7h)_