### PR TITLE
Fix VectorPlot/StreamPlot/StreamDensityPlot dropping PlotLabel

### DIFF
--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -99,16 +99,14 @@ fn parse_field_plot_label(
 /// with [`crate::functions::plot::generate_axes_only_opts`], so the top
 /// margin, tick-label areas, and font-size fallback all move together.
 fn field_plot_label_margins(
-  plot_label: &Option<(String, Option<f64>)>,
+  plot_label: Option<&(String, Option<f64>)>,
 ) -> Option<crate::functions::plot::MarginOverrides> {
-  plot_label
-    .as_ref()
-    .map(|(_, size)| crate::functions::plot::MarginOverrides {
-      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
-        * RESOLUTION_SCALE,
-      x_label_area: 40 * RESOLUTION_SCALE,
-      y_label_area: 65 * RESOLUTION_SCALE,
-    })
+  plot_label.map(|(_, size)| crate::functions::plot::MarginOverrides {
+    top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
+      * RESOLUTION_SCALE,
+    x_label_area: 40 * RESOLUTION_SCALE,
+    y_label_area: 65 * RESOLUTION_SCALE,
+  })
 }
 
 /// Split `Style[expr, …, n, …]` into its content and the font size `n`.
@@ -1797,7 +1795,7 @@ pub fn region_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let plot_label = parse_field_plot_label(args, 3);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = field_plot_label_margins(&plot_label);
+  let margins = field_plot_label_margins(plot_label.as_ref());
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -1977,7 +1975,7 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = field_plot_label_margins(&plot_label);
+  let margins = field_plot_label_margins(plot_label.as_ref());
   let mut area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -2147,7 +2145,7 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let plot_label = parse_field_plot_label(args, 3);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = field_plot_label_margins(&plot_label);
+  let margins = field_plot_label_margins(plot_label.as_ref());
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -2322,7 +2320,7 @@ pub fn stream_density_plot_ast(
   let (v_min, v_max) = robust_value_range(&mag_samples);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = field_plot_label_margins(&plot_label);
+  let margins = field_plot_label_margins(plot_label.as_ref());
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1945,6 +1945,7 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let body = resolved.as_ref().unwrap_or(&args[0]);
   let (svg_width, svg_height, full_width) = parse_field_options(args, 3);
   let epilog = parse_vector_plot_epilog(args, 3);
+  let plot_label = parse_field_plot_label(args, 3);
 
   let x_step = (x_max - x_min) / VECTOR_GRID as f64;
   let y_step = (y_max - y_min) / VECTOR_GRID as f64;
@@ -1964,18 +1965,31 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  // Use plotters for axes
-  let mut area = generate_axes_only(
+  // Use plotters for axes, reserving room above the frame for a PlotLabel.
+  let margins = plot_label.as_ref().map(|(_, size)| {
+    crate::functions::plot::MarginOverrides {
+      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
+        * RESOLUTION_SCALE,
+      x_label_area: 40 * RESOLUTION_SCALE,
+      y_label_area: 65 * RESOLUTION_SCALE,
+    }
+  });
+  let mut area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
     svg_width,
     svg_height,
     full_width,
+    None,
+    margins.as_ref(),
   )?;
 
   let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
+  }
+  if let Some(label) = &plot_label {
+    inject_field_plot_label(&mut svg, &area, label);
   }
 
   let cell_size =
@@ -2126,14 +2140,25 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   );
   let body = resolved.as_ref().unwrap_or(&args[0]);
   let (svg_width, svg_height, full_width) = parse_field_options(args, 3);
+  let plot_label = parse_field_plot_label(args, 3);
 
-  // Use plotters for axes
-  let area = generate_axes_only(
+  // Use plotters for axes, reserving room above the frame for a PlotLabel.
+  let margins = plot_label.as_ref().map(|(_, size)| {
+    crate::functions::plot::MarginOverrides {
+      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
+        * RESOLUTION_SCALE,
+      x_label_area: 40 * RESOLUTION_SCALE,
+      y_label_area: 65 * RESOLUTION_SCALE,
+    }
+  });
+  let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
     svg_width,
     svg_height,
     full_width,
+    None,
+    margins.as_ref(),
   )?;
 
   let plot_x0 = area.plot_x0;
