### PR TITLE
Make Compile's RuntimeAttributes -> {Listable} thread over list arguments

### DIFF
--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -69,10 +69,27 @@ pub fn dispatch_structural(
       // survive: `{s, _Integer, 0}` must bind an integer, not the Real every
       // argument used to be coerced to. A bare-name spec list (`{x, y}`) is
       // already its own name list, so the untyped form is unchanged.
-      return Some(Ok(call(
-        "CompiledFunction",
-        vec![args[0].clone(), args[1].clone()],
-      )));
+      //
+      // `RuntimeAttributes -> {Listable}` makes the *compiled function
+      // itself* Listable — a call like `f[{1, 2, 3}, y]` then threads
+      // element-wise over the list argument, the same as
+      // `SetAttributes[f, Listable]` would for an ordinary function —
+      // instead of passing the whole list into the body as one opaque
+      // value. Woxi has no bytecode VM to honor `Parallelization` or
+      // `RuntimeOptions`, so those are accepted (like real Mathematica
+      // silently degrading on a machine that can't parallelize) but only
+      // `Listable` changes evaluation. Record it as a 3rd `CompiledFunction`
+      // arg — `apply_curried_call` reads it to decide whether to thread.
+      let listable = args[2..].iter().any(|opt| {
+        matches!(opt, Expr::Rule { pattern, replacement }
+          if matches!(pattern.as_ref(), Expr::Identifier(n) if n == "RuntimeAttributes")
+            && rule_value_mentions_listable(replacement))
+      });
+      let mut compiled_args = vec![args[0].clone(), args[1].clone()];
+      if listable {
+        compiled_args.push(Expr::Identifier("Listable".to_string()));
+      }
+      return Some(Ok(call("CompiledFunction", compiled_args)));
     }
     "Rational" if args.len() == 2 => {
       if let (Some(n), Some(d)) =
@@ -100,4 +117,17 @@ pub fn dispatch_structural(
     _ => {}
   }
   None
+}
+
+/// Whether a `RuntimeAttributes -> …` value names `Listable`, either bare
+/// (`RuntimeAttributes -> Listable`) or inside the usual attribute list
+/// (`RuntimeAttributes -> {Listable}`).
+fn rule_value_mentions_listable(value: &Expr) -> bool {
+  match value {
+    Expr::Identifier(n) => n == "Listable",
+    Expr::List(items) => items
+      .iter()
+      .any(|i| matches!(i, Expr::Identifier(n) if n == "Listable")),
+    _ => false,
+  }
 }

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -148,6 +148,19 @@ fn compile_arg_spec(spec: &Expr, body: &Expr) -> Option<(String, bool)> {
   }
 }
 
+/// Whether a `Compile` argument spec is a scalar (rank-0) parameter — a
+/// bare name, or `{name}`/`{name, _Type}` — as opposed to a declared array
+/// (`{name, _Type, rank}`). Only a scalar position threads when the
+/// enclosing `CompiledFunction` is `RuntimeAttributes -> {Listable}`; an
+/// array-typed position is meant to receive a list itself, so a list
+/// argument there is passed through unchanged.
+fn compile_spec_is_scalar(spec: &Expr) -> bool {
+  match spec {
+    Expr::List(items) => items.len() <= 2,
+    _ => true,
+  }
+}
+
 /// Whether `body` uses the bare parameter `name` in a fixed count
 /// *position* — the 3rd argument of `Nest`/`NestList`/`FixedPointList`, the
 /// 2nd of `Array`, or a bare `{name}` iterator spec in one of `Do`'s/
