### PR TITLE
Fix clippy::approx_constant for Erf/Erfc's derivative constant

### DIFF
--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),


### PR DESCRIPTION
## Summary

- `make lint` (and CI's `lint` job) is currently red on `main`: a newer clippy release flags the hand-written `2/Sqrt[Pi]` literal in `unary_condition_number` (used by `Erf`/`Erfc`'s condition-number estimate) as an approximation of `std::f64::consts::FRAC_2_SQRT_PI`.
- Replaces the literal with the standard-library constant (same value, `1.1283791670955126`).

Found while investigating an unrelated CI failure on #739, which inherits this same base-branch failure.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes clean


---
_Generated by [Claude Code](https://claude.ai/code/session_019Hh8nDnSkjnf9y6DWEsuUd)_