@@ -2146,9 +2171,12 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let ay_min = area.y_min;
   let ay_max = area.y_max;
 
-  let mut svg = area.svg;
+  let mut svg = area.svg.clone();
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
+  }
+  if let Some(label) = &plot_label {
+    inject_field_plot_label(&mut svg, &area, label);
   }
 
   let to_px = |x: f64, y: f64| -> (f64, f64) {
@@ -2273,6 +2301,7 @@ pub fn stream_density_plot_ast(
   );
   let body = resolved.as_ref().unwrap_or(&args[0]);
   let (svg_width, svg_height, full_width) = parse_field_options(args, 3);
+  let plot_label = parse_field_plot_label(args, 3);
 
   let grid_n = 60;
 
@@ -2295,13 +2324,23 @@ pub fn stream_density_plot_ast(
   }
   let (v_min, v_max) = robust_value_range(&mag_samples);
 
-  // Use plotters for axes
-  let area = generate_axes_only(
+  // Use plotters for axes, reserving room above the frame for a PlotLabel.
+  let margins = plot_label.as_ref().map(|(_, size)| {
+    crate::functions::plot::MarginOverrides {
+      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
+        * RESOLUTION_SCALE,
+      x_label_area: 40 * RESOLUTION_SCALE,
+      y_label_area: 65 * RESOLUTION_SCALE,
+    }
+  });
+  let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
     svg_width,
     svg_height,
     full_width,
+    None,
+    margins.as_ref(),
   )?;
 
   let plot_x0 = area.plot_x0;
@@ -2314,9 +2353,12 @@ pub fn stream_density_plot_ast(
   let ay_min = area.y_min;
   let ay_max = area.y_max;
 
-  let mut svg = area.svg;
+  let mut svg = area.svg.clone();
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
+  }
+  if let Some(label) = &plot_label {
+    inject_field_plot_label(&mut svg, &area, label);
   }
 
   let to_px = |x: f64, y: f64| -> (f64, f64) {

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -93,6 +93,24 @@ fn parse_field_plot_label(
   })
 }
 
