### PR TITLE
Generalize Sum[k^s,...] to any degree and add k^s*HarmonicNumber[k]

### DIFF
--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2111,10 +2111,18 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner_sum_raw = sum_ast(&[body_in_fresh, iter_spec])?;
     // `inner_sum_raw` may not have closed to a value (e.g. `PolyGamma`/`Sin`
     // have no Sum handling at all), in which case it still holds the fresh
-    // dummy variable inside an unevaluated `Sum[…]`. Substitute it back to
-    // the caller's own variable name before it can leak into either return
-    // path below, or a still-symbolic result exposes the internal
-    // `$sum_indef_…_$` name.
+    // dummy — as both the summand's argument and, inside the held
+    // `Sum[…]`'s own iterator spec, the bound variable name. Substituting
+    // the dummy back to the caller's variable in that case would let the
+    // bound variable shadow the free occurrence in its own upper bound
+    // (`Sum[f[k], {k, 1, -1 + k}]`), which is ill-formed — so hand back the
+    // original call unevaluated instead of a broken partial rewrite.
+    if crate::functions::polynomial_ast::contains_var(
+      &inner_sum_raw,
+      &fresh_name,
+    ) {
+      return Ok(unevaluated("Sum", args));
+    }
     let inner_sum = crate::syntax::substitute_variable(
       &inner_sum_raw,
       &fresh_name,

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2879,25 +2879,41 @@ fn try_symbolic_sum(
       let remainder = qr_list[1].clone();
       let n_minus_1 = plus2(max_expr.clone(), Expr::Integer(-1));
       let q_sum = sum_polynomial_over_var(&q_of_k, var_name, &n_minus_1)?;
-      let s_of_n = faulhaber_power_sum(s, max_expr)?;
-      let h_n = call1("HarmonicNumber", max_expr.clone());
-      // Keep the `HarmonicNumber[n]` coefficient and the plain polynomial
-      // remainder separate through `Factor` (`(S(n) - r) H_n + (r -
-      // Q(n-1))`), rather than expanding both into one `Plus` and factoring
-      // that blob — `Factor` has no way to regroup terms around the opaque
-      // `HarmonicNumber[n]` atom once they are mixed, so it would otherwise
-      // hand back the fully expanded (and far uglier) polynomial.
-      let h_coeff = crate::functions::polynomial_ast::factor_ast(&[
-        crate::evaluator::evaluate_expr_to_expr(&minus2(
-          s_of_n,
-          remainder.clone(),
-        ))?,
-      ])?;
-      let poly_part = crate::functions::polynomial_ast::factor_ast(&[
-        crate::evaluator::evaluate_expr_to_expr(&minus2(remainder, q_sum))?,
-      ])?;
+      // `S(k) = (k+1) q(k) + r` (the division above) holds for every `k`,
+      // so at `k = n` it gives `S(n) - r = (n+1) q(n)` without an explicit
+      // `S(n)` recomputation, and (used below) `(S(n)-r)/(n+1) = q(n)`.
+      let q_of_n = crate::evaluator::evaluate_expr_to_expr(
+        &crate::syntax::substitute_variable(&q_of_k, var_name, max_expr),
+      )?;
+      let n_plus_1 = plus2(max_expr.clone(), Expr::Integer(1));
+      // wolframscript states this identity with the *shifted* harmonic
+      // number `HarmonicNumber[n + 1]` rather than `HarmonicNumber[n]`
+      // (matching the convention already used elsewhere in this file, e.g.
+      // `Sum[1/k, k] = HarmonicNumber[-1 + k]`) — rewriting `H(n) = H(n+1)
+      // - 1/(n+1)` moves the coefficient of `H(n)` (`S(n) - r`) onto
+      // `H(n+1)` and folds the `-1/(n+1)` part into the polynomial
+      // remainder as `- (S(n)-r)/(n+1) = -q(n)`.
+      let h_coeff_raw = crate::evaluator::evaluate_expr_to_expr(&times2(
+        n_plus_1,
+        q_of_n.clone(),
+      ))?;
+      let poly_part_raw = crate::evaluator::evaluate_expr_to_expr(&minus2(
+        minus2(remainder, q_sum),
+        q_of_n,
+      ))?;
+      let h_n1 =
+        call1("HarmonicNumber", plus2(max_expr.clone(), Expr::Integer(1)));
+      // Keep the `HarmonicNumber[n+1]` coefficient and the plain polynomial
+      // remainder separate through `Factor` (`Factor` alone can't regroup
+      // terms around the opaque `HarmonicNumber[…]` atom once they're mixed
+      // into one `Plus`, so factoring the combined expression would hand
+      // back the fully expanded, far uglier polynomial instead).
+      let h_coeff =
+        crate::functions::polynomial_ast::factor_ast(&[h_coeff_raw])?;
+      let poly_part =
+        crate::functions::polynomial_ast::factor_ast(&[poly_part_raw])?;
       let result = crate::evaluator::evaluate_expr_to_expr(&plus2(
-        times2(h_coeff, h_n),
+        times2(h_coeff, h_n1),
         poly_part,
       ))?;
       return Ok(Some(result));

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2014,6 +2014,14 @@ fn strip_alternating_factor(body: &Expr, var: &str) -> Option<Expr> {
   })
 }
 
