### PR TITLE
Support RegionFunction in ContourPlot and DensityPlot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 # Unreleased
 
+- `ContourPlot` and `DensityPlot` honor `RegionFunction -> Function[{x, y,
+    z}, …]`, masking out grid cells where it is not `True` instead of
+    silently ignoring the option and filling the whole rectangular domain.
+    `Plot3D`/`ContourPlot3D` already supported `RegionFunction`; a
+    Wolfram Demonstration ("Steady-State Heat Conduction in an Annulus")
+    plotting its solution only over an annulus (`RegionFunction ->
+    Function[{x, y, z}, r1^2 < x^2 + y^2 < r2^2]`) rendered as a solid
+    square in Woxi Studio instead of the ring the physics is defined on.
+
 - `Dot` sums a vector/matrix product's terms in one `Plus` call instead of
     folding them pairwise. The pairwise fold re-flattened and re-collected
     the whole running sum on every term, turning an n-term dot product into

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1178,7 +1178,10 @@ struct MeshGrid {
 
 /// Sample a mesh function over the plot's grid and pick `count` evenly
 /// spaced levels across the values it takes — `MeshFunctions -> {10 #1 &}`
-/// with `Mesh -> 11` gives eleven lines of constant x.
+/// with `Mesh -> 11` gives eleven lines of constant x. `region_mask`, when
+/// given, is the main plot's already `RegionFunction`-masked grid (NaN
+/// outside the region): a cell excluded there is excluded here too, so mesh
+/// lines don't spill past the region boundary the contours/bands stop at.
 #[allow(clippy::too_many_arguments)]
 fn sample_mesh_grid(
   f: &Expr,
@@ -1189,6 +1192,7 @@ fn sample_mesh_grid(
   y_min: f64,
   y_max: f64,
   count: usize,
+  region_mask: Option<&[Vec<f64>]>,
 ) -> Option<MeshGrid> {
   let n = FIELD_GRID + 1;
   let mut grid = vec![vec![f64::NAN; n]; n];
@@ -1197,6 +1201,12 @@ fn sample_mesh_grid(
     let x = x_min + i as f64 / FIELD_GRID as f64 * (x_max - x_min);
     for j in 0..n {
       let y = y_min + j as f64 / FIELD_GRID as f64 * (y_max - y_min);
+      let masked = region_mask
+        .and_then(|m| m.get(i).and_then(|row| row.get(j)))
+        .is_some_and(|v| !v.is_finite());
+      if masked {
+        continue;
+      }
       // A mesh function is usually a pure function of the two
       // coordinates (`10 #1 &`); a plain expression in x and y works too.
       let v = mesh_function_value(f, xvar, yvar, x, y)?;
@@ -1448,7 +1458,17 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       functions
         .iter()
         .filter_map(|f| {
-          sample_mesh_grid(f, &xvar, &yvar, x_min, x_max, y_min, y_max, count)
+          sample_mesh_grid(
+            f,
+            &xvar,
+            &yvar,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            count,
+            Some(&grid),
+          )
         })
         .collect()
     }
@@ -1701,6 +1721,10 @@ fn contour_plot_equations(
         let y = y_min + j as f64 / FIELD_GRID as f64 * (y_max - y_min);
         if let Some(v) = evaluate_at_xy(body, &xvar, &yvar, x, y)
           && v.is_finite()
+          && opts
+            .region_function
+            .as_ref()
+            .is_none_or(|r| region_allows(r, x, y, v))
         {
           *cell = v;
           any_finite = true;

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -213,6 +213,10 @@ struct DensityContourOptions {
   /// `PlotLabel -> …`: the caption drawn above the plot, already typeset
   /// as SVG markup, alongside the font size its outer `Style` asked for.
   plot_label: Option<(String, Option<f64>)>,
+  /// `RegionFunction -> f`: keep only grid cells where `f[x, y, z]` (the
+  /// plotted value `z`) is `True`; other cells are left blank, matching
+  /// `Plot3D`/`ContourPlot3D`'s `RegionFunction`.
+  region_function: Option<Expr>,
 }
 
 /// Parse ImageSize, ColorFunction, Contours, ContourShading, Mesh,
@@ -230,6 +234,7 @@ fn parse_density_contour_options(
   let mut contour_style = None;
   let mut frame_labels = crate::functions::plot::FrameLabels::default();
   let mut epilog: Vec<Expr> = Vec::new();
+  let mut region_function: Option<Expr> = None;
   for opt in &args[start..] {
     if let Expr::Rule {
       pattern,
@@ -314,6 +319,9 @@ fn parse_density_contour_options(
             other => vec![other],
           };
         }
+        "RegionFunction" => {
+          region_function = Some(replacement.clone());
+        }
         _ => {}
       }
     }
@@ -331,7 +339,23 @@ fn parse_density_contour_options(
     frame_labels,
     epilog,
     plot_label: parse_field_plot_label(args, start),
+    region_function,
   }
+}
+
+/// Whether `(x, y, z)` satisfies `region`, a `RegionFunction ->
+/// Function[{x, y, z}, …]` value: called positionally exactly like
+/// `Plot3D`/`ContourPlot3D`'s region function, so it does not need the
+/// plot's own x/y variable names substituted in first.
+fn region_allows(region: &Expr, x: f64, y: f64, z: f64) -> bool {
+  let call = Expr::CurriedCall {
+    func: Box::new(region.clone()),
+    args: vec![Expr::Real(x), Expr::Real(y), Expr::Real(z)],
+  };
+  matches!(
+    evaluate_expr_to_expr(&call),
+    Ok(Expr::Identifier(ref s)) if s == "True"
+  )
 }
 
 impl DensityContourOptions {
@@ -1267,6 +1291,10 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let y = y_min + (j as f64 + 0.5) / FIELD_GRID as f64 * (y_max - y_min);
       if let Some(v) = evaluate_at_xy(body, &xvar, &yvar, x, y)
         && v.is_finite()
+        && opts
+          .region_function
+          .as_ref()
+          .is_none_or(|r| region_allows(r, x, y, v))
       {
         grid[i][j] = v;
         samples.push(v);
@@ -1385,6 +1413,10 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let y = y_min + j as f64 / FIELD_GRID as f64 * (y_max - y_min);
       if let Some(v) = evaluate_at_xy(body, &xvar, &yvar, x, y)
         && v.is_finite()
+        && opts
+          .region_function
+          .as_ref()
+          .is_none_or(|r| region_allows(r, x, y, v))
       {
         grid[i][j] = v;
         samples.push(v);

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11037,6 +11037,38 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    /// `RegionFunction` also restricts the equation form
+    /// (`ContourPlot[lhs == rhs, …]`, drawn by `contour_plot_equations`, a
+    /// separate code path from the function form above): a circle clipped
+    /// to `x > 0` must only draw its right half.
+    #[test]
+    fn contour_plot_equation_region_function_restricts_curve() {
+      let result = interpret(
+        "pts = Flatten[Cases[ContourPlot[x^2 + y^2 == 1, {x, -2, 2}, \
+         {y, -2, 2}, RegionFunction -> Function[{x, y, z}, x > 0]][[1]], \
+         _Line, Infinity][[All, 1]], 1]; \
+         {Length[pts] > 0, AllTrue[pts, #[[1]] > -0.1 &]}",
+      )
+      .unwrap();
+      assert_eq!(result, "{True, True}", "result: {result}");
+    }
+
+    /// `Mesh -> n` grid lines must stop at the same `RegionFunction`
+    /// boundary as the contour bands/lines, not spill across the whole
+    /// rectangular domain.
+    #[test]
+    fn contour_plot_mesh_respects_region_function() {
+      let result = interpret(
+        "pts = Flatten[Cases[ContourPlot[x + y, {x, 0, 4}, {y, 0, 4}, \
+         RegionFunction -> Function[{x, y, z}, 4 < x^2 + y^2 < 16], \
+         Mesh -> 10][[1]], _Line, Infinity][[All, 1]], 1]; \
+         {Length[pts] > 0, \
+          AllTrue[pts, (r2 = #[[1]]^2 + #[[2]]^2; 4 - 0.3 <= r2 <= 16 + 0.3) &]}",
+      )
+      .unwrap();
+      assert_eq!(result, "{True, True}", "result: {result}");
+    }
+
     /// `ContourStyle` colours and thickens the contour lines. Both the
     /// function form and the equation form draw through it — the equation
     /// form is how a Demonstration draws a stability boundary.

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -10927,6 +10927,38 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       ));
     }
 
+    /// `RegionFunction -> Function[{x, y, z}, …]` masks out grid cells
+    /// where it is `False`, matching `Plot3D`/`ContourPlot3D`'s option of
+    /// the same name. A region excluding the whole domain leaves no
+    /// sample behind, so no `<image>` bitmap is embedded at all — the
+    /// same as a plot with nothing to draw.
+    #[test]
+    fn density_plot_region_function_excludes_everything() {
+      let svg = export_svg(
+        "DensityPlot[x + y, {x, 0, 1}, {y, 0, 1}, \
+         RegionFunction -> Function[{x, y, z}, False]]",
+      );
+      assert!(
+        !svg.contains("<image"),
+        "expected no embedded bitmap, got: {svg}"
+      );
+    }
+
+    /// A region excluding only part of the domain still renders the
+    /// allowed part (regression: `RegionFunction` used to be silently
+    /// ignored by `DensityPlot`/`ContourPlot`, filling the whole grid).
+    #[test]
+    fn density_plot_region_function_keeps_partial_region() {
+      let svg = export_svg(
+        "DensityPlot[x + y, {x, 0, 4}, {y, 0, 4}, \
+         RegionFunction -> Function[{x, y, z}, 4 < x^2 + y^2 < 16]]",
+      );
+      assert!(
+        svg.contains("<image"),
+        "expected an embedded bitmap, got: {svg}"
+      );
+    }
+
     #[test]
     fn contour_plot_basic() {
       insta::assert_snapshot!(export_svg(
@@ -10967,6 +10999,41 @@ ParametricPlot[f[t], {t, 0, 1}]]",
         polyline_count > 1,
         "expected multiple contour polylines away from the pole, got {polyline_count}: {}",
         &svg[..svg.len().min(300)]
+      );
+    }
+
+    /// `RegionFunction -> Function[{x, y, z}, …]` restricts the plot to
+    /// grid cells where it is `True` — the annulus a "Steady-State Heat
+    /// Conduction in an Annulus" style Demonstration draws its ContourPlot
+    /// over. Every filled band's polygon point must fall inside the ring
+    /// (loosened by one grid cell's diagonal to absorb marching-squares
+    /// interpolation right at the boundary), and there must be at least
+    /// one such point.
+    #[test]
+    fn contour_plot_region_function_restricts_grid() {
+      let result = interpret(
+        "pts = Flatten[Cases[ContourPlot[x + y, {x, 0, 4}, {y, 0, 4}, \
+         RegionFunction -> Function[{x, y, z}, 4 < x^2 + y^2 < 16]][[1]], \
+         _Polygon, Infinity][[All, 1]], 1]; \
+         {Length[pts] > 0, \
+          AllTrue[pts, (r2 = #[[1]]^2 + #[[2]]^2; 4 - 0.3 <= r2 <= 16 + 0.3) &]}",
+      )
+      .unwrap();
+      assert_eq!(result, "{True, True}", "result: {result}");
+    }
+
+    /// A `RegionFunction` that excludes the whole domain leaves no sample
+    /// behind, matching a plot whose function is undefined everywhere —
+    /// no filled bands, no contour lines.
+    #[test]
+    fn contour_plot_region_function_excludes_everything() {
+      let svg = export_svg(
+        "ContourPlot[x + y, {x, 0, 1}, {y, 0, 1}, \
+         RegionFunction -> Function[{x, y, z}, False]]",
+      );
+      assert!(
+        !svg.contains("<polyline") && !svg.contains("<polygon"),
+        "expected a blank plot, got: {svg}"
       );
     }
 


### PR DESCRIPTION
## Summary

- Fetched a random Wolfram Demonstration ("Steady-State Heat Conduction in an Annulus") and checked whether Woxi Studio fully supports it.
- Its `ContourPlot` restricts the plotted domain to an annulus via `RegionFunction -> Function[{x, y, z}, r1^2 < x^2 + y^2 < r2^2]`. That option was already implemented for `Plot3D`/`ContourPlot3D`, but the 2D field-plot grid sampler (`src/functions/field_plot.rs`) silently ignored it, so the Demonstration rendered as a solid filled square in Woxi Studio instead of the ring the physics is actually defined on.
- Added a `region_function` field to `DensityContourOptions`, parsed the `RegionFunction` option, and masked grid cells outside the region (same calling convention as `Plot3D`'s `RegionFunction`, called positionally with `{x, y, z}`) in both `contour_plot_ast` and `density_plot_ast`.
- Verified against the actual Demonstration notebook via `woxi-studio`'s `dump_manipulate`/`rasterize_svg` examples: the rendered contour plot now shows the correct quarter-annulus shape with the expected temperature field, matching the physics.

## Test plan

- [x] Added regression unit tests in `tests/interpreter_tests/graphics.rs`:
  - `contour_plot_region_function_restricts_grid` — polygon points from a `RegionFunction`-restricted `ContourPlot` all fall inside the specified annulus.
  - `contour_plot_region_function_excludes_everything` — a region excluding the whole domain renders a blank plot.
  - `density_plot_region_function_excludes_everything` / `density_plot_region_function_keeps_partial_region` — same coverage for `DensityPlot`.
- [x] `make test` (27,958 tests, all passing)
- [x] `make format`
- [x] Manually verified the fix against the downloaded Demonstration notebook by rasterizing the rendered SVG before/after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtSGBwbvGUJT4gX36nq6rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtSGBwbvGUJT4gX36nq6rp)_