### PR TITLE
Fix Woxi Studio re-running a Manipulate's Initialization twice on load

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -17748,6 +17748,40 @@ fn is_track_everything_symbol(sym: &str) -> bool {
   matches!(sym, "All" | "Full" | "Manipulate" | "Automatic" | "True")
 }
 
+/// Whether a `Manipulate[…]`/`Animate[…]` call carries its own
+/// `Initialization :> …`/`Initialization -> …` option, checked structurally
+/// (no evaluation, no side effects) so a caller can decide whether a
+/// *different* recovered copy of Initialization — e.g. one salvaged from a
+/// notebook's cached box-dump output for a `SaveDefinitions -> True`
+/// Manipulate — is actually needed. Wolfram embeds that same box-dump shape
+/// for a Manipulate with its own `Initialization` too, so recovering and
+/// running it there would just duplicate what the live source already runs.
+pub fn manipulate_has_own_initialization(expr: &Expr) -> bool {
+  let Expr::FunctionCall { name, args } = expr else {
+    return false;
+  };
+  if name != "Manipulate" && name != "Animate" {
+    return false;
+  }
+  // A Manipulate whose body is itself an `Animate[…]` flattens the inner
+  // Animate's own Initialization into the combined spec (see
+  // `extract_manipulate_spec`), so check there too.
+  if name == "Manipulate"
+    && let Some(Expr::FunctionCall { name: n, .. }) = args.first()
+    && n == "Animate"
+    && manipulate_has_own_initialization(&args[0])
+  {
+    return true;
+  }
+  args.iter().skip(1).any(|spec| {
+    matches!(
+      spec,
+      Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. }
+        if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Initialization")
+    )
+  })
+}
+
 /// Attempt to extract a `ManipulateSpec` from a held `Manipulate[…]` or
 /// `Animate[…]` expression. `Animate` shares `Manipulate`'s argument shape
 /// (a body followed by `{u, umin, umax}`-style control specs) but auto-plays,