@@ -1917,6 +1930,71 @@ pub fn apply_curried_call(
     } if name == "TransformationFunction" && func_args.len() == 1 => {
       // TransformationFunction[matrix][{x, y, ...}] — apply affine transformation
       apply_transformation_function(&func_args[0], args)
+    }
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "CompiledFunction"
+      && func_args.len() == 3
+      && matches!(&func_args[2], Expr::Identifier(s) if s == "Listable") =>
+    {
+      // `Compile[…, RuntimeAttributes -> {Listable}]` makes the resulting
+      // CompiledFunction itself Listable: a call with a list at one of its
+      // scalar-typed argument positions (e.g. `f[{1+I, 2+I}, y]` where `x`
+      // is declared `_Complex`, not `_Complex, 1`) threads element-wise,
+      // broadcasting the other arguments — the idiom Wolfram Demonstrations
+      // Project notebooks lean on to evaluate a `Compile`d kernel over an
+      // `ArrayPlot`/`Table` grid in one call. Without this, the list was
+      // passed straight into the body as one opaque value, so a body using
+      // it as a scalar (e.g. `NestWhileList[…, x, …]`) silently computed
+      // the wrong thing instead of a per-element result.
+      let specs: Vec<&Expr> = match &func_args[0] {
+        Expr::List(items) => items.iter().collect(),
+        other => vec![other],
+      };
+      let scalar_positions: Vec<bool> =
+        specs.iter().map(|s| compile_spec_is_scalar(s)).collect();
+      let list_len =
+        args
+          .iter()
+          .zip(scalar_positions.iter())
+          .find_map(|(a, &is_scalar)| match a {
+            Expr::List(items) if is_scalar => Some(items.len()),
+            _ => None,
+          });
+      match list_len {
+        Some(len)
+          if args.iter().zip(scalar_positions.iter()).all(
+            |(a, &is_scalar)| match a {
+              Expr::List(items) if is_scalar => items.len() == len,
+              _ => true,
+            },
+          ) =>
+        {
+          let mut results = Vec::with_capacity(len);
+          for i in 0..len {
+            let threaded_args: Vec<Expr> = args
+              .iter()
+              .zip(scalar_positions.iter())
+              .map(|(a, &is_scalar)| match a {
+                Expr::List(items) if is_scalar => items[i].clone(),
+                _ => a.clone(),
+              })
+              .collect();
+            results.push(apply_curried_call(func, &threaded_args)?);
+          }
+          Ok(Expr::List(results.into()))
+        }
+        // No listed scalar-position argument (or mismatched lengths) —
+        // behave exactly like the plain 2-argument CompiledFunction.
+        _ => apply_curried_call(
+          &call(
+            "CompiledFunction",
+            vec![func_args[0].clone(), func_args[1].clone()],
+          ),
+          args,
+        ),
+      }
     }
     Expr::FunctionCall {
       name,

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -943,6 +943,58 @@ mod compile {
     assert_eq!(interpret("Head[cf]").unwrap(), "CompiledFunction");
   }
 
+  // Regression: `RuntimeAttributes -> {Listable}` was accepted syntactically
+  // (see `compile_accepts_trailing_option_rules` above) but never made the
+  // resulting `CompiledFunction` actually thread over a list argument — it
+  // was passed straight into the body as one opaque value instead of being
+  // mapped element-wise, the way `SetAttributes[f, Listable]` threads an
+  // ordinary function. That happened to go unnoticed for bodies built from
+  // already-Listable primitives (`Abs`, `Plus`, …), which thread on their
+  // own regardless of the compiled function's own attribute — but a body
+  // using a scalar-typed parameter as opaque state passed to a
+  // non-Listable list-producing function (`NestWhileList`, as many Wolfram
+  // Demonstrations Project escape-time fractal kernels do) computed the
+  // wrong thing entirely: a matrix argument collapsed to a single scalar
+  // result instead of a same-shaped matrix of per-element results.
+  #[test]
+  fn compile_listable_runtime_attribute_threads_over_list_argument() {
+    clear_state();
+    let r = woxi::interpret_with_stdout(
+      r#"escapeSteps = Compile[{{z0, _Complex}, {c, _Complex}, {maxSteps, _Integer}},
+           Length[NestWhileList[#^2 + c &, z0, Abs[#] <= 2 &, 1, maxSteps]],
+           RuntimeAttributes -> {Listable}];
+         escapeSteps[{{0.+0. I, 2.+2. I}, {3.+0. I, 0.1+0.1 I}}, -1.+0. I, 20]"#,
+    )
+    .unwrap();
+    // (0, 0) and (0.1, 0.1) both fall in the basin of the map's attracting
+    // {0, -1} 2-cycle and never escape, so all 20 allowed applications run:
+    // 21 elements (the initial value plus 20 applications). (2, 2) and (3,
+    // 0) start outside the escape radius, so the very first `test` check
+    // fails and the list stays just the initial value: 1 element. The
+    // `_Complex` spec makes the whole compiled function work in machine
+    // reals, so the integer `Length` comes back real-coerced (`21.`/`1.`).
+    assert_eq!(r.result, "{{21., 1.}, {1., 21.}}");
+    assert!(
+      r.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      r.warnings
+    );
+    // A plain (non-Listable) CompiledFunction must keep passing a list
+    // argument straight through as opaque state, unchanged by this fix:
+    // `Abs` and `<=` thread over the 2-element list on their own, but the
+    // result is a 2-element list of booleans, not a single True/False, so
+    // `NestWhileList`'s test is never definitely satisfied and it stops
+    // after just the initial value.
+    assert_eq!(
+      interpret(
+        r#"raw = Compile[{{z0, _Complex}}, Length[NestWhileList[#^2 &, z0, Abs[#] <= 2 &, 1, 3]]];
+           raw[{0.5+0. I, 0.5+0. I}]"#
+      )
+      .unwrap(),
+      "1."
+    );
+  }
+
   // Regression: a `.nb` notebook's `SaveDefinitions -> True` dump can embed a
   // helper as Mathematica's fully serialized `CompiledFunction[…]` — an id
   // tuple, argument patterns, type/constant tables, raw bytecode, the

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6997,6 +6997,55 @@ mod tests {
     assert_eq!(state.error, None, "the compiled body must evaluate cleanly");
   }
 
+  /// An escape-time fractal Manipulate: an `Initialization`-defined
+  /// `Compile`d kernel with `RuntimeAttributes -> {Listable}` is called on
+  /// a `Table`-built grid of complex numbers and rendered through
+  /// `ArrayPlot`, with three Tiny-sized sliders and `ControlPlacement ->
+  /// Left` — the general shape several Wolfram Demonstrations Project
+  /// notebooks use for a Julia/Mandelbrot-style renderer (independently
+  /// written, not copied from any specific one). Regression: a compiled
+  /// function's `RuntimeAttributes -> {Listable}` option was accepted
+  /// syntactically but never made the resulting `CompiledFunction` thread
+  /// over a list/matrix argument — the whole matrix was passed into the
+  /// body as one opaque value instead of being mapped element-wise, so a
+  /// body using its scalar-typed parameter as state for a non-Listable
+  /// function like `NestWhileList` silently collapsed a same-shaped-matrix
+  /// result down to a single scalar, which meant `ArrayPlot` never got a
+  /// matrix to render at all (`ArrayPlot::rectype`) and Woxi Studio's
+  /// output for the whole Manipulate came out blank.
+  #[test]
+  fn manipulate_listable_compile_kernel_feeds_array_plot() {
+    let code = r#"Manipulate[
+      ArrayPlot[
+        Quiet@escapeGrid[Table[a + b I, {b, -1., 1., step}, {a, -1., 1., step}], c + 0. I, maxSteps],
+        ColorFunction -> (ColorData["TemperatureMap"][#] &)
+      ],
+      {{c, -1., "c"}, -2., 2., .1, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{maxSteps, 10, "iterations"}, 2, 50, 1, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{step, 0.5, "resolution"}, 0.1, 1., 0.1, ImageSize -> Tiny},
+      ControlPlacement -> Left,
+      SaveDefinitions -> True,
+      Initialization :> (
+        escapeGrid = Compile[{{z0, _Complex}, {c, _Complex}, {maxSteps, _Integer}},
+          Length[NestWhileList[#^2 + c &, z0, Abs[#] <= 2 &, 1, maxSteps]],
+          RuntimeAttributes -> {Listable}];
+      )
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "a Listable-Compile escape-time kernel feeding ArrayPlot should build a ManipulateState",
+    );
+    assert_eq!(
+      state.error, None,
+      "ArrayPlot must receive a real matrix, not a collapsed scalar"
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the escape-time grid should render as a graphic"
+    );
+  }
+
   /// A dissection Manipulate assembling colored polygon pieces with
   /// `Translate`/`Rotate`, a boolean checkbox control (`{False, True}`
   /// domain) toggling a hint overlay, and several `Tiny` step sliders with


### PR DESCRIPTION
## Summary

This session downloaded a random Wolfram Demonstration ("A Subfamily of Julia Sets") and checked whether Woxi Studio fully supports it. It does not, without this fix: the Manipulate renders blank.

- `Compile[…, RuntimeAttributes -> {Listable}]` was accepted syntactically (it didn't error) but never actually made the resulting `CompiledFunction` thread over a list/matrix argument — the whole matrix was passed into the body as one opaque value instead of being mapped element-wise.
- This went unnoticed for bodies built entirely from already-Listable primitives (`Abs`, `Plus`, …), since those thread on their own regardless of the compiled function's own attribute.
- It broke for a body using its scalar-typed parameter as opaque state for a non-Listable list-producing function like `NestWhileList` — exactly the escape-time-fractal idiom several Wolfram Demonstrations Project notebooks use (`Compile` a kernel with `RuntimeAttributes -> {Listable}`, call it on a `Table`-built grid, render with `ArrayPlot`). The matrix result silently collapsed to a single scalar instead of a same-shaped matrix, so `ArrayPlot` had nothing to render.
- `Compile`'s dispatch now records a `Listable` marker on `CompiledFunction` when `RuntimeAttributes -> {Listable}` (or bare `Listable`) is present among the trailing option rules; applying such a `CompiledFunction` to arguments now threads element-wise over any scalar-typed position that receives a list, broadcasting the other arguments — recursing naturally for nested lists — while falling back to the existing behavior when no scalar position gets a list or list lengths disagree.
- `RuntimeOptions`/`Parallelization` remain accepted but inert (Woxi has no bytecode VM/parallel runtime to honor them), matching how real Mathematica degrades gracefully when those don't apply.

Not copying any verbatim code from the notebook (it's copyrighted); regression tests below reflect the same general construct category with independently written code.

## Test plan
- [x] Added `compile_listable_runtime_attribute_threads_over_list_argument` in `tests/interpreter_tests/function_definitions.rs`, covering both the threaded case and confirming a plain (non-`Listable`) `CompiledFunction` keeps its prior pass-through behavior.
- [x] Added `manipulate_listable_compile_kernel_feeds_array_plot` in `woxi-studio/src/main.rs`, an independently-written escape-time-fractal `Manipulate` (Compile+RuntimeAttributes->Listable+ArrayPlot+Tiny sliders+ControlPlacement->Left+SaveDefinitions->True) matching the real notebook's general construct shape.
- [x] `make test` — 27955 tests passed, 0 failed.
- [x] `make test-studio` — 216 tests passed, 0 failed.
- [x] `make format`.
- [x] Manually parsed the actual downloaded notebook's cells via `woxi::notebook::parse_notebook` and confirmed they extract to exactly the `Compile`/`Manipulate` shape the new tests exercise (not committed, for local verification only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125hQubTq5JLDh7R2w5kHHq

---
_Generated by [Claude Code](https://claude.ai/code/session_0125hQubTq5JLDh7R2w5kHHq)_