### PR TITLE
Support PlotRangePadding in Graphics rendering

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -6820,6 +6820,88 @@ fn parse_range_spec(expr: &Expr) -> Option<(f64, f64)> {
   }
 }
 
+/// A single side's `PlotRangePadding` amount.
+#[derive(Clone, Copy)]
+enum PlotPadAmount {
+  None,
+  Automatic,
+  Absolute(f64),
+  Scaled(f64),
+}
+
+impl PlotPadAmount {
+  /// Resolve to an absolute amount given the axis's (unpadded) span.
+  /// `automatic_frac` is the fraction of the span `Automatic` falls back to.
+  fn resolve(self, span: f64, automatic_frac: f64) -> f64 {
+    match self {
+      Self::None => 0.0,
+      Self::Automatic => span * automatic_frac,
+      Self::Absolute(v) => v,
+      Self::Scaled(v) => span * v,
+    }
+  }
+}
+
+fn parse_plot_pad_amount(expr: &Expr) -> PlotPadAmount {
+  match expr {
+    Expr::Identifier(s) if s == "None" => PlotPadAmount::None,
+    Expr::Identifier(s) if s == "Automatic" => PlotPadAmount::Automatic,
+    Expr::FunctionCall { name, args }
+      if name == "Scaled" && args.len() == 1 =>
+    {
+      expr_to_f64(&args[0]).map_or(PlotPadAmount::None, PlotPadAmount::Scaled)
+    }
+    _ => expr_to_f64(expr).map_or(PlotPadAmount::None, PlotPadAmount::Absolute),
+  }
+}
+
+struct AxisPadding {
+  lo: PlotPadAmount,
+  hi: PlotPadAmount,
+}
+
+struct PlotRangePaddingSpec {
+  x: AxisPadding,
+  y: AxisPadding,
+}
+
+/// Parse a `PlotRangePadding` option value: a single spec (applied to both
+/// sides of both axes), `{xSpec, ySpec}`, or the full per-side form
+/// `{{xMinPad, xMaxPad}, {yMinPad, yMaxPad}}`.
+fn parse_plot_range_padding(expr: &Expr) -> PlotRangePaddingSpec {
+  fn symmetric(amt: PlotPadAmount) -> AxisPadding {
+    AxisPadding { lo: amt, hi: amt }
+  }
+  if let Expr::List(items) = expr
+    && items.len() == 2
+  {
+    if let (Expr::List(x_sides), Expr::List(y_sides)) = (&items[0], &items[1])
+      && x_sides.len() == 2
+      && y_sides.len() == 2
+    {
+      return PlotRangePaddingSpec {
+        x: AxisPadding {
+          lo: parse_plot_pad_amount(&x_sides[0]),
+          hi: parse_plot_pad_amount(&x_sides[1]),
+        },
+        y: AxisPadding {
+          lo: parse_plot_pad_amount(&y_sides[0]),
+          hi: parse_plot_pad_amount(&y_sides[1]),
+        },
+      };
+    }
+    return PlotRangePaddingSpec {
+      x: symmetric(parse_plot_pad_amount(&items[0])),
+      y: symmetric(parse_plot_pad_amount(&items[1])),
+    };
+  }
+  let amt = parse_plot_pad_amount(expr);
+  PlotRangePaddingSpec {
+    x: symmetric(amt),
+    y: symmetric(amt),
+  }
+}
+
 fn parse_background(expr: &Expr) -> Option<Color> {
   parse_color(expr)
 }
@@ -7101,6 +7183,10 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // they are collected only once the range is settled.
   let mut prolog: Option<Expr> = None;
   let mut epilog: Option<Expr> = None;
+  // `PlotRangePadding -> …`: extra room to leave around the effective plot
+  // range (the primitives' bounding box, or an explicit `PlotRange`).
+  // Unset keeps the existing flat-4%-on-automatic-axes default.
+  let mut plot_range_padding: Option<Expr> = None;
 
   for raw_opt in &args[1..] {
     let opt =
@@ -7130,6 +7216,9 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let (xr, yr) = parse_plot_range(replacement);
           plot_range_x = xr;
           plot_range_y = yr;
+        }
+        "PlotRangePadding" => {
+          plot_range_padding = Some(replacement.clone());
         }
         "Prolog" => prolog = Some(replacement.clone()),
         "Epilog" => epilog = Some(replacement.clone()),
@@ -7307,17 +7396,31 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
   }
 