+/// The axes margins that leave room for a field plot's `PlotLabel`, or
+/// `None` when there is no label to draw (the caller then keeps plotters'
+/// default margins). Shared by every field plot that draws its own axes
+/// with [`crate::functions::plot::generate_axes_only_opts`], so the top
+/// margin, tick-label areas, and font-size fallback all move together.
+fn field_plot_label_margins(
+  plot_label: &Option<(String, Option<f64>)>,
+) -> Option<crate::functions::plot::MarginOverrides> {
+  plot_label
+    .as_ref()
+    .map(|(_, size)| crate::functions::plot::MarginOverrides {
+      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
+        * RESOLUTION_SCALE,
+      x_label_area: 40 * RESOLUTION_SCALE,
+      y_label_area: 65 * RESOLUTION_SCALE,
+    })
+}
+
 /// Split `Style[expr, …, n, …]` into its content and the font size `n`.
 fn peel_label_font_size(value: &Expr) -> (&Expr, Option<f64>) {
   let Expr::FunctionCall { name, args } = value else {
@@ -1779,14 +1797,7 @@ pub fn region_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let plot_label = parse_field_plot_label(args, 3);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = plot_label.as_ref().map(|(_, size)| {
-    crate::functions::plot::MarginOverrides {
-      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
-        * crate::functions::plot::RESOLUTION_SCALE,
-      x_label_area: 40 * crate::functions::plot::RESOLUTION_SCALE,
-      y_label_area: 65 * crate::functions::plot::RESOLUTION_SCALE,
-    }
-  });
+  let margins = field_plot_label_margins(&plot_label);
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -1966,14 +1977,7 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = plot_label.as_ref().map(|(_, size)| {
-    crate::functions::plot::MarginOverrides {
-      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
-        * RESOLUTION_SCALE,
-      x_label_area: 40 * RESOLUTION_SCALE,
-      y_label_area: 65 * RESOLUTION_SCALE,
-    }
-  });
+  let margins = field_plot_label_margins(&plot_label);
   let mut area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -2143,14 +2147,7 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let plot_label = parse_field_plot_label(args, 3);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = plot_label.as_ref().map(|(_, size)| {
-    crate::functions::plot::MarginOverrides {
-      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
-        * RESOLUTION_SCALE,
-      x_label_area: 40 * RESOLUTION_SCALE,
-      y_label_area: 65 * RESOLUTION_SCALE,
-    }
-  });
+  let margins = field_plot_label_margins(&plot_label);
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),
@@ -2325,14 +2322,7 @@ pub fn stream_density_plot_ast(
   let (v_min, v_max) = robust_value_range(&mag_samples);
 
   // Use plotters for axes, reserving room above the frame for a PlotLabel.
-  let margins = plot_label.as_ref().map(|(_, size)| {
-    crate::functions::plot::MarginOverrides {
-      top_margin: ((size.unwrap_or(14.0) * 2.0).round() as u32)
-        * RESOLUTION_SCALE,
-      x_label_area: 40 * RESOLUTION_SCALE,
-      y_label_area: 65 * RESOLUTION_SCALE,
-    }
-  });
+  let margins = field_plot_label_margins(&plot_label);
   let area = crate::functions::plot::generate_axes_only_opts(
     (x_min, x_max),
     (y_min, y_max),

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11212,6 +11212,20 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     }
 
     #[test]
+    fn vector_plot_plot_label_renders() {
+      // Regression: VectorPlot built its axes with `generate_axes_only`,
+      // which never reserved room for or drew a `PlotLabel` at all — unlike
+      // ContourPlot/DensityPlot/Plot, which already rendered it. A
+      // Demonstration's "plot type" switch (VectorPlot vs. ContourPlot vs.
+      // Plot3D, all fed the same PlotLabel) silently lost its title only on
+      // the vector-field branch.
+      let svg = export_svg(
+        "VectorPlot[{-y, x}, {x, -2, 2}, {y, -2, 2}, PlotLabel -> \"field\"]",
+      );
+      assert!(svg.contains(">field<"), "{svg}");
+    }
+
+    #[test]
     fn vector_plot3d_basic() {
       insta::assert_snapshot!(export_svg(
         "VectorPlot3D[{x, y, z}, {x, -1, 1}, {y, -1, 1}, {z, -1, 1}]"
@@ -11345,6 +11359,16 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       ));
     }
 
+    #[test]
+    fn stream_plot_plot_label_renders() {
+      // Regression: StreamPlot shared VectorPlot's `generate_axes_only`
+      // call, so it silently dropped `PlotLabel` the same way.
+      let svg = export_svg(
+        "StreamPlot[{-y, x}, {x, -2, 2}, {y, -2, 2}, PlotLabel -> \"flow\"]",
+      );
+      assert!(svg.contains(">flow<"), "{svg}");
+    }
+
     // Part 1 of a field plot is its graphics content, so a Demonstration can
     // lift the field into a `Graphics[{Opacity[…], StreamPlot[…][[1]]}]` of
     // its own instead of showing the plot on its own.
@@ -11419,6 +11443,17 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       insta::assert_snapshot!(export_svg(
         "StreamDensityPlot[{-y, x}, {x, -2, 2}, {y, -2, 2}]"
       ));
+    }
+
+    #[test]
+    fn stream_density_plot_plot_label_renders() {
+      // Regression: StreamDensityPlot shared VectorPlot's
+      // `generate_axes_only` call too, so it also silently dropped
+      // `PlotLabel`.
+      let svg = export_svg(
+        "StreamDensityPlot[{-y, x}, {x, -2, 2}, {y, -2, 2}, PlotLabel -> \"magnitude\"]",
+      );
+      assert!(svg.contains(">magnitude<"), "{svg}");
     }
 
     #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -24226,4 +24226,177 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ 
       degenerate.graphics
     );
   }