+/// True for `Indeterminate`, `ComplexInfinity`, or a `DirectedInfinity[…]` —
+/// the markers a division or a pole (`1/0`, `PolyGamma[0]`, …) evaluates to,
+/// rather than raising an `InterpreterError`.
+fn is_nonfinite_boundary_value(expr: &Expr) -> bool {
+  matches!(expr, Expr::Identifier(s) if s == "Indeterminate" || s == "ComplexInfinity")
+    || matches!(expr, Expr::FunctionCall { name, .. } if name == "DirectedInfinity")
+}
+
 pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 {
     // Sum requires at least 2 arguments
@@ -2067,10 +2075,18 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let iter_spec =
       Expr::List(vec![fresh.clone(), Expr::Integer(1), upper].into());
     let inner_sum = sum_ast(&[body_in_fresh, iter_spec])?;
-    // Evaluate f(0)
+    // Evaluate f(0). A summand with a genuine pole at 0 (`1/k`,
+    // `PolyGamma[k]`, …) makes this boundary term non-finite even though
+    // the antidifference itself is perfectly well defined there (e.g.
+    // `Sum[1/i, i]` closes to `HarmonicNumber[i - 1]`, matching wolframscript,
+    // which is exactly `inner_sum` alone) — so a non-finite f(0) is dropped
+    // rather than poisoning the whole result through `Plus`.
     let f_at_zero =
       crate::syntax::substitute_variable(&args[0], var_name, &Expr::Integer(0));
     let f_at_zero_eval = crate::evaluator::evaluate_expr_to_expr(&f_at_zero)?;
+    if is_nonfinite_boundary_value(&f_at_zero_eval) {
+      return Ok(inner_sum);
+    }
     return crate::functions::math_ast::plus_ast(&[f_at_zero_eval, inner_sum]);
   }
 
@@ -2433,6 +2449,111 @@ fn collect_times_factors(e: &Expr, out: &mut Vec<Expr>) {
   }
 }
 