-  // Apply 4% padding
-  bb = bb.with_padding(0.04);
-
-  // Apply PlotRange overrides
-  if let Some((lo, hi)) = plot_range_x {
-    bb.x_min = lo;
-    bb.x_max = hi;
-  }
-  if let Some((lo, hi)) = plot_range_y {
-    bb.y_min = lo;
-    bb.y_max = hi;
+  if let Some(padding_expr) = &plot_range_padding {
+    // `PlotRangePadding` pads whatever the effective range ends up being,
+    // whether that came from the primitives' automatic bounding box or an
+    // explicit `PlotRange`.
+    let (x_min, x_max) = plot_range_x.unwrap_or((bb.x_min, bb.x_max));
+    let (y_min, y_max) = plot_range_y.unwrap_or((bb.y_min, bb.y_max));
+    let spec = parse_plot_range_padding(padding_expr);
+    let x_span = x_max - x_min;
+    let y_span = y_max - y_min;
+    bb.x_min = x_min - spec.x.lo.resolve(x_span, 0.04);
+    bb.x_max = x_max + spec.x.hi.resolve(x_span, 0.04);
+    bb.y_min = y_min - spec.y.lo.resolve(y_span, 0.04);
+    bb.y_max = y_max + spec.y.hi.resolve(y_span, 0.04);
+  } else {
+    // Default: flat 4% padding on automatically-computed axes; an axis
+    // pinned by an explicit `PlotRange` is drawn exactly, with no padding.
+    bb = bb.with_padding(0.04);
+    if let Some((lo, hi)) = plot_range_x {
+      bb.x_min = lo;
+      bb.x_max = hi;
+    }
+    if let Some((lo, hi)) = plot_range_y {
+      bb.y_min = lo;
+      bb.y_max = hi;
+    }
   }
 
   // The plot range is settled, so the Prolog's and Epilog's own primitives

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1743,6 +1743,135 @@ mod graphics {
       ));
     }
 