+
+  /// A randomly-sampled Wolfram Demonstrations Project notebook (Multipole
+  /// Fields) builds a `Sum` of point-source terms placed evenly around a
+  /// circle (count set by an integer slider with `Appearance -> "Labeled"`),
+  /// feeds it through a `Delimiter`-separated "plot type" popup whose three
+  /// choices are `Plot3D`, `(ContourPlot[SlotSequence[1], …] &)`, and a
+  /// `Quiet[VectorPlot[Evaluate[-{D[#, x], D[#, y]}], …]] &` gradient-field
+  /// function (the default), and switches `Mesh`/`MaxRecursion` via
+  /// `ControlActive[…, If[view === Plot3D, …]]` plus a `PlotLabel` that
+  /// names the source count through `ReplaceAll` against an integer table.
+  /// Woxi Studio already builds and drives this correctly; pin it down with
+  /// an independently written regression test covering the same construct
+  /// category (a ring of point sources instead of multipole terms,
+  /// different names, counts and labels throughout — not copied from the
+  /// original).
+  #[test]
+  fn demonstration_ring_source_field() {
+    let code = r#"Manipulate[
+  view$[Sum[1/Sqrt[(x - Cos[2. Pi (k/count$)])^2 + (y - Sin[2. Pi (k/count$)])^2], {k, 1, count$}],
+    {x, -2, 2}, {y, -2, 2},
+    PlotRange -> {-cap$, cap$}, MeshFunctions -> {#3 &}, Ticks -> None,
+    PlotRangePadding -> 0,
+    Mesh -> ControlActive[None, If[view$ === Plot3D, 12, None]],
+    MaxRecursion -> ControlActive[1, If[view$ === Plot3D, 3, 1]],
+    PlotLabel -> Style[
+      ReplaceAll[count$, {2 -> "binary", 3 -> "ternary", 4 -> "quaternary", 5 -> "quinary", 6 -> "senary"}],
+      "Label"],
+    ImageSize -> {400, 300}],
+  {{count$, 3, "source count"}, 2, 6, 1, Appearance -> "Labeled"}, Delimiter,
+  {{view$,
+     Quiet[VectorPlot[Evaluate[-{D[#, x], D[#, y]}], {x, -2, 2}, {y, -2, 2}, ImageSize -> {400, 300}, VectorPoints -> 15]] &,
+     "view mode"},
+   {Plot3D -> "surface",
+    (ContourPlot[SlotSequence[1], FrameTicks -> None] &) -> "contours",
+    (Quiet[VectorPlot[Evaluate[-{D[#, x], D[#, y]}], {x, -2, 2}, {y, -2, 2}, ImageSize -> {400, 300}, VectorPoints -> 15]] &) -> "gradient"}},
+  {{cap$, 8, "value cap"}, 4, 16}
+]"#;
+
+    let expr = woxi::interpret_to_expr(code).expect("parse/hold Manipulate");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a labeled slider, a Delimiter, a Rule-choice popup, and a plain slider should build a widget");
+    assert!(
+      state.error.is_none(),
+      "initial build failed: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state.controls.iter().map(|c| c.name()).collect::<Vec<_>>(),
+      vec!["count$", "", "view$", "cap$"],
+      "panel rows: source-count slider, the Delimiter as an unnamed row, the view-mode popup, the cap slider"
+    );
+    assert!(
+      matches!(state.controls[1], manipulate::ControlState::Divider),
+      "Delimiter must become a Divider row"
+    );
+    match &state.controls[2] {
+      manipulate::ControlState::Discrete {
+        values,
+        value_labels,
+        current_index,
+        ..
+      } => {
+        assert_eq!(
+          value_labels,
+          &vec!["surface", "contours", "gradient"],
+          "the three Rule labels, in source order"
+        );
+        // The default `view$` value is textually identical to the third
+        // choice's function, so it must resolve to that index.
+        assert_eq!(
+          *current_index, 2,
+          "the default gradient function must match the third choice"
+        );
+        assert!(
+          values[0] == "Plot3D",
+          "the first choice's bound value is the bare symbol Plot3D: {values:?}"
+        );
+      }
+      other => panic!("expected `view$` as a Discrete popup, got {other:?}"),
+    }
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+    };
+    let initial = render(&state);
+    assert!(
+      initial.graphics.is_some(),
+      "the default gradient-field view must render"
+    );
+    // The gradient-field choice's function only names `#` (the body), so
+    // Wolfram's Slot substitution drops every argument after the first —
+    // the outer PlotLabel/PlotRange/MeshFunctions never reach it, and this
+    // view's own hard-coded VectorPlot draws no title. Only the Plot3D and
+    // contour choices forward the full argument list (a bare symbol and
+    // `SlotSequence[1]` both pass everything through), so PlotLabel is
+    // checked after switching to one of those below.
+    assert!(
+      !initial
+        .graphics
+        .as_deref()
+        .unwrap_or_default()
+        .contains("ternary"),
+      "the gradient view's Slot-only function must not see the outer PlotLabel: {:?}",
+      initial.graphics
+    );
+
+    // Switch the view mode to the surface (Plot3D) choice and re-render.
+    for c in state.controls.iter_mut() {
+      if let manipulate::ControlState::Discrete {
+        name,
+        current_index,
+        ..
+      } = c
+        && name == "view$"
+      {
+        *current_index = 0;
+      }
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "switching to the Plot3D surface view must not error: {:?}",
+      state.error
+    );
+    let surface = render(&state);
+    assert!(
+      surface.graphics.is_some(),
+      "the Plot3D surface view must also render"
+    );
+    assert!(
+      surface
+        .graphics
+        .as_deref()
+        .unwrap_or_default()
+        .contains("ternary"),
+      "Plot3D receives the full argument list, so PlotLabel must report the source count (3 -> ternary): {:?}",
+      surface.graphics
+    );
+
+    // Move the source-count slider and confirm the PlotLabel tracks it.
+    for c in state.controls.iter_mut() {
+      if let manipulate::ControlState::Continuous { name, current, .. } = c
+        && name == "count$"
+      {
+        *current = 5.0;
+      }
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "moving the source-count slider must not error: {:?}",
+      state.error
+    );
+    let after = render(&state);
+    assert!(
+      after
+        .graphics
+        .as_deref()
+        .unwrap_or_default()
+        .contains("quinary"),
+      "PlotLabel must recompute after the slider moves (5 -> quinary): {:?}",
+      after.graphics
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Sampled a random Wolfram Demonstrations Project notebook ([Multipole Fields](https://demonstrations.wolfram.com/MultipoleFields/)) to check whether Woxi Studio fully supports it, per the recurring compatibility-check routine.
- Its `Manipulate` switches between `Plot3D`, `ContourPlot` and a `Quiet[VectorPlot[Evaluate[-{D[#, x], D[#, y]}], ...]] &` gradient-field view through a `Delimiter`-separated popup, with `PlotLabel` tracking a source-count slider via `ReplaceAll`. Woxi Studio already builds and drives the widget correctly (all controls, discrete popup choices, and re-evaluation all work), but along the way I found that `VectorPlot` (and the closely related `StreamPlot`/`StreamDensityPlot`) silently drop `PlotLabel` entirely — unlike `ContourPlot`/`DensityPlot`/`Plot`, which already render it correctly.
- Fixed by reserving margin above the plot for the label and injecting it, mirroring the pattern `RegionPlot` already uses.
- Pinned the fix down with an independently-written regression test in `woxi-studio` covering the same construct category (a ring of point sources instead of multipole terms, different names/counts/labels throughout — not copied from the original, per the project's copyright rule for Demonstrations content).

## Test plan
- [x] `cargo run -- eval 'ExportString[VectorPlot[{0, 0}, {x, -2, 2}, {y, -2, 2}, PlotLabel -> "hello"], "SVG"]'` now includes the label (previously missing)
- [x] Same check for `StreamPlot` and `StreamDensityPlot`
- [x] New regression test `demonstration_ring_source_field` in `woxi-studio/src/main.rs` passes
- [x] `make test` (`cargo nextest run`, 27,954 tests across the workspace) passes
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxpFfG3K9vFog54FqFQ6UE


---
_Generated by [Claude Code](https://claude.ai/code/session_01JxpFfG3K9vFog54FqFQ6UE)_