--- a/woxi-studio/examples/dump_manipulate.rs
+++ b/woxi-studio/examples/dump_manipulate.rs
@@ -45,17 +45,6 @@ fn main() {
     if !matches!(cell.style, CellStyle::Input | CellStyle::Code) {
       continue;
     }
-    // `Manipulate[…, SaveDefinitions -> True]` stores the definitions its
-    // body depends on in the following Output cell's widget dump. The
-    // Studio runs them before instantiating; do the same here, or a
-    // Demonstration's helper functions look undefined.
-    if let Some(next) = all_cells.get(idx + 1)
-      && next.style == CellStyle::Output
-      && let Some(init) =
-        woxi::notebook::extract_saved_initialization(&next.content)
-    {
-      let _ = woxi::interpret(&init);
-    }
     let code = cell.content.trim();
     for stmt in woxi::split_into_statements(code) {
       // Evaluate for side effects (definitions) exactly like the studio.
@@ -63,6 +52,26 @@ fn main() {
       let Ok(expr) = woxi::interpret_to_expr(&stmt) else {
         continue;
       };
+      // `Manipulate[…, SaveDefinitions -> True]` stores the definitions its
+      // body depends on in the following Output cell's widget dump, because
+      // the Manipulate's own `Initialization` option is absent. The Studio
+      // runs the recovered copy before instantiating, or a Demonstration's
+      // helper functions look undefined — but only when the live source
+      // truly has no `Initialization` of its own: Wolfram embeds this same
+      // box-dump shape for an ordinary `Initialization :> …` Manipulate too,
+      // and running that FullForm copy a second time (ahead of the live one
+      // `ManipulateState::from_expr` runs) can leave a helper function bound
+      // to a broken duplicate rule.
+      let has_own_initialization =
+        woxi::functions::graphics::manipulate_has_own_initialization(&expr);
+      if !has_own_initialization
+        && let Some(next) = all_cells.get(idx + 1)
+        && next.style == CellStyle::Output
+        && let Some(init) =
+          woxi::notebook::extract_saved_initialization(&next.content)
+      {
+        let _ = woxi::interpret(&init);
+      }
       let Some(state) = manipulate::ManipulateState::from_expr(&expr) else {
         if let Ok(res) = &eval
           && res.result.starts_with("Manipulate[")

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -5186,13 +5186,29 @@ fn instantiate_stored_manipulate(
   if statements.len() != 1 {
     return None;
   }
+  let expr = woxi::interpret_to_expr(&statements[0]).ok()?;
   // `Manipulate[…, SaveDefinitions -> True]` embeds the definitions its
-  // body depends on in the stored output's Initialization. Run them once
-  // (Wolfram's SynchronousInitialization) before instantiating, so the
-  // widget works right when the notebook opens — before any of the
-  // notebook's definition cells have been evaluated.
-  if let Some(init) =
-    woxi::notebook::extract_saved_initialization(stored_output)
+  // body depends on in the stored output's Initialization, because the
+  // Manipulate's own `Initialization` option is absent — the helper
+  // definitions live in a separate "Initialization Code" cell instead. Run
+  // the recovered copy once (Wolfram's SynchronousInitialization) before
+  // instantiating, so the widget works right when the notebook opens —
+  // before any of the notebook's definition cells have been evaluated.
+  //
+  // Wolfram embeds this very same `Initialization:>(…)` shape in the box
+  // dump for *any* Manipulate that carries its own `Initialization :> …`
+  // option too, not just a `SaveDefinitions -> True` one. Recovering and
+  // running that FullForm copy in that case is pure duplication — the live
+  // source's `Initialization` already runs it correctly a moment later —
+  // and running it twice can leave a helper function bound to a broken
+  // duplicate rule (its Module locals shadow differently in FullForm).
+  // Only fall back to the stored copy when the live source truly has none
+  // of its own.
+  let has_own_initialization =
+    woxi::functions::graphics::manipulate_has_own_initialization(&expr);
+  if !has_own_initialization
+    && let Some(init) =
+      woxi::notebook::extract_saved_initialization(stored_output)
   {
     // These names lived in the DynamicModule's private `$CellContext`` in
     // Wolfram, isolated from anything of the same name elsewhere —
@@ -5209,7 +5225,6 @@ fn instantiate_stored_manipulate(
     }
     let _ = woxi::interpret(&init);
   }
-  let expr = woxi::interpret_to_expr(&statements[0]).ok()?;
   manipulate::ManipulateState::from_expr(&expr)
 }
 
@@ -8495,6 +8510,47 @@ Cell[BoxData["standalone output"], "Output"]
       state.text_output.as_deref(),
       Some("5"),
       "the notebook's own Midpoint must win over the built-in"
+    );
+  }
+
+  #[test]
+  fn stored_manipulate_own_initialization_skips_saved_box_dump_copy() {
+    // Wolfram embeds an `Initialization:>(…)` copy of *any* Manipulate's own
+    // `Initialization :> …` option into its cached DynamicModuleBox output —
+    // not only for a `SaveDefinitions -> True` one. Regression: that copy
+    // was mistaken for a SaveDefinitions recovery and evaluated a second
+    // time (in FullForm) ahead of the live Initialization, which could leave
+    // a helper function bound to a broken duplicate rule (this is how the
+    // Wolfram Demonstrations Project's "Spherical Pendulum" notebook's
+    // NDSolve-backed body broke in the Studio). The stored copy must only
+    // run when the live source has no Initialization of its own.
+    woxi::clear_state();
+    let dump = "DynamicModuleBox[{$CellContext`x$$ = 0}, \
+      DynamicBox[…],\n\
+      Deinitialization:>None,\n\
+      Initialization:>({$CellContext`sawBoxDumpInit = True}; \
+      Typeset`initDone$$ = True),\n\
+      SynchronousInitialization->True]";
+    let state = instantiate_stored_manipulate(
+      "Manipulate[x, {x, 0, 10}, Initialization :> (ownOffset = 1)]",
+      dump,
+    )
+    .unwrap();
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert_eq!(
+      woxi::interpret("sawBoxDumpInit").ok().as_deref(),
+      Some("sawBoxDumpInit"),
+      "the stored box dump's cached Initialization copy must not run \
+       when the Manipulate already carries its own"
+    );
+    assert_eq!(
+      woxi::interpret("ownOffset").ok().as_deref(),
+      Some("1"),
+      "the live Initialization must still run"
     );
   }
 


### PR DESCRIPTION
## Summary

- The Wolfram Demonstrations Project's ["Spherical Pendulum"](https://demonstrations.wolfram.com/SphericalPendulum/) notebook (a random `Demonstration` fetched via the resource system API) failed to render its `Manipulate` widget in Woxi Studio, with the error `ParametricPlot3D: parametric function produced no finite values`.
- Root cause: Wolfram caches an `Initialization:>(...)` copy of **any** `Manipulate`'s own `Initialization` option inside its `DynamicModuleBox` output — not only for a `SaveDefinitions -> True` one. Woxi Studio's `instantiate_stored_manipulate` mistook that cached copy for a `SaveDefinitions` recovery and evaluated it (in FullForm) a second time, ahead of the live `Initialization`. Running the notebook's NDSolve-backed helper function definition twice left it bound to a broken duplicate rule, so the body's `ParametricPlot3D` sampled non-finite values across the whole domain.
- Fix: add `manipulate_has_own_initialization` (a structural, side-effect-free check) and only fall back to the recovered box-dump `Initialization` when the live `Manipulate` source truly carries none of its own — preserving the genuine `SaveDefinitions -> True` and share-link (box-dump-only) recovery paths.
- Applied the same guard to the `dump_manipulate` diagnostic example used to check whether a notebook's `Manipulate` builds correctly outside the GUI.

## Test plan

- [x] Added a regression test, `stored_manipulate_own_initialization_skips_saved_box_dump_copy`, verifying the stored box-dump's cached Initialization is skipped when the live source has its own, while the live Initialization still runs.
- [x] `cargo test --lib` (core `woxi` crate): 269 passed, 0 failed.
- [x] `cargo test -p woxi-studio --bin woxi-studio`: 216 passed, 0 failed (includes the existing `SaveDefinitions` recovery tests, confirming no regression there).
- [x] Verified against the downloaded "Spherical Pendulum" notebook directly (via the `dump_manipulate` diagnostic example): the widget now renders (`graphics=true error=None`) instead of failing.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmTCuqGvY1BDhKHWGAkM7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmTCuqGvY1BDhKHWGAkM7G)_