### PR TITLE
Fix clippy approx_constant lint blocking CI on main

### DIFF
--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),


### PR DESCRIPTION
## Summary
- `make lint` (`cargo clippy --all-targets -- -D warnings`) currently fails on `main` itself: the pinned toolchain's clippy now flags the hand-written `2/Sqrt[Pi]` literal in `unary_condition_number`'s Erf/Erfc branch as `clippy::approx_constant` (it's within float precision of `f64::consts::FRAC_2_SQRT_PI`).
- Discovered as a red `lint` check on an unrelated PR (#743); confirmed it reproduces identically on `main` at the same commit, so it isn't that PR's fault.
- Fix: use the named standard-library constant directly, as clippy suggests.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` (269 tests) passes
- [x] `cargo run -- eval 'N[Erf[1]]'` still returns `0.8427007929497149` (unchanged)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxpFfG3K9vFog54FqFQ6UE


---
_Generated by [Claude Code](https://claude.ai/code/session_01JxpFfG3K9vFog54FqFQ6UE)_