### PR TITLE
Fix clippy approx_constant lint on TWO_OVER_SQRT_PI

### DIFF
--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),


### PR DESCRIPTION
## Summary

- `main`'s `lint` CI job is currently red (e.g. [run 33540516038](https://github.com/ad-si/Woxi/actions/runs/33540516038/job/99965310561), commit `bc0003d`): a newer clippy flags the hand-written `2/Sqrt[Pi]` literal in `unary_condition_number` (`src/functions/math_ast/trigonometric.rs`) as an approximation of `std::f64::consts::FRAC_2_SQRT_PI`.
- Use the std constant directly instead of duplicating its value, matching clippy's own suggested fix. The value is unchanged (`FRAC_2_SQRT_PI` is exactly `2/sqrt(pi)`).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (the exact CI lint command) passes clean.
- [x] Full workspace compiles (`cargo clippy` build succeeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtSGBwbvGUJT4gX36nq6rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtSGBwbvGUJT4gX36nq6rp)_