### PR TITLE
Prefer negation to multiplying by +/-1

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4603,14 +4603,13 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
     let mut terms: Vec<Expr> = Vec::new();
     for j in 0..=k {
       let binom = crate::functions::binomial_coeff(k as i128, j as i128);
-      let sign = if j % 2 == 0 { 1i128 } else { -1 };
       let new_cos_power = cos_power + 2 * j;
       let new_power = new_cos_power + 1;
       let cos_power_expr =
         pow2(cos_f.clone(), Expr::Integer(new_power as i128));
-      // coefficient = binom * sign * (-1) / ((new_power) * a)
-      // = -binom * sign / (new_power * a)
-      let numer = -sign * binom;
+      // coefficient = binom * (-1)^j * (-1) / ((new_power) * a)
+      // = (-1)^{j+1} binom / (new_power * a)
+      let numer = if j % 2 == 0 { -binom } else { binom };
       let total_divisor =
         simplify(times2(Expr::Integer(new_power as i128), coeff.clone()));
       let term = if numer == 1 {
@@ -4639,12 +4638,11 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
     let mut terms: Vec<Expr> = Vec::new();
     for j in 0..=k {
       let binom = crate::functions::binomial_coeff(k as i128, j as i128);
-      let sign = if j % 2 == 0 { 1i128 } else { -1 };
       let new_sin_power = sin_power + 2 * j;
       let new_power = new_sin_power + 1;
       let sin_power_expr =
         pow2(sin_f.clone(), Expr::Integer(new_power as i128));
-      let numer = sign * binom;
+      let numer = if j % 2 != 0 { -binom } else { binom };
       let total_divisor =
         simplify(times2(Expr::Integer(new_power as i128), coeff.clone()));
       let term = if numer == 1 {
@@ -4813,15 +4811,10 @@ fn try_integrate_trig_quotient(
       terms.push(coeff_term(-1, 1, call1("Log", trig_pow("Cos", 1)), &coeff));
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
+        let numer = if j % 2 == 0 { -binom } else { binom };
         let denom = 2 * j as i128;
-        let sign = if j % 2 == 1 { 1 } else { -1 };
-        let (binom, denom) = rat_reduce(binom, denom);
-        terms.push(coeff_term(
-          sign * binom,
-          denom,
-          trig_pow("Cos", 2 * j),
-          &coeff,
-        ));
+        let (numer, denom) = rat_reduce(numer, denom);
+        terms.push(coeff_term(numer, denom, trig_pow("Cos", 2 * j), &coeff));
       }
     }
     return Some(call("Plus", terms));
@@ -4842,15 +4835,10 @@ fn try_integrate_trig_quotient(
       terms.push(coeff_term(1, 1, call1("Log", trig_pow("Sin", 1)), &coeff));
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
+        let numer = if j % 2 != 0 { -binom } else { binom };
         let denom = 2 * j as i128;
-        let sign = if j % 2 == 1 { -1 } else { 1 };
-        let (binom, denom) = rat_reduce(binom, denom);
-        terms.push(coeff_term(
-          sign * binom,
-          denom,
-          trig_pow("Sin", 2 * j),
-          &coeff,
-        ));
+        let (numer, denom) = rat_reduce(numer, denom);
+        terms.push(coeff_term(numer, denom, trig_pow("Sin", 2 * j), &coeff));
       }
     } else {
       // Even p ≥ 4 needs wolframscript's multiple-angle presentation.

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -533,10 +533,6 @@ fn gamma_incomplete_upper_int_a(
   } else {
     call("Plus", terms)
   };
-  let mut n_minus_1_factorial: i128 = 1;
-  for i in 2..n as i128 {
-    n_minus_1_factorial *= i;
-  }
   let exp_neg_z = Expr::FunctionCall {
     name: "Power".to_string(),
     args: vec![
@@ -545,13 +541,10 @@ fn gamma_incomplete_upper_int_a(
     ]
     .into(),
   };
-  let result = if n_minus_1_factorial == 1 {
+  let result = if factorial == 1 {
     call("Times", vec![exp_neg_z, sum])
   } else {
-    call(
-      "Times",
-      vec![Expr::Integer(n_minus_1_factorial), exp_neg_z, sum],
-    )
+    call("Times", vec![Expr::Integer(factorial), exp_neg_z, sum])
   };
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
@@ -699,10 +692,10 @@ pub fn gamma_fn(x: f64) -> f64 {
 /// Beta[z, a, b] = integral_0^z t^(a-1) (1 - t)^(b-1) dt
 /// Exact factorial as a BigInt, so Beta of larger integer arguments does not
 /// overflow i128 (e.g. Beta[20, 20] needs 39! ≈ 2×10^46).
-fn factorial_big(n: usize) -> BigInt {
+fn factorial_big(n: u64) -> BigInt {
   let mut result = BigInt::from(1);
   for i in 2..=n {
-    result *= i as u64;
+    result *= i;
   }
   result
 }
@@ -836,7 +829,7 @@ pub fn beta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           // When a, b are half-integers, Γ(n+1/2) = (2n)! sqrt(π) / (4^n n!)
           // So Gamma product has π, and if sum is integer, Γ(sum) is (sum-1)!
           // Beta = Γ(a)Γ(b) / (sum-1)!
-          let sum_int = (sum2 / 2) as usize;
+          let sum_int = (sum2 / 2) as u64;
           {
             let sum_fact = factorial_big(sum_int - 1);
             // Compute Γ(a) * Γ(b) / (sum-1)! where a, b are half-integers
@@ -1201,14 +1194,16 @@ fn gamma_half_integer_parts_big(k2: i128) -> Option<(BigInt, BigInt, i128)> {
     return None;
   }
   if k2 % 2 == 0 {
-    let m = (k2 / 2) as usize;
+    let m = (k2 / 2) as u64;
     Some((factorial_big(m - 1), BigInt::from(1), 0))
   } else {
-    let m = ((k2 - 1) / 2) as usize;
-    let two_m_fact = factorial_big(2 * m);
-    let m_fact = factorial_big(m);
-    let four_m = BigInt::from(4).pow(m as u32);
-    Some((two_m_fact, four_m * m_fact, 1))
+    let m = ((k2 - 1) / 2) as u64;
+    let mut numer = BigInt::from(1);
+    for i in (m + 1)..=(2 * m) {
+      numer *= i;
+    }
+    let denom = BigInt::from(4).pow(m as u32);
+    Some((numer, denom, 1))
   }
 }
 

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -4435,8 +4435,9 @@ pub fn binomial_coeff(n: i128, k: i128) -> i128 {
     if n >= 0 {
       return 0;
     }
-    let sign = if (n + k) % 2 == 0 { 1 } else { -1 };
-    return sign * binomial_coeff(-k - 1, -n - 1);
+    let negate = (n + k) % 2 != 0;
+    let r = binomial_coeff(-k - 1, -n - 1);
+    return if negate { -r } else { r };
   }
   if k == 0 {
     return 1;
@@ -4454,8 +4455,9 @@ pub fn binomial_coeff(n: i128, k: i128) -> i128 {
     result
   } else {
     // Generalized: Binomial[-n, k] = (-1)^k * Binomial[n+k-1, k]
-    let sign = if k % 2 == 0 { 1 } else { -1 };
-    sign * binomial_coeff(-n + k - 1, k)
+    let negate = k % 2 != 0;
+    let r = binomial_coeff(-n + k - 1, k);
+    if negate { -r } else { r }
   }
 }
 


### PR DESCRIPTION
This is a collection of old changes I wrote back in June and never submitted. Most of them are changes to use negation instead of multiplying by +/-1.

There's also a removal of an unnecessary factorial in gamma_incomplete_upper_int_a and an optimization to gamma_half_integer_parts_big to compute (2m)!/m! with fewer multiplications.