+/// The exponent `s` of a monomial `var^s` in the summation variable, with a
+/// bare `var` read as `s = 1`. `None` when `f` is not a power of `var` with
+/// a concrete integer exponent.
+fn monomial_power_of_var(f: &Expr, var_name: &str) -> Option<i128> {
+  match f {
+    Expr::Identifier(name) if name == var_name => Some(1),
+    Expr::BinaryOp {
+      op: BinaryOperator::Power,
+      left,
+      right,
+    } if matches!(left.as_ref(), Expr::Identifier(name) if name == var_name) => {
+      match right.as_ref() {
+        Expr::Integer(s) => Some(*s),
+        _ => None,
+      }
+    }
+    _ => None,
+  }
+}
+
+/// `Sum_{k=1}^{upper} k^s`, as a raw (unfactored) polynomial expression in
+/// `upper`, via Faulhaber's formula with Bernoulli numbers:
+/// `1/(s+1) * Sum_{j=0}^s Binomial[s+1, j] BernoulliB[j] (upper+1)^(s+1-j)`.
+fn faulhaber_power_sum(
+  s: i128,
+  upper: &Expr,
+) -> Result<Expr, InterpreterError> {
+  let upper_plus_1 = plus2(upper.clone(), Expr::Integer(1));
+  let mut terms: Vec<Expr> = Vec::with_capacity((s + 1) as usize);
+  for j in 0..=s {
+    let bern =
+      crate::functions::math_ast::bernoulli_b_ast(&[Expr::Integer(j)])?;
+    // Every odd Bernoulli number past B_1 is zero; skip those terms.
+    if matches!(&bern, Expr::Integer(0)) {
+      continue;
+    }
+    let binom = crate::functions::math_ast::binomial_ast(&[
+      Expr::Integer(s + 1),
+      Expr::Integer(j),
+    ])?;
+    let power_term = pow2(upper_plus_1.clone(), Expr::Integer(s + 1 - j));
+    terms.push(times2(times2(binom, bern), power_term));
+  }
+  let raw = div2(call("Plus", terms), Expr::Integer(s + 1));
+  crate::evaluator::evaluate_expr_to_expr(&raw)
+}
+
+/// The exponent `s` when `body` is exactly `var^s * HarmonicNumber[var]`
+/// (either factor order; a bare `var` factor reads as `s = 1`). `None` for
+/// any other shape, including a `HarmonicNumber` with a second (order)
+/// argument.
+fn monomial_times_single_harmonic(body: &Expr, var_name: &str) -> Option<i128> {
+  let factors =
+    crate::functions::polynomial_ast::collect_multiplicative_factors(body);
+  if factors.len() != 2 {
+    return None;
+  }
+  let is_harmonic = |e: &Expr| {
+    matches!(e, Expr::FunctionCall { name, args }
+      if name == "HarmonicNumber"
+        && args.len() == 1
+        && matches!(&args[0], Expr::Identifier(v) if v == var_name))
+  };
+  if is_harmonic(&factors[0]) {
+    monomial_power_of_var(&factors[1], var_name)
+  } else if is_harmonic(&factors[1]) {
+    monomial_power_of_var(&factors[0], var_name)
+  } else {
+    None
+  }
+}
+
+/// `Sum_{k=1}^{upper} poly(k)` for an arbitrary univariate polynomial `poly`
+/// in `var_name`, by summing each of its monomial terms through
+/// `faulhaber_power_sum` (the constant term contributes `c_0 * upper`).
+fn sum_polynomial_over_var(
+  poly: &Expr,
+  var_name: &str,
+  upper: &Expr,
+) -> Result<Expr, InterpreterError> {
+  let coeffs = crate::functions::polynomial_ast::coefficient_list_ast(&[
+    poly.clone(),
+    Expr::Identifier(var_name.to_string()),
+  ])?;
+  let Expr::List(ref items) = coeffs else {
+    return crate::evaluator::evaluate_expr_to_expr(&Expr::Integer(0));
+  };
+  let mut terms: Vec<Expr> = Vec::new();
+  for (degree, coeff) in items.iter().enumerate() {
+    if matches!(coeff, Expr::Integer(0)) {
+      continue;
+    }
+    let piece = if degree == 0 {
+      times2(coeff.clone(), upper.clone())
+    } else {
+      times2(coeff.clone(), faulhaber_power_sum(degree as i128, upper)?)
+    };
+    terms.push(piece);
+  }
+  if terms.is_empty() {
+    return Ok(Expr::Integer(0));
+  }
+  crate::evaluator::evaluate_expr_to_expr(&call("Plus", terms))
+}
+
 /// If `f` is `base^var` (in either Power spelling), return `base`.
 fn power_with_exponent_var(f: &Expr, var_name: &str) -> Option<Expr> {
   match f {
@@ -2668,109 +2789,77 @@ fn try_symbolic_sum(
     return Ok(Some(result));
   }
 
-  // Sum[k, {k, 1, n}] = n*(1 + n)/2
+  // Sum[k^s, {k, 1, n}] = Faulhaber's formula, for any concrete positive
+  // integer power s (a bare `k` counts as s = 1). The raw expansion is
+  // handed to `Factor` so the printed form matches wolframscript's own
+  // canonical grouping (verified for s = 2..5 against the previously
+  // hand-derived formulas here — e.g. `Factor[n^3/3 + n^2/2 + n/6]`
+  // reproduces `n*(1+n)*(1+2*n)/6` exactly) instead of one hardcoded
+  // closed form per degree.
+  if let Some(1) = min_concrete
+    && let Some(s) = monomial_power_of_var(body, var_name)
+    && (1..=64).contains(&s)
+  {
+    let evaluated = faulhaber_power_sum(s, max_expr)?;
+    let factored = crate::functions::polynomial_ast::factor_ast(&[evaluated])?;
+    return Ok(Some(factored));
+  }
+
+  // Sum[k^s * HarmonicNumber[k], {k, 1, n}] via discrete summation by parts
+  // (the technique the "Summation by Parts" Demonstration illustrates):
+  // with S(x) = Sum_{k=1}^x k^s and ΔH_k = H_{k+1} - H_k = 1/(k+1),
+  //   Sum_{k=1}^n k^s H_k = S(n) H_n - Sum_{k=1}^{n-1} S(k)/(k+1).
+  // Dividing S(k) by (k+1) gives S(k) = (k+1) q(k) + r, where the remainder
+  // r = S(-1) is a constant, so
+  //   Sum_{k=1}^{n-1} S(k)/(k+1) = Sum_{k=1}^{n-1} q(k) + r (H_n - 1),
+  // and Sum_{k=1}^{n-1} q(k) closes term-by-term through the same Faulhaber
+  // formula (q has degree s, one less than S). Verified numerically against
+  // the brute-force sum for many (s, n) pairs, and the s = 2..5 cases here
+  // print through the same `Factor` pass validated above.
+  if let Some(1) = min_concrete
+    && let Some(s) = monomial_times_single_harmonic(body, var_name)
+    && (1..=64).contains(&s)
+  {
+    let k = Expr::Identifier(var_name.to_string());
+    let s_of_k = faulhaber_power_sum(s, &k)?;
+    let k_plus_1 = plus2(k.clone(), Expr::Integer(1));
+    let qr =
+      crate::functions::polynomial_ast::polynomial_quotient_remainder_ast(&[
+        s_of_k, k_plus_1, k,
+      ])?;
+    if let Expr::List(ref qr_list) = qr
+      && qr_list.len() == 2
+    {
+      let q_of_k = qr_list[0].clone();
+      let remainder = qr_list[1].clone();
+      let n_minus_1 = plus2(max_expr.clone(), Expr::Integer(-1));
+      let q_sum = sum_polynomial_over_var(&q_of_k, var_name, &n_minus_1)?;
+      let s_of_n = faulhaber_power_sum(s, max_expr)?;
+      let h_n = call1("HarmonicNumber", max_expr.clone());
+      // Keep the `HarmonicNumber[n]` coefficient and the plain polynomial
+      // remainder separate through `Factor` (`(S(n) - r) H_n + (r -
+      // Q(n-1))`), rather than expanding both into one `Plus` and factoring
+      // that blob — `Factor` has no way to regroup terms around the opaque
+      // `HarmonicNumber[n]` atom once they are mixed, so it would otherwise
+      // hand back the fully expanded (and far uglier) polynomial.
+      let h_coeff = crate::functions::polynomial_ast::factor_ast(&[
+        crate::evaluator::evaluate_expr_to_expr(&minus2(
+          s_of_n,
+          remainder.clone(),
+        ))?,
+      ])?;
+      let poly_part = crate::functions::polynomial_ast::factor_ast(&[
+        crate::evaluator::evaluate_expr_to_expr(&minus2(remainder, q_sum))?,
+      ])?;
+      let result = crate::evaluator::evaluate_expr_to_expr(&plus2(
+        times2(h_coeff, h_n),
+        poly_part,
+      ))?;
+      return Ok(Some(result));
+    }
+  }
+
   if let Some(1) = min_concrete {
-    if matches!(body, Expr::Identifier(name) if name == var_name) {
-      let n = max_expr.clone();
-      return Ok(Some(div2(
-        times2(n.clone(), plus2(Expr::Integer(1), n)),
-        Expr::Integer(2),
-      )));
-    }
-
-    // Sum[k^2, {k, 1, n}] = n*(1 + n)*(1 + 2*n)/6
-    if let Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: base,
-      right: exp,
-    } = body
-      && matches!(base.as_ref(), Expr::Identifier(name) if name == var_name)
-      && matches!(exp.as_ref(), Expr::Integer(2))
-    {
-      let n = max_expr.clone();
-      return Ok(Some(div2(
-        times2(
-          times2(n.clone(), plus2(Expr::Integer(1), n.clone())),
-          plus2(Expr::Integer(1), times2(Expr::Integer(2), n)),
-        ),
-        Expr::Integer(6),
-      )));
-    }
-
-    // Sum[k^3, {k, 1, n}] = (n*(1 + n)/2)^2
-    if let Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: base,
-      right: exp,
-    } = body
-      && matches!(base.as_ref(), Expr::Identifier(name) if name == var_name)
-      && matches!(exp.as_ref(), Expr::Integer(3))
-    {
-      let n = max_expr.clone();
-      // (n*(1+n)/2)^2
-      return Ok(Some(pow2(
-        div2(
-          times2(n.clone(), plus2(Expr::Integer(1), n)),
-          Expr::Integer(2),
-        ),
-        Expr::Integer(2),
-      )));
-    }
-
-    // Sum[k^4, {k, 1, n}] = n*(1+n)*(1+2*n)*(-1+3*n+3*n^2)/30
-    if let Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: base,
-      right: exp,
-    } = body
-      && matches!(base.as_ref(), Expr::Identifier(name) if name == var_name)
-      && matches!(exp.as_ref(), Expr::Integer(4))
-    {
-      let n = max_expr.clone();
-      // n*(1+n)*(1+2*n)*(-1+3*n+3*n^2)/30
-      let n_plus_1 = plus2(Expr::Integer(1), n.clone());
-      let one_plus_2n =
-        plus2(Expr::Integer(1), times2(Expr::Integer(2), n.clone()));
-      let neg1_plus_3n_plus_3n2 = plus2(
-        Expr::Integer(-1),
-        plus2(
-          times2(Expr::Integer(3), n.clone()),
-          times2(Expr::Integer(3), pow2(n.clone(), Expr::Integer(2))),
-        ),
-      );
-      let numerator = call(
-        "Times",
-        vec![n, n_plus_1, one_plus_2n, neg1_plus_3n_plus_3n2],
-      );
-      return Ok(Some(div2(numerator, Expr::Integer(30))));
-    }
-
-    // Sum[k^5, {k, 1, n}] = n^2*(1+n)^2*(-1+2*n+2*n^2)/12
-    if let Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: base,
-      right: exp,
-    } = body
-      && matches!(base.as_ref(), Expr::Identifier(name) if name == var_name)
-      && matches!(exp.as_ref(), Expr::Integer(5))
-    {
-      let n = max_expr.clone();
-      // n^2*(1+n)^2*(-1+2*n+2*n^2)/12
-      let n_sq = pow2(n.clone(), Expr::Integer(2));
-      let n_plus_1_sq =
-        pow2(plus2(Expr::Integer(1), n.clone()), Expr::Integer(2));
-      let neg1_plus_2n_plus_2n2 = plus2(
-        Expr::Integer(-1),
-        plus2(
-          times2(Expr::Integer(2), n.clone()),
-          times2(Expr::Integer(2), pow2(n, Expr::Integer(2))),
-        ),
-      );
-      let numerator =
-        call("Times", vec![n_sq, n_plus_1_sq, neg1_plus_2n_plus_2n2]);
-      return Ok(Some(div2(numerator, Expr::Integer(12))));
-    }
-
     // Sum[HarmonicNumber[k], {k, 1, n}]      = HyperHarmonicNumber[2, n]
     // Sum[HarmonicNumber[k, r], {k, 1, n}]   = HyperHarmonicNumber[2, n, r]
     // (the r-fold cumulative sum of harmonic numbers), when the order r is

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2014,12 +2014,46 @@ fn strip_alternating_factor(body: &Expr, var: &str) -> Option<Expr> {
   })
 }
 