+    // `PlotRangePadding` was silently ignored (it wasn't parsed at all), so
+    // an explicit `PlotRange` always rendered with zero padding around it —
+    // found via a Demonstration's logo-shaped `Graphics` that relied on
+    // `PlotRangePadding -> 1` to leave visible margin around a narrow
+    // `PlotRange`; without it, the curves filled the frame edge to edge and
+    // were clipped. The point below sits exactly at the `PlotRange`
+    // corner, so its rendered pixel position directly shows how much
+    // padding was applied around that corner.
+    mod plot_range_padding {
+      use super::*;
+
+      /// The pixel `(cx, cy)` of the lone `<circle>` a single `Point[]`
+      /// renders as.
+      fn point_px(svg: &str) -> (f64, f64) {
+        let tag = svg.split("<circle ").nth(1).expect("a circle");
+        let attr = |name: &str| -> f64 {
+          tag
+            .split(&format!("{name}=\""))
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .unwrap_or_else(|| panic!("circle {name} in {tag}"))
+            .parse()
+            .unwrap_or_else(|_| panic!("numeric circle {name} in {tag}"))
+        };
+        (attr("cx"), attr("cy"))
+      }
+
+      // With no `PlotRangePadding`, an explicit `PlotRange` is drawn exactly
+      // (the existing default), so a point at its corner lands right on the
+      // image edge.
+      #[test]
+      fn unset_leaves_no_room() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           ImageSize -> {100, 100}, Axes -> False]",
+        );
+        let (cx, _) = point_px(&svg);
+        assert!(cx < 5.0, "expected the corner point flush left, cx={cx}");
+      }
+
+      // A plain number pads both axes by that many plot units on every
+      // side: `{0,1}` padded by 1 becomes `{-1,2}` (span 3), so the corner
+      // point sits a third of the way in.
+      #[test]
+      fn absolute_number_pads_both_axes() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           PlotRangePadding -> 1, ImageSize -> {100, 100}, Axes -> False]",
+        );
+        let (cx, _) = point_px(&svg);
+        assert!(
+          (28.0..39.0).contains(&cx),
+          "expected the point ~1/3 into the image (padded {{-1,2}} span), \
+           cx={cx}"
+        );
+      }
+
+      // `None` explicitly asks for zero padding — same as leaving the
+      // option unset.
+      #[test]
+      fn none_leaves_no_room() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           PlotRangePadding -> None, ImageSize -> {100, 100}, Axes -> False]",
+        );
+        let (cx, _) = point_px(&svg);
+        assert!(cx < 5.0, "expected the corner point flush left, cx={cx}");
+      }
+
+      // `Scaled[s]` pads by a fraction of the axis's own span. With a
+      // {0,1} range (span 1) and `Scaled[1]`, the padding equals the whole
+      // span, giving the same {-1,2} result as `PlotRangePadding -> 1`.
+      #[test]
+      fn scaled_pads_by_a_fraction_of_the_span() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           PlotRangePadding -> Scaled[1], ImageSize -> {100, 100}, Axes -> False]",
+        );
+        let (cx, _) = point_px(&svg);
+        assert!(
+          (28.0..39.0).contains(&cx),
+          "expected the point ~1/3 into the image (padded {{-1,2}} span), \
+           cx={cx}"
+        );
+      }
+
+      // `{xSpec, ySpec}` pads each axis independently: no room on x, a full
+      // unit on y, so the corner point stays flush on x but moves inward
+      // on y. `AspectRatio -> Full` keeps the two axes independently
+      // scaled — without it, a fixed square `ImageSize` re-expands the
+      // narrower (unpadded) axis to match the padded one, so the "no
+      // padding" side wouldn't actually measure as unpadded.
+      #[test]
+      fn per_axis_list_pads_each_axis_independently() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           PlotRangePadding -> {0, 1}, ImageSize -> {100, 100}, \
+           AspectRatio -> Full, Axes -> False]",
+        );
+        let (cx, cy) = point_px(&svg);
+        assert!(cx < 5.0, "expected no x padding, cx={cx}");
+        assert!(
+          (61.0..72.0).contains(&cy),
+          "expected the point ~1/3 into the image on y (padded {{-1,2}} \
+           span, y flipped so the low corner sits near the bottom), cy={cy}"
+        );
+      }
+
+      // The full per-side form `{{xMinPad, xMaxPad}, {yMinPad, yMaxPad}}`
+      // pads each side independently: padding only the max side of x
+      // shifts the whole (unpadded-on-min) axis without touching where the
+      // min-corner point lands. `AspectRatio -> Full` again keeps the axes
+      // independently scaled (see the comment above).
+      #[test]
+      fn full_per_side_form_only_pads_the_named_side() {
+        let svg = export_svg(
+          "Graphics[{Point[{0, 0}]}, PlotRange -> {{0, 1}, {0, 1}}, \
+           PlotRangePadding -> {{0, 2}, {0, 0}}, \
+           ImageSize -> {100, 100}, AspectRatio -> Full, Axes -> False]",
+        );
+        let (cx, cy) = point_px(&svg);
+        // x range becomes {0,3} (span 3): the min-corner point (x=0) still
+        // sits flush left since only the max side padded.
+        assert!(cx < 5.0, "expected the min corner flush left, cx={cx}");
+        // y wasn't padded at all.
+        assert!(cy > 95.0, "expected no y padding, cy={cy}");
+      }
+    }
+
     // `PlotRange -> r` (a bare number) means "r in all directions from the
     // origin", equivalent to `{{-r, r}, {-r, r}}` — found via a
     // Demonstration's polar-curve viewer, whose "zoom" slider shrinks the


### PR DESCRIPTION
## Summary

- `PlotRangePadding` was parsed nowhere in the `Graphics` rendering pipeline, so it was silently ignored — an explicit `PlotRange` always rendered with zero padding around it, regardless of the option.
- Found via testing Woxi Studio against a random Wolfram Demonstration whose logo-shaped `Graphics` relied on `PlotRangePadding` to keep its curves from touching the frame; without the fix, the shape rendered edge-to-edge and got clipped instead of showing the intended margin.
- Adds support for the documented forms: a plain number (absolute padding), `Scaled[s]` (fraction of the axis span), `None`, per-axis `{xSpec, ySpec}`, and the full per-side `{{xMin, xMax}, {yMin, yMax}}`.
- Leaves the existing default behavior (flat 4% padding on automatically-computed axes, none on an explicit `PlotRange`) unchanged when the option isn't given, so no existing snapshots/tests were affected.

## Test plan

- [x] Added 6 unit tests in `tests/interpreter_tests/graphics.rs` (`mod plot_range_padding`) covering: unset default, absolute number, `None`, `Scaled[]`, per-axis `{x,y}`, and full per-side `{{},{}}` forms.
- [x] `make test` — all 27,915 tests pass.
- [x] `make format`.
- [x] Verified visually via Woxi Studio's `dump_manipulate`/`rasterize_svg` example tools against the triggering Demonstration notebook — the rendered shape now shows correct margin instead of being cropped edge-to-edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019hSDqfheePgpQAfRXue1gU)_