### PR TITLE
Fix missing parens around BinaryOp::Times exponent in Power InputForm

### DIFF
--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -10467,7 +10467,7 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
           || matches!(
             &args[1],
             Expr::BinaryOp {
-              op: BinaryOperator::Divide,
+              op: BinaryOperator::Divide | BinaryOperator::Times,
               ..
             }
           )

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2156,6 +2156,27 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_negative_product_exponent_keeps_parens_in_input_form() {
+    // Regression: `Power[base, -(k*rest)]` printed via a division (moving
+    // the negative-exponent factor to the denominator) must parenthesize
+    // the positive exponent it reconstructs. `denominator_form` strips a
+    // `UnaryOp::Minus` exponent down to its `BinaryOp::Times` operand, and
+    // the exponent-parenthesization check only recognized a `Times`
+    // spelled as `Expr::FunctionCall` — a `BinaryOp::Times` exponent (the
+    // shape juxtaposed factors like `-k ((-1+x))^(2)` parse to, e.g. from
+    // a Wolfram Demonstrations notebook's reconstructed box source)
+    // printed without parens, so `E^(k*(-1+x)^2)` came back as
+    // `E^k*(-1+x)^2`: precedence silently pulls `(-1+x)^2` out of the
+    // exponent, changing the value.
+    clear_state();
+    assert_eq!(
+      interpret("ToString[Hold[(x-1)(E)^(-k((-1+x))^(2))], InputForm]")
+        .unwrap(),
+      "Hold[(x - 1)/E^(k*(-1 + x)^2)]"
+    );
+  }
+
+  #[test]
   fn test_definition_of_compound_expression_body_keeps_parens() {
     // Same regression, surfaced through Definition[] (which formats
     // DownValues by hand rather than through expr_to_input_form): a


### PR DESCRIPTION
## Summary

As part of the recurring "check a random Wolfram Demonstration notebook against Woxi Studio" routine, I downloaded a random Demonstrations Project notebook (*Quasi-exact Solution for a Double-Well Potential*) and ran it through Woxi's notebook parser and `Manipulate` extraction pipeline end-to-end.

Parsing, control extraction (a labeled slider plus two checkboxes), and body evaluation all worked correctly. However, the `Initialization` code — several wavefunction definitions using nested `E^(-k*(...)^2)` terms — came back from the box-source reconstruction with **silently wrong operator grouping**: `E^(k*(-1 + x)^2)` printed as `E^k*(-1 + x)^2`, i.e. `(-1+x)^2` fell outside the exponent entirely. This changes the value, not just the display.

### Root cause

`Power[base, exponent]` printed via the "move negative-exponent factor to denominator" heuristic (`format_times_with_denominator`/`denominator_form` in `src/syntax.rs`) reconstructs a *positive* exponent from a `UnaryOp::Minus` node by returning its operand directly. When that operand is a `BinaryOp::Times` (the shape a parsed product like `-k ((-1+x))^(2)` produces — as opposed to `Expr::FunctionCall{name: "Times", ...}`), the exponent-parenthesization check in `format_expr_impl` only recognized the `FunctionCall` spelling of `Times`, not the `BinaryOp` one. So the reconstructed exponent printed unparenthesized, and `^` (higher precedence than `*`) silently only applied to the first factor.

### Fix

Add `BinaryOperator::Times` alongside the existing `BinaryOperator::Divide` case in the exponent-parenthesization check (mirroring the equivalent check that already existed for the *base* side a few lines above).

## Test plan

- [x] Added a regression test (`test_negative_product_exponent_keeps_parens_in_input_form` in `tests/interpreter_tests.rs`) reproducing the exact box-source-reconstruction shape that triggered the bug
- [x] `cargo test` — full suite green: 25,803 unit tests + 1,262 CLI tests + 576 script snapshot tests, 0 failures
- [x] `make format` — no changes needed
- [x] Manually verified the fix against the originating Demonstration's actual `Initialization` code end-to-end (all wavefunction definitions now round-trip correctly)

No verbatim notebook content is included in this PR — only a description of the pattern and a hand-written minimal repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQkS2G7ZDpg3HvX9CCJejn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQkS2G7ZDpg3HvX9CCJejn)_