-/// True for `Indeterminate`, `ComplexInfinity`, or a `DirectedInfinity[…]` —
-/// the markers a division or a pole (`1/0`, `PolyGamma[0]`, …) evaluates to,
-/// rather than raising an `InterpreterError`.
+/// True for `Indeterminate`, `ComplexInfinity`, `Infinity` (in any of the
+/// spellings a negation can leave it in: a bare identifier, `-Infinity` as
+/// `UnaryOp[Minus, …]`, or `Times[-1, Infinity]`), or a `DirectedInfinity[…]`
+/// — the markers a division or a pole (`1/0`, `PolyGamma[0]`, `Log[0]`, …)
+/// evaluates to, rather than raising an `InterpreterError`.
 fn is_nonfinite_boundary_value(expr: &Expr) -> bool {
-  matches!(expr, Expr::Identifier(s) if s == "Indeterminate" || s == "ComplexInfinity")
+  let is_infinity = |e: &Expr| matches!(e, Expr::Identifier(s) | Expr::Constant(s) if s == "Infinity");
+  if is_infinity(expr)
+    || matches!(expr, Expr::Identifier(s) if s == "Indeterminate" || s == "ComplexInfinity")
     || matches!(expr, Expr::FunctionCall { name, .. } if name == "DirectedInfinity")
+  {
+    return true;
+  }
+  if let Expr::UnaryOp {
+    op: UnaryOperator::Minus,
+    operand,
+  } = expr
+  {
+    return is_infinity(operand);
+  }
+  let times_args: Option<&[Expr]> = match expr {
+    Expr::FunctionCall { name, args } if name == "Times" => Some(args),
+    _ => None,
+  };
+  if let Some(args) = times_args
+    && args.len() == 2
+  {
+    return (matches!(&args[0], Expr::Integer(-1)) && is_infinity(&args[1]))
+      || (matches!(&args[1], Expr::Integer(-1)) && is_infinity(&args[0]));
+  }
+  if let Expr::BinaryOp {
+    op: BinaryOperator::Times,
+    left,
+    right,
+  } = expr
+  {
+    return (matches!(left.as_ref(), Expr::Integer(-1)) && is_infinity(right))
+      || (matches!(right.as_ref(), Expr::Integer(-1)) && is_infinity(left));
+  }
+  false
 }
 
 pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -2074,7 +2108,18 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     );
     let iter_spec =
       Expr::List(vec![fresh.clone(), Expr::Integer(1), upper].into());
-    let inner_sum = sum_ast(&[body_in_fresh, iter_spec])?;
+    let inner_sum_raw = sum_ast(&[body_in_fresh, iter_spec])?;
+    // `inner_sum_raw` may not have closed to a value (e.g. `PolyGamma`/`Sin`
+    // have no Sum handling at all), in which case it still holds the fresh
+    // dummy variable inside an unevaluated `Sum[…]`. Substitute it back to
+    // the caller's own variable name before it can leak into either return
+    // path below, or a still-symbolic result exposes the internal
+    // `$sum_indef_…_$` name.
+    let inner_sum = crate::syntax::substitute_variable(
+      &inner_sum_raw,
+      &fresh_name,
+      &Expr::Identifier(var_name.clone()),
+    );
     // Evaluate f(0). A summand with a genuine pole at 0 (`1/k`,
     // `PolyGamma[k]`, …) makes this boundary term non-finite even though
     // the antidifference itself is perfectly well defined there (e.g.

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1806,6 +1806,128 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_sum_of_kth_powers_beyond_the_hand_derived_degrees() {
+    // `Sum[k^s, {k, 1, n}]` used to hand-derive one closed form per degree
+    // (s = 2..5) and leave every higher power unevaluated — a Demonstration
+    // sampled from the Wolfram Demonstrations Project ("Summation by
+    // Parts") drives a slider up to degree 17, so a numeric answer was
+    // needed for every degree in between too, not just the five that had
+    // been transcribed by hand. Faulhaber's formula (Bernoulli numbers)
+    // closes any degree; each result is checked against a brute-force sum
+    // for several `n`, and s = 2..5 must still print exactly as before.
+    clear_state();
+    assert_eq!(
+      interpret("Sum[k^2, {k, 1, n}]").unwrap(),
+      "(n*(1 + n)*(1 + 2*n))/6"
+    );
+    assert_eq!(
+      interpret("Sum[k^3, {k, 1, n}]").unwrap(),
+      "(n^2*(1 + n)^2)/4"
+    );
+    assert_eq!(
+      interpret("Sum[k^5, {k, 1, n}]").unwrap(),
+      "(n^2*(1 + n)^2*(-1 + 2*n + 2*n^2))/12"
+    );
+    for s in [1, 6, 7, 9, 17] {
+      let closed_form = interpret(&format!("Sum[k^{s}, {{k, 1, n}}]")).unwrap();
+      assert!(
+        !closed_form.contains("Sum["),
+        "degree {s} stayed unevaluated: {closed_form}"
+      );
+      for n in [1, 2, 5, 12] {
+        let via_formula: i64 =
+          interpret(&format!("Sum[k^{s}, {{k, 1, n}}] /. n -> {n}"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        let brute_force: i64 = interpret(&format!("Sum[k^{s}, {{k, 1, {n}}}]"))
+          .unwrap()
+          .parse()
+          .unwrap();
+        assert_eq!(
+          via_formula, brute_force,
+          "degree {s}, n = {n}: {closed_form}"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn test_sum_of_power_times_harmonic_number() {
+    // The same "Summation by Parts" Demonstration's whole point is a
+    // closed form for `Sum[k^s HarmonicNumber[k], {k, 1, n}]` — discrete
+    // summation by parts (Abel summation), independently re-derived here
+    // rather than read off the notebook. Checked against a brute-force sum
+    // (with `HarmonicNumber` expanded numerically) for several `n`.
+    // wolframscript/Woxi print a machine real past a certain magnitude in
+    // `1.234*^6`-style scientific notation, which Rust's `f64` parser
+    // rejects outright (it wants `1.234e6`).
+    fn parse_wolfram_real(s: &str) -> f64 {
+      s.replace("*^", "e").parse().unwrap()
+    }
+
+    clear_state();
+    for s in [1, 2, 4, 8] {
+      let closed_form =
+        interpret(&format!("Sum[k^{s}*HarmonicNumber[k], {{k, 1, n}}]"))
+          .unwrap();
+      assert!(
+        !closed_form.contains("Sum["),
+        "degree {s} stayed unevaluated: {closed_form}"
+      );
+      for n in [1, 2, 5, 9] {
+        let via_formula = parse_wolfram_real(
+          &interpret(&format!(
+            "N[Sum[k^{s}*HarmonicNumber[k], {{k, 1, n}}] /. n -> {n}]"
+          ))
+          .unwrap(),
+        );
+        let brute_force = parse_wolfram_real(
+          &interpret(&format!(
+            "N[Sum[k^{s}*HarmonicNumber[k], {{k, 1, {n}}}]]"
+          ))
+          .unwrap(),
+        );
+        assert!(
+          (via_formula - brute_force).abs() < 1e-6 * brute_force.abs().max(1.0),
+          "degree {s}, n = {n}: formula {via_formula} vs brute force \
+           {brute_force} ({closed_form})"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn test_indefinite_sum_drops_a_nonfinite_boundary_term() {
+    // `Sum[f[i], i]` (indefinite) closes as `f(0) + Sum[f[k], {k, 1, i-1}]`.
+    // For a summand with a genuine pole at 0 (`1/k`, `PolyGamma[k]`) that
+    // boundary term evaluates to `ComplexInfinity`/`Indeterminate` and used
+    // to poison the whole result through `Plus`, even though the
+    // antidifference itself is perfectly well defined there — wolframscript's
+    // `Sum[1/i, i]` is `HarmonicNumber[-1 + i]`, exactly the telescoping
+    // part alone. A non-finite boundary term is now dropped instead of
+    // added in.
+    clear_state();
+    assert_eq!(interpret("Sum[1/k, k]").unwrap(), "HarmonicNumber[-1 + k]");
+    assert!(
+      !interpret("Sum[PolyGamma[k], k]")
+        .unwrap()
+        .contains("Indeterminate"),
+      "a pole at the boundary must not poison the whole sum"
+    );
+    assert!(
+      !interpret("Sum[k*PolyGamma[k], k]")
+        .unwrap()
+        .contains("Indeterminate"),
+      "a pole at the boundary must not poison the whole sum"
+    );
+    // A regular (non-singular) summand is unaffected: the boundary term is
+    // still added in as before.
+    assert_eq!(interpret("Sum[1, i]").unwrap(), "i");
+    assert_eq!(interpret("Sum[i, i]").unwrap(), "((-1 + i)*i)/2");
+  }
+
+  #[test]
   fn test_distinct_images_are_not_same_q_or_equal() {
     // `expr_to_string` reports every `Image[…]` as the same `-Image-`
     // display placeholder. `SameQ`/`Equal` and the structural-equality

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1906,25 +1906,44 @@ mod interpreter_tests {
     // antidifference itself is perfectly well defined there — wolframscript's
     // `Sum[1/i, i]` is `HarmonicNumber[-1 + i]`, exactly the telescoping
     // part alone. A non-finite boundary term is now dropped instead of
-    // added in.
+    // added in. `Log[0]` evaluates to a plain (unary-negated) `Infinity`
+    // rather than `ComplexInfinity`/`Indeterminate` — a different spelling
+    // of "non-finite" that must be caught too, or it still poisons the sum
+    // through `Plus` the same way.
     clear_state();
     assert_eq!(interpret("Sum[1/k, k]").unwrap(), "HarmonicNumber[-1 + k]");
+    for code in ["Sum[PolyGamma[k], k]", "Sum[k*PolyGamma[k], k]"] {
+      let result = interpret(code).unwrap();
+      assert!(
+        !result.contains("Indeterminate"),
+        "{code}: a pole at the boundary must not poison the whole sum, got {result}"
+      );
+      // The antidifference has no closed form either, so the result stays a
+      // symbolic `Sum[...]` — but it must be expressed in the caller's own
+      // variable, not the internal `$sum_indef_k_$` dummy the indefinite-sum
+      // rewrite substitutes in and must substitute back out.
+      assert!(
+        !result.contains("sum_indef"),
+        "{code}: leaked the internal dummy variable, got {result}"
+      );
+    }
     assert!(
-      !interpret("Sum[PolyGamma[k], k]")
-        .unwrap()
-        .contains("Indeterminate"),
-      "a pole at the boundary must not poison the whole sum"
-    );
-    assert!(
-      !interpret("Sum[k*PolyGamma[k], k]")
-        .unwrap()
-        .contains("Indeterminate"),
-      "a pole at the boundary must not poison the whole sum"
+      !interpret("Sum[Log[i], i]").unwrap().contains("Infinity"),
+      "a plain (non-ComplexInfinity) infinite boundary term must not poison \
+       the whole sum either"
     );
     // A regular (non-singular) summand is unaffected: the boundary term is
-    // still added in as before.
+    // still added in as before, and an unresolved antidifference (no Sum
+    // pattern for `Sin`/a bare symbolic function) still must not leak the
+    // dummy variable either.
     assert_eq!(interpret("Sum[1, i]").unwrap(), "i");
     assert_eq!(interpret("Sum[i, i]").unwrap(), "((-1 + i)*i)/2");
+    for code in ["Sum[Sin[k], k]", "Sum[f[k], k]"] {
+      assert!(
+        !interpret(code).unwrap().contains("sum_indef"),
+        "{code}: leaked the internal dummy variable"
+      );
+    }
   }
 
   #[test]

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1978,14 +1978,14 @@ mod interpreter_tests {
         !result.contains("Indeterminate"),
         "{code}: a pole at the boundary must not poison the whole sum, got {result}"
       );
-      // The antidifference has no closed form either, so the result stays a
-      // symbolic `Sum[...]` — but it must be expressed in the caller's own
-      // variable, not the internal `$sum_indef_k_$` dummy the indefinite-sum
-      // rewrite substitutes in and must substitute back out.
-      assert!(
-        !result.contains("sum_indef"),
-        "{code}: leaked the internal dummy variable, got {result}"
-      );
+      // The antidifference has no closed form either (no `Sum` handling for
+      // `PolyGamma`), so the rewrite must hand back the original call
+      // unevaluated rather than a partial rewrite still holding the
+      // internal `$sum_indef_k_$` dummy — which would otherwise leak either
+      // as a bare occurrence, or (worse) get blindly substituted back to
+      // `k` and shadow the free `k` inside the held `Sum`'s own iterator
+      // spec (`Sum[PolyGamma[k], {k, 1, -1 + k}]`, ill-formed).
+      assert_eq!(result, code, "{code}: must stay unevaluated verbatim");
     }
     assert!(
       !interpret("Sum[Log[i], i]").unwrap().contains("Infinity"),
@@ -1999,9 +1999,12 @@ mod interpreter_tests {
     assert_eq!(interpret("Sum[1, i]").unwrap(), "i");
     assert_eq!(interpret("Sum[i, i]").unwrap(), "((-1 + i)*i)/2");
     for code in ["Sum[Sin[k], k]", "Sum[f[k], k]"] {
-      assert!(
-        !interpret(code).unwrap().contains("sum_indef"),
-        "{code}: leaked the internal dummy variable"
+      assert_eq!(
+        interpret(code).unwrap(),
+        code,
+        "{code}: an unclosed antidifference must stay unevaluated verbatim, \
+         not leak the internal dummy variable or produce an ill-formed \
+         iterator that shadows its own free variable"
       );
     }
   }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -24226,4 +24226,101 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ 
       degenerate.graphics
     );
   }
+
+  /// A Manipulate whose body typesets a running total as a formula (no
+  /// `Graphics`) via `Text[TraditionalForm[…]]`, driven by an exponent
+  /// slider (`Appearance -> "Labeled"`) and a discrete rule-labeled control
+  /// switching which weighting function multiplies the summand — mirroring
+  /// the general construct category of Wolfram Demonstrations Project
+  /// notebooks that display a symbolic identity rather than a picture
+  /// (independently written, not copied from any specific one). Regression:
+  /// `Sum[k^s, {k, 1, n}]` only had hand-derived closed forms for s = 2..5,
+  /// and `Sum[k^s*HarmonicNumber[k], {k, 1, n}]` had none at all, so the
+  /// formula stayed as a raw, un-typeset `Sum[…]` for any exponent above 5
+  /// (or any use of the harmonic weighting) instead of a closed form.
+  #[test]
+  fn manipulate_text_formula_power_times_harmonic_weight() {
+    let code = r#"Manipulate[
+      Text[TraditionalForm[Pane[(total == ReleaseHold[total]) /. {deg -> exponent, weight -> choice}, {380, 260}]]],
+      {{exponent, 6, "exponent"}, 1, 15, 1, Appearance -> "Labeled"},
+      {{choice, HarmonicNumber, "weight"}, {PolyGamma -> "digamma weight", HarmonicNumber -> "harmonic weight"}},
+      Initialization :> {total = HoldForm[Sum[j^deg*weight[j], j]]}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "an exponent slider plus a rule-labeled weight picker should build a widget",
+    );
+    assert!(
+      state.error.is_none(),
+      "initial render failed: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state.controls.iter().map(|c| c.name()).collect::<Vec<_>>(),
+      vec!["exponent", "choice"],
+      "panel rows: exponent slider, weight picker"
+    );
+    assert!(
+      matches!(
+        state.controls[0],
+        manipulate::ControlState::Continuous { .. }
+      ),
+      "the exponent spec must become a Continuous slider"
+    );
+    match &state.controls[1] {
+      manipulate::ControlState::Discrete {
+        values,
+        value_labels,
+        ..
+      } => {
+        assert_eq!(values, &["PolyGamma", "HarmonicNumber"]);
+        assert_eq!(value_labels, &["digamma weight", "harmonic weight"]);
+      }
+      other => panic!("expected a Discrete control, got {other:?}"),
+    }
+
+    // The default weight (HarmonicNumber) must close to a typeset formula,
+    // not a raw unevaluated Sum or an Indeterminate boundary artifact.
+    assert!(
+      state.graphics_handle.is_none(),
+      "a Text[...] body draws no graphic"
+    );
+    // The formula reads `HoldForm[Sum[...]] == <closed form>` — the LHS
+    // stays an unevaluated `Sum[...]` on purpose (it names the symbolic
+    // total being displayed); only the right-hand side is the closed form
+    // this test is pinning down.
+    let formula = state.text_output.clone().unwrap_or_default();
+    let rhs = formula.rsplit("==").next().unwrap_or_default();
+    assert!(
+      rhs.contains("HarmonicNumber")
+        && !rhs.contains("Sum[")
+        && !rhs.contains("Indeterminate"),
+      "expected a closed-form harmonic formula, got: {formula:?}"
+    );
+
+    // Dragging the exponent slider re-evaluates cleanly for every degree in
+    // its range, not just the hand-derived ones that used to work.
+    for exponent in [1.0, 2.0, 5.0, 9.0, 15.0] {
+      for c in &mut state.controls {
+        if let manipulate::ControlState::Continuous { name, current, .. } = c
+          && name == "exponent"
+        {
+          *current = exponent;
+        }
+      }
+      state.reevaluate();
+      assert!(
+        state.error.is_none(),
+        "exponent {exponent} failed: {:?}",
+        state.error
+      );
+      let formula = state.text_output.clone().unwrap_or_default();
+      let rhs = formula.rsplit("==").next().unwrap_or_default();
+      assert!(
+        !rhs.contains("Sum[") && !rhs.contains("Indeterminate"),
+        "exponent {exponent} did not close to a formula: {formula:?}"
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Sampled a random Wolfram Demonstrations Project notebook ("Summation by Parts"): a `Manipulate` with a degree slider (`Appearance -> "Labeled"`) from 1 to 17 and a rule-labeled discrete control switching between `HarmonicNumber` and `PolyGamma`, whose body reconstructs and displays `ReleaseHold[Sum[k^p*h[k], k]]`.

This exposed two gaps in Woxi's CAS, plus a related indefinite-sum bug:

- `Sum[k^s, {k, 1, n}]` only had hand-derived closed forms for `s = 2..5` — any higher degree (the demonstration's slider goes to 17) stayed unevaluated.
- `Sum[k^s*HarmonicNumber[k], {k, 1, n}]` had no closed form at all — this is exactly the summation-by-parts identity the demonstration itself illustrates.
- Indefinite `Sum[f[i], i]` unconditionally adds `f(0)` as a boundary term. For a summand with a genuine pole at `0` (`1/k`, `PolyGamma[k]`) this made the whole result `Indeterminate`, even though the antidifference is perfectly well defined there.

## Changes

- Replace the five hardcoded power-sum formulas in `Sum[k^s, {k, 1, n}]` with one generic Faulhaber's-formula (Bernoulli number) implementation covering any concrete positive integer degree. Verified to reproduce the previous `s = 2..5` output exactly (via `Factor`), and this also fixes a latent `s = 1` edge case and improves `HarmonicNumber[n, -j]` for `j > 5`, which delegates to the same `Sum` machinery.
- Add `Sum[k^s*HarmonicNumber[k], {k, a, n}]` via discrete summation by parts (Abel summation) — independently derived (not copied from the notebook) and checked numerically against brute-force sums for many `(s, n)` pairs.
- Drop a non-finite (`ComplexInfinity`/`Indeterminate`) indefinite-sum boundary term instead of adding it in, matching wolframscript's `Sum[1/i, i] = HarmonicNumber[-1 + i]`.
- Add a Woxi Studio regression test (independently written, not copied from the notebook) covering the same construct category: a `Text[TraditionalForm[...]]` formula body (no graphics), a `Labeled` continuous slider, and a rule-labeled discrete control.

The `PolyGamma` radio option in the notebook's control still doesn't reach a closed form in the general (deferred-substitution / `Initialization` + `ReleaseHold`) usage pattern — it now degrades to a well-formed unevaluated `Sum[...]` instead of `Indeterminate`, but does not fully close. This is left as a known follow-up rather than guessed at further without a way to verify against wolframscript in this environment.

## Test plan

- [x] `cargo test` (full workspace-root suite): 25805 + 269 + 45 + 1262 + 576 passed, 0 failed
- [x] `cargo test -p woxi-studio`: 216 passed, 0 failed
- [x] New unit tests: `test_sum_of_kth_powers_beyond_the_hand_derived_degrees`, `test_sum_of_power_times_harmonic_number`, `test_indefinite_sum_drops_a_nonfinite_boundary_term`
- [x] New Woxi Studio test: `manipulate_text_formula_power_times_harmonic_weight`
- [x] Manually verified `Sum[k^n, {k,1,m}]` for `n = 1..17` and `Sum[k^n*HarmonicNumber[k], {k,1,m}]` against brute-force numeric sums
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_011GLcRP2JsF6HnrQ7a7G8Wo)_