### PR TITLE
Fix Expectation/Variance gaps found via a random Demonstration

### DIFF
--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -3184,6 +3184,36 @@ fn cdf_extreme_value(
   eval(&pow2(e(), neg1(pow2(e(), ab))))
 }
 
+/// `Variance[GompertzMakehamDistribution[l, x0]]` for concrete numeric `l`,
+/// `x0`: Simpson's rule against the closed-form density (no elementary
+/// closed form exists for the second central moment), evaluated directly in
+/// `f64` rather than through the AST integrator so that repeated calls
+/// (e.g. from `FindRoot` fitting `l`/`x0` to a target mean/stdev) stay fast.
+/// The upper cutoff is extended until the CDF leaves negligible tail mass.
+fn gompertz_makeham_variance_numeric(l: f64, x0: f64, mean: f64) -> f64 {
+  let pdf = |x: f64| -> f64 {
+    let lx = l * x;
+    l * x0 * (lx + (1.0 - lx.exp()) * x0).exp()
+  };
+  let cdf = |x: f64| -> f64 { 1.0 - ((1.0 - (l * x).exp()) * x0).exp() };
+  let mut hi = mean.abs().max(1.0) * 4.0;
+  for _ in 0..200 {
+    if cdf(hi) > 1.0 - 1e-13 {
+      break;
+    }
+    hi *= 1.5;
+  }
+  let n = 4_000;
+  let dx = hi / n as f64;
+  let mut sum = 0.0;
+  for i in 0..=n {
+    let x = i as f64 * dx;
+    let weight = if i == 0 || i == n { 0.5 } else { 1.0 };
+    sum += weight * (x - mean).powi(2) * pdf(x);
+  }
+  sum * dx
+}
+
 // PDF[GompertzMakehamDistribution[l, x0], x] = Piecewise[{{E^(l*x + (1 - E^(l*x))*x0)*l*x0, x >= 0}}, 0]
 fn pdf_gompertz_makeham(
   dargs: &[Expr],
@@ -3858,56 +3888,61 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let var_name = vars.into_iter().next().unwrap();
 
-  // Compute E[f(x)] using known moment formulas
-  // First try to get mean and variance for common distributions
-  let (mean, variance) = distribution_mean_variance(dist_name, dargs)?;
+  // Compute E[f(x)] using known moment formulas when a closed form exists
+  // for this distribution. Distributions with no such formula (e.g. a
+  // TruncatedDistribution wrapping a distribution with no elementary
+  // variance) fall through to the symbolic/numerical paths below instead
+  // of aborting the whole computation.
+  let mean_variance = distribution_mean_variance(dist_name, dargs).ok();
 
-  // Check if expr is just the variable (E[x] = mean)
-  if matches!(expr, Expr::Identifier(n) if *n == var_name) {
-    return eval(&mean);
-  }
-
-  // Check if expr is x^2 (E[x^2] = Var + Mean^2)
-  if is_power_of_var(expr, &var_name, 2) {
-    // For LogNormal and Weibull, Var + Mean^2 does not simplify to the clean
-    // closed-form second moment (E^(2 m + 2 s^2), b^2 Gamma[1 + 2/a]), so use
-    // the raw-moment formula directly.
-    if matches!(
-      dist_name,
-      "LogNormalDistribution"
-        | "WeibullDistribution"
-        | "HalfNormalDistribution"
-    ) && let Some(raw) = distribution_raw_moment(dist_name, dargs, 2)
-    {
-      return Ok(raw);
+  if let Some((mean, variance)) = &mean_variance {
+    // Check if expr is just the variable (E[x] = mean)
+    if matches!(expr, Expr::Identifier(n) if *n == var_name) {
+      return eval(mean);
     }
-    let result = plus2(variance.clone(), pow2(mean.clone(), int(2)));
-    return eval(&result);
-  }
 
-  // Check for linear expressions: a*x + b
-  if let Some((a, b)) = extract_linear(expr, &var_name) {
-    // E[a*x + b] = a*E[x] + b
-    let result = plus2(times2(a, mean), b);
-    return eval(&result);
-  }
+    // Check if expr is x^2 (E[x^2] = Var + Mean^2)
+    if is_power_of_var(expr, &var_name, 2) {
+      // For LogNormal and Weibull, Var + Mean^2 does not simplify to the
+      // clean closed-form second moment (E^(2 m + 2 s^2), b^2 Gamma[1 +
+      // 2/a]), so use the raw-moment formula directly.
+      if matches!(
+        dist_name,
+        "LogNormalDistribution"
+          | "WeibullDistribution"
+          | "HalfNormalDistribution"
+      ) && let Some(raw) = distribution_raw_moment(dist_name, dargs, 2)
+      {
+        return Ok(raw);
+      }
+      let result = plus2(variance.clone(), pow2(mean.clone(), int(2)));
+      return eval(&result);
+    }
 
-  // MGF identity: E[c · Exp[t·x]] = c · MGF_X(t). Recognised for normal
-  // distributions where MGF(t) = exp(μ t + σ² t²/2), giving exact
-  // symbolic results like `3 Sqrt[E]` instead of numerical surrogates.
-  if dist_name == "NormalDistribution"
-    && let Some((c, t)) = extract_mgf_pattern(expr, &var_name)
-  {
-    let mu = mean.clone();
-    let sigma_sq = variance.clone();
-    // exponent = μ t + σ² t² / 2
-    let mu_t = times2(mu, t.clone());
-    let half = call("Rational", vec![int(1), int(2)]);
-    let sigma_sq_t_sq_half =
-      times2(times2(sigma_sq, pow2(t.clone(), int(2))), half);
-    let exponent = plus2(mu_t, sigma_sq_t_sq_half);
-    let mgf = pow2(Expr::Identifier("E".to_string()), exponent);
-    return eval(&times2(c, mgf));
+    // Check for linear expressions: a*x + b
+    if let Some((a, b)) = extract_linear(expr, &var_name) {
+      // E[a*x + b] = a*E[x] + b
+      let result = plus2(times2(a, mean.clone()), b);
+      return eval(&result);
+    }
+
+    // MGF identity: E[c · Exp[t·x]] = c · MGF_X(t). Recognised for normal
+    // distributions where MGF(t) = exp(μ t + σ² t²/2), giving exact
+    // symbolic results like `3 Sqrt[E]` instead of numerical surrogates.
+    if dist_name == "NormalDistribution"
+      && let Some((c, t)) = extract_mgf_pattern(expr, &var_name)
+    {
+      let mu = mean.clone();
+      let sigma_sq = variance.clone();
+      // exponent = μ t + σ² t² / 2
+      let mu_t = times2(mu, t.clone());
+      let half = call("Rational", vec![int(1), int(2)]);
+      let sigma_sq_t_sq_half =
+        times2(times2(sigma_sq.clone(), pow2(t.clone(), int(2))), half);
+      let exponent = plus2(mu_t, sigma_sq_t_sq_half);
+      let mgf = pow2(Expr::Identifier("E".to_string()), exponent);
+      return eval(&times2(c, mgf));
+    }
   }
 
   // Polynomial integrands: exact raw moments (the numerical fallback
@@ -5428,15 +5463,24 @@ pub fn distribution_mean_variance(
       let xi = dargs[1].clone();
       // Mean = (E^xi * Gamma[0, xi]) / lambda
       let gamma_0_xi = call("Gamma", vec![int(0), xi.clone()]);
-      let mean = div2(times2(pow2(e(), xi), gamma_0_xi), lambda.clone());
-      // Variance has no simple closed form in elementary functions;
-      // GompertzMakehamDistribution is intentionally absent from the
-      // Variance dispatch list, so this placeholder is never returned
-      // to the user. Provide an unevaluated stub so the tuple typechecks.
-      let var = call(
-        "Variance",
-        vec![unevaluated("GompertzMakehamDistribution", dargs)],
-      );
+      let mean =
+        div2(times2(pow2(e(), xi.clone()), gamma_0_xi), lambda.clone());
+      // The variance has no simple closed form in elementary functions. With
+      // concrete numeric parameters (as produced by, e.g., FindRoot fitting
+      // a distribution to a target mean/stdev), integrate the second central
+      // moment against the density numerically instead of leaving the whole
+      // computation stuck on a symbolic placeholder. With symbolic
+      // parameters it stays unevaluated, same as wolframscript.
+      let var = match (try_eval_to_f64(&lambda), try_eval_to_f64(&xi)) {
+        (Some(l), Some(x0)) if l != 0.0 => {
+          let mean_num = try_eval_to_f64(&eval(&mean)?).unwrap_or(0.0);
+          Expr::Real(gompertz_makeham_variance_numeric(l, x0, mean_num))
+        }
+        _ => call(
+          "Variance",
+          vec![unevaluated("GompertzMakehamDistribution", dargs)],
+        ),
+      };
       Ok((mean, var))
     }
     "FrechetDistribution" => {
@@ -6154,6 +6198,42 @@ fn contains_var(expr: &Expr, var: &str) -> bool {
   }
 }
 
+/// One side of a `TruncatedDistribution[{a, b}, base]` domain, as a finite
+/// `f64` usable as an integration bound. When `bound` is already a finite
+/// number, that value is used directly. Otherwise (an infinite bound, e.g.
+/// `{x0, Infinity}`) the base distribution's CDF is searched outward from
+/// `seed` — expanding the step on each probe — until it has captured all
+/// but `eps` of the tail on that side (`positive` selects which tail).
+/// Returns `None` if `base`'s CDF can't be evaluated numerically.
+fn truncated_side_bound(
+  bound: &Expr,
+  base: &Expr,
+  seed: f64,
+  positive: bool,
+  eps: f64,
+) -> Option<f64> {
+  if let Some(v) = try_eval_to_f64(bound)
+    && v.is_finite()
+  {
+    return Some(v);
+  }
+  let cdf_at = |x: f64| -> Option<f64> {
+    try_eval_to_f64(&cdf_ast(&[base.clone(), Expr::Real(x)]).ok()?)
+  };
+  let mut x = seed;
+  let mut step = 1.0_f64;
+  for _ in 0..200 {
+    x = if positive { x + step } else { x - step };
+    let c = cdf_at(x)?;
+    let reached = if positive { c > 1.0 - eps } else { c < eps };
+    step *= 1.5;
+    if reached {
+      break;
+    }
+  }
+  Some(x)
+}
+
 /// Numerical expectation via Monte Carlo or numerical integration.
 fn expectation_numerical(
   expr: &Expr,
@@ -6166,8 +6246,43 @@ fn expectation_numerical(
   // Get integration range and PDF for quadrature
   let n_points = 1000;
 
+  let unevaluated_result = || {
+    call(
+      "Expectation",
+      vec![
+        expr.clone(),
+        call(
+          "Distributed",
+          vec![
+            Expr::Identifier(var.to_string()),
+            unevaluated(dist_name, dargs),
+          ],
+        ),
+      ],
+    )
+  };
+
   // Determine integration bounds based on distribution
   let (lo, hi): (f64, f64) = match dist_name {
+    "TruncatedDistribution" if dargs.len() == 2 => {
+      let Expr::List(bounds) = &dargs[0] else {
+        return unevaluated_result();
+      };
+      if bounds.len() != 2 {
+        return unevaluated_result();
+      }
+      let base = &dargs[1];
+      let a_finite = try_eval_to_f64(&bounds[0]).filter(|v| v.is_finite());
+      let b_finite = try_eval_to_f64(&bounds[1]).filter(|v| v.is_finite());
+      let seed_lo = a_finite.unwrap_or_else(|| b_finite.unwrap_or(0.0) - 1.0);
+      let seed_hi = b_finite.unwrap_or_else(|| a_finite.unwrap_or(0.0) + 1.0);
+      let lo = truncated_side_bound(&bounds[0], base, seed_hi, false, 1e-12);
+      let hi = truncated_side_bound(&bounds[1], base, seed_lo, true, 1e-12);
+      match (lo, hi) {
+        (Some(lo), Some(hi)) if hi > lo => (lo, hi),
+        _ => return unevaluated_result(),
+      }
+    }
     "UniformDistribution" => {
       let (a, b) = match dargs.len() {
         0 => (0.0, 1.0),
@@ -6205,22 +6320,8 @@ fn expectation_numerical(
       };
       (mu - 6.0 * sigma, mu + 6.0 * sigma)
     }
-    _ => {
-      // Return unevaluated for unsupported distributions
-      return call(
-        "Expectation",
-        vec![
-          expr.clone(),
-          call(
-            "Distributed",
-            vec![
-              Expr::Identifier(var.to_string()),
-              unevaluated(dist_name, dargs),
-            ],
-          ),
-        ],
-      );
-    }
+    // Return unevaluated for unsupported distributions
+    _ => return unevaluated_result(),
   };
 
   // Numerical integration: E[f(x)] = integral f(x) * pdf(x) dx

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -1245,6 +1245,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         | "WeibullDistribution"
         | "FrechetDistribution"
         | "ExtremeValueDistribution"
+        | "GompertzMakehamDistribution"
         | "HalfNormalDistribution"
         | "HypoexponentialDistribution"
         | "CoxianDistribution"

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests/distributions.rs
+++ b/tests/interpreter_tests/distributions.rs
@@ -8360,6 +8360,38 @@ mod truncated_distribution {
     );
   }
 
+  // Regression: `Expectation`/`NExpectation` used to abort with "unsupported
+  // distribution TruncatedDistribution" whenever the base distribution had
+  // no closed-form Mean/Variance registered (e.g. a Wolfram Demonstration's
+  // `NExpectation[z, z \[Distributed] TruncatedDistribution[{x0, Infinity},
+  // GompertzMakehamDistribution[...]]]`), because the lookup error aborted
+  // the whole computation instead of falling through to the generic
+  // symbolic/numerical paths. `Expectation[x, x ~ dist]` must always agree
+  // with the already-tested `Mean[dist]` path.
+  #[test]
+  fn expectation_of_the_identity_matches_mean() {
+    assert_eq!(
+      interpret(&format!("Expectation[x, x \\[Distributed] {HALF}]")).unwrap(),
+      interpret(&format!("Mean[{HALF}]")).unwrap()
+    );
+  }
+
+  #[test]
+  fn nexpectation_over_an_infinite_truncation_falls_through_to_quadrature() {
+    // Same distribution as `a_continuous_base_integrates` (mean of a
+    // standard normal kept on [0, Infinity)), but reached through
+    // `NExpectation` instead of `Mean` — exercising the generic numerical
+    // fallback rather than the closed-form truncated-moment path.
+    let got = interpret(
+      "NExpectation[x, x \\[Distributed] TruncatedDistribution[{0, Infinity}, \
+       NormalDistribution[]]]",
+    )
+    .unwrap()
+    .parse::<f64>()
+    .unwrap();
+    assert!((got - 0.7978845608028654).abs() < 1e-3, "got {got}");
+  }
+
   // Rounded to dodge last-digit float noise in the normal CDF.
   #[test]
   fn a_normal_base_renormalizes_numerically() {

--- a/tests/miscellaneous_tests/list.rs
+++ b/tests/miscellaneous_tests/list.rs
@@ -2919,6 +2919,61 @@ mod list {
   }
 
   #[test]
+  fn gompertz_makeham_variance_numeric_via_quadrature() {
+    // The second central moment has no elementary closed form, so with
+    // concrete numeric parameters it is computed by numerical integration
+    // against the density instead of staying stuck on a symbolic
+    // placeholder (regression: this used to make `StandardDeviation` never
+    // evaluate to a number, which broke `FindRoot` calls that fit a
+    // GompertzMakehamDistribution to a target mean/stdev — e.g. a
+    // Wolfram Demonstration bootstrapping a mortality curve).
+    //
+    // wolframscript is unavailable in this environment, so this is instead
+    // cross-checked against an independent computation built from already
+    // separately-tested primitives: `E[X^2] - Mean^2` via `NIntegrate` over
+    // the (also separately tested) `PDF[GompertzMakehamDistribution[...]]`.
+    let variance =
+      interpret("Variance[GompertzMakehamDistribution[0.07, 0.004]]")
+        .unwrap()
+        .parse::<f64>()
+        .unwrap();
+    let cross_check = interpret(
+      "NIntegrate[x^2*PDF[GompertzMakehamDistribution[0.07, 0.004], x], \
+       {x, 0, 2000}] - Mean[GompertzMakehamDistribution[0.07, 0.004]]^2",
+    )
+    .unwrap()
+    .parse::<f64>()
+    .unwrap();
+    assert!(
+      (variance - cross_check).abs() < 1e-3,
+      "Variance = {variance}, cross-check = {cross_check}"
+    );
+
+    // StandardDeviation = Sqrt[Variance] and stays consistent with it.
+    let stdev =
+      interpret("StandardDeviation[GompertzMakehamDistribution[0.07, 0.004]]")
+        .unwrap()
+        .parse::<f64>()
+        .unwrap();
+    assert!(
+      (stdev * stdev - variance).abs() < 1e-6,
+      "stdev^2 = {}, variance = {variance}",
+      stdev * stdev
+    );
+  }
+
+  #[test]
+  fn gompertz_makeham_variance_stays_symbolic_for_symbolic_parameters() {
+    // With symbolic parameters, Variance still has no closed form and
+    // stays unevaluated (matching wolframscript) rather than attempting
+    // (and failing) numeric integration.
+    assert_eq!(
+      interpret("Variance[GompertzMakehamDistribution[l, x]]").unwrap(),
+      "Variance[GompertzMakehamDistribution[l, x]]"
+    );
+  }
+
+  #[test]
   fn extreme_value_zero_arg_form() {
     // Zero-arg form defaults to a = 0, b = 1.
     assert_eq!(


### PR DESCRIPTION
## Summary

Following the scheduled routine: fetched a random Wolfram Demonstration ("Multiplication of Hazard in Gompertz-Makeham Distributions") and checked whether Woxi Studio fully supports it.

Notebook parsing, cell extraction, and the `Manipulate` control panel (4 labeled sliders, a `Delimiter`, and a discrete visualization picker) all worked correctly out of the box. However, evaluating the Manipulate's body uncovered two real interpreter gaps:

- **`StandardDeviation[GompertzMakehamDistribution[...]]` never evaluated to a number**, even with concrete numeric parameters, because the distribution has no elementary closed-form variance and was simply left out of the `Variance` dispatch list. This broke the notebook's `FindRoot` call that fits the distribution to a target mean/stdev (`FindRoot` needs a real number at the starting point). Fix: fall back to a fast, direct `f64` numerical integration against the density when the parameters are numeric; stay symbolic otherwise (matching wolframscript's behavior for other distributions with no closed-form variance, e.g. `VonMisesDistribution`).
- **`Expectation`/`NExpectation` aborted outright** ("unsupported distribution ...") for *any* distribution lacking a closed-form mean/variance entry — including a `TruncatedDistribution` wrapping one — because the lookup error was propagated with `?` instead of falling through to the existing symbolic/numerical fallback paths already present later in the same function. Fix: make the fallthrough generic (not distribution-specific), and teach the numerical quadrature fallback to derive `TruncatedDistribution`'s integration bounds (including infinite ones) from the base distribution's CDF.

Both fixes are general — they apply to any distribution/expectation that hits these code paths, not just the one Demonstration that surfaced them. No verbatim notebook content was copied; the notebook itself needed no parser changes.

## Test plan

- [x] Added `gompertz_makeham_variance_numeric_via_quadrature` / `..._stays_symbolic_for_symbolic_parameters` (cross-checked the numeric result against an independent `NIntegrate`-based computation, since `wolframscript` isn't available in this environment)
- [x] Added `expectation_of_the_identity_matches_mean` / `nexpectation_over_an_infinite_truncation_falls_through_to_quadrature` to `tests/interpreter_tests/distributions.rs`
- [x] `make test` — all 27,933 tests pass
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_019Hh8nDnSkjnf9y6DWEsuUd)_