### PR TITLE
Implement Overlay for compositing graphics

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1167,7 +1167,7 @@ Subsuperscript,Subsuperscript notation wrapper (stays symbolic),✅,unevaluated,
 KelvinBei,Kelvin bei function (imaginary part of BesselJ on a rotated argument),✅,pure,6.0,1153
 CubeRoot,Returns the real-valued cube root,✅,pure,9.0,1154
 ContinuousAction,Option for continuous action during interactive manipulation,✅,pure,6.0,1155
-Overlay,,🚫,,8.0,1156
+Overlay,Displays a collection of items overlaid on top of each other,✅,pure,8.0,1156
 Permissions,,🚫,,10.0,1157
 CirclePlus,Represents the direct sum or XOR operator,✅,pure,3.0,1158
 TableAlignments,,🚫,,2.0,1159

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -163,6 +163,9 @@ pub fn dispatch_plotting(
     "GraphicsGrid" if !args.is_empty() => {
       Some(crate::functions::graphics::graphics_grid_ast(args))
     }
+    "Overlay" if !args.is_empty() => {
+      Some(crate::functions::graphics::overlay_ast(args))
+    }
     "PlotGrid" if !args.is_empty() => {
       Some(crate::functions::graphics::plot_grid_ast(args))
     }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -15065,6 +15065,129 @@ pub fn graphics_column_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
+/// Overlay[{expr1, expr2, ...}] or Overlay[{...}, Alignment -> align]
+/// Stacks items on top of each other at a shared alignment point, instead
+/// of laying them out side by side — e.g. a plot and a colorbar computed
+/// separately, composited into one picture. Each item renders at its own
+/// natural size; the combined canvas is the bounding box needed to hold
+/// every item once aligned.
+pub fn overlay_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let list_owned;
+  let items: &[Expr] = if let Expr::List(items) = &args[0] {
+    items
+  } else {
+    list_owned = evaluate_expr_to_expr(&args[0])?;
+    match &list_owned {
+      Expr::List(items) => items,
+      _ => {
+        return Err(InterpreterError::EvaluationError(
+          "Overlay expects a list as its first argument".into(),
+        ));
+      }
+    }
+  };
+
+  if items.is_empty() {
+    return Ok(crate::graphics_result(
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".to_string(),
+    ));
+  }
+
+  let (align_h, align_v) = parse_overlay_alignment(&args[1..]);
+
+  let svgs: Vec<String> = items
+    .iter()
+    .filter_map(|item| {
+      let evaluated = evaluate_expr_to_expr(item).ok()?;
+      let svg = crate::evaluator::expr_to_svg(&evaluated);
+      (!svg.is_empty()).then_some(svg)
+    })
+    .collect();
+
+  if svgs.is_empty() {
+    return Ok(crate::graphics_result(
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".to_string(),
+    ));
+  }
+
+  let dims: Vec<(f64, f64)> = svgs
+    .iter()
+    .map(|s| svg_natural_size(s).unwrap_or((0.0, 0.0)))
+    .collect();
+  let canvas_w = dims.iter().fold(0.0_f64, |m, (w, _)| m.max(*w));
+  let canvas_h = dims.iter().fold(0.0_f64, |m, (_, h)| m.max(*h));
+
+  let mut inner = String::new();
+  for (svg, (w, h)) in svgs.iter().zip(dims.iter()) {
+    let cx = align_h * (canvas_w - w) + w / 2.0;
+    let cy = align_v * (canvas_h - h) + h / 2.0;
+    inner.push_str(&embed_svg_centered(svg, cx, cy, *w, *h));
+  }
+
+  let combined = format!(
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{canvas_w:.2}\" height=\"{canvas_h:.2}\" viewBox=\"0 0 {canvas_w:.2} {canvas_h:.2}\">\n{inner}</svg>\n"
+  );
+  crate::clear_captured_graphics();
+  Ok(crate::graphics_result(combined))
+}
+
+/// Parse `Alignment -> spec` for `Overlay`. `spec` is either a single
+/// symbol/number applied to both axes, or `{horizontal, vertical}`. Each
+/// axis accepts `Left`/`Center`/`Right` (horizontal) or `Top`/`Center`/
+/// `Bottom` (vertical), or a bare number used directly as the alignment
+/// fraction (0 = left/top edge, 1 = right/bottom edge — the convention a
+/// Demonstrations Project notebook typically writes as `{0.5, 0.5}` for
+/// `Center`). Defaults to `{Center, Center}`: real Mathematica defaults the
+/// vertical axis to `Baseline`, but `Overlay`'s items are almost always
+/// full graphics rather than text runs, for which `Baseline` and `Center`
+/// coincide.
+fn parse_overlay_alignment(args: &[Expr]) -> (f64, f64) {
+  let mut align_h = 0.5;
+  let mut align_v = 0.5;
+  for arg in args {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    } = arg
+      && matches!(pattern.as_ref(), Expr::Identifier(name) if name == "Alignment")
+    {
+      match replacement.as_ref() {
+        Expr::List(parts) if parts.len() == 2 => {
+          if let Some(f) = alignment_axis_fraction(&parts[0], true) {
+            align_h = f;
+          }
+          if let Some(f) = alignment_axis_fraction(&parts[1], false) {
+            align_v = f;
+          }
+        }
+        other => {
+          if let Some(f) = alignment_axis_fraction(other, true) {
+            align_h = f;
+            align_v = f;
+          }
+        }
+      }
+    }
+  }
+  (align_h, align_v)
+}
+
+/// A single `Alignment` axis value as a 0..1 fraction (see
+/// `parse_overlay_alignment`).
+fn alignment_axis_fraction(expr: &Expr, horizontal: bool) -> Option<f64> {
+  match expr {
+    Expr::Identifier(name) => match name.as_str() {
+      "Center" | "Baseline" => Some(0.5),
+      "Left" if horizontal => Some(0.0),
+      "Right" if horizontal => Some(1.0),
+      "Top" if !horizontal => Some(0.0),
+      "Bottom" if !horizontal => Some(1.0),
+      _ => None,
+    },
+    _ => try_eval_to_f64(expr),
+  }
+}
+
 /// GraphicsGrid[{{g1, g2}, {g3, g4}}, opts...]
 /// Arranges graphics in a 2D grid.
 pub fn graphics_grid_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14734,6 +14734,83 @@ mod graphics_grid {
     assert!(svg.contains(">label</text>"), "{svg}");
   }
 
+  /// `Overlay[{expr1, expr2, ...}]` stacks its items on top of each other
+  /// (composited into one picture) instead of laying them out side by
+  /// side — the shape a Demonstration uses to draw a colorbar or a second
+  /// plot directly over a first one.
+  #[test]
+  fn overlay_stacks_graphics_instead_of_arranging_them() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "Head[Overlay[{Graphics[{Red, Disk[]}], \
+         Graphics[{Blue, Circle[{1, 0}]}]}]]"
+      )
+      .unwrap(),
+      "Graphics"
+    );
+    let result = interpret_with_stdout(
+      "Overlay[{Graphics[{Disk[]}, ImageSize -> 100], \
+       Graphics[{Red, Rectangle[]}, ImageSize -> 100]}]",
+    )
+    .unwrap();
+    assert_eq!(result.result, "-Graphics-");
+    let svg = result.graphics.unwrap();
+    assert!(!svg.contains("-Graphics-"), "cells must be drawn: {svg}");
+    // Both cells occupy the same footprint (one on top of the other), not
+    // side by side or stacked in a column.
+    assert_eq!(svg.matches("<svg x=").count(), 2, "{svg}");
+    assert!(svg.contains("rgb(255,0,0)"), "the red cell must render");
+  }
+
+  /// `Overlay`'s `Alignment -> {h, v}` positions a smaller item within the
+  /// larger items' shared canvas — the same fractional positioning `Column`
+  /// uses, but on both axes at once since items overlap rather than stack.
+  /// A Demonstrations Project notebook commonly spells `Center` as the
+  /// fraction pair `{0.5, 0.5}` rather than the symbol.
+  #[test]
+  fn overlay_alignment_positions_the_smaller_item() {
+    let xy_of = |code: &str| -> Vec<(f64, f64)> {
+      export_svg(code)
+        .lines()
+        .filter(|l| l.starts_with("<svg x="))
+        .filter_map(|l| {
+          let x = l.split("x=\"").nth(1)?.split('"').next()?.parse().ok()?;
+          let y = l.split("y=\"").nth(1)?.split('"').next()?.parse().ok()?;
+          Some((x, y))
+        })
+        .collect()
+    };
+    let items = "{Graphics[{Disk[]}, ImageSize -> {200, 200}], \
+                 Graphics[{Rectangle[]}, ImageSize -> {40, 40}]}";
+    assert_eq!(
+      xy_of(&format!("Overlay[{items}]")),
+      vec![(0.0, 0.0), (80.0, 80.0)],
+      "default alignment centers the smaller item on both axes"
+    );
+    assert_eq!(
+      xy_of(&format!("Overlay[{items}, Alignment -> {{0.5, 0.5}}]")),
+      vec![(0.0, 0.0), (80.0, 80.0)],
+      "a {{0.5, 0.5}} fraction pair means Center, same as the default"
+    );
+    assert_eq!(
+      xy_of(&format!("Overlay[{items}, Alignment -> {{Left, Top}}]")),
+      vec![(0.0, 0.0), (0.0, 0.0)],
+      "Left/Top pins the smaller item to the corner"
+    );
+    assert_eq!(
+      xy_of(&format!("Overlay[{items}, Alignment -> {{Right, Bottom}}]")),
+      vec![(0.0, 0.0), (160.0, 160.0)],
+      "Right/Bottom pins the smaller item to the opposite corner"
+    );
+  }
+
+  #[test]
+  fn overlay_of_an_empty_list_is_a_blank_picture() {
+    clear_state();
+    assert_eq!(interpret("Head[Overlay[{}]]").unwrap(), "Graphics");
+  }
+
   /// A Demonstration's `Manipulate` body commonly styles its whole display
   /// as `Pane[Text@Style[Grid[{…}], size], {w, h}]` — a `Style` sitting
   /// above `Text`/`Pane` wrappers, not directly on the `Grid`. The styled-

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6997,6 +6997,31 @@ mod tests {
     assert_eq!(state.error, None, "the compiled body must evaluate cleanly");
   }
 
+  /// A Manipulate whose body composites two independently computed plots
+  /// with `Overlay[{…}, Alignment -> {0.5, 0.5}]` — the shape a Wolfram
+  /// Demonstrations Project notebook uses to draw one plot directly on top
+  /// of another, e.g. a solution curve over a heat-map inset (independently
+  /// written, not copied from any specific one). Regression: `Overlay` was
+  /// unimplemented, so the body's final expression evaluated to a bare
+  /// symbolic `Overlay[…]` call instead of a picture, leaving the widget's
+  /// graphic blank in Woxi Studio.
+  #[test]
+  fn manipulate_body_overlaying_two_plots() {
+    let code = r#"Manipulate[
+      Overlay[{Plot[Sin[a x], {x, 0, 2 Pi}], Graphics[{Red, Disk[{0, 0}, 0.2]}]}, Alignment -> {0.5, 0.5}],
+      {{a, 1}, 1, 3}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("Overlay body should build a ManipulateState");
+    assert_eq!(state.error, None, "the Overlay body must evaluate cleanly");
+    assert!(
+      state.graphics_handle.is_some(),
+      "the composited picture must render"
+    );
+  }
+
   /// A dissection Manipulate assembling colored polygon pieces with
   /// `Translate`/`Rotate`, a boolean checkbox control (`{False, True}`
   /// domain) toggling a hint overlay, and several `Tiny` step sliders with


### PR DESCRIPTION
## Summary

- Picked a random Wolfram Demonstrations Project notebook ("Controlled Release of a Drug from a Hemispherical Matrix") via the resource system's `RandomResourcePage` API and checked whether Woxi Studio fully supports it.
- Its `Manipulate` body used `Overlay[{plot1, plot2}, Alignment -> {0.5, 0.5}]` to draw a `Plot` and a `ContourPlot` on top of each other. `Overlay` was listed as unimplemented (🚫) in `functions.csv`, so Woxi Studio evaluated the body to a bare symbolic `Overlay[...]` call instead of a picture, leaving the widget's graphic blank.
- Implemented `Overlay`: each item renders to SVG at its own natural size, then all items are composited onto a shared canvas sized to the largest item, positioned per the `Alignment` option (symbols `Left`/`Center`/`Right`/`Top`/`Bottom`, or a `0..1` fraction pair — defaulting to `Center`/`Center`).
- Registered the new function in the plotting dispatch table and marked it ✅ in `functions.csv`.

## Test plan

- [x] Added interpreter unit tests in `tests/interpreter_tests/graphics.rs` covering: stacking two `Graphics` objects, `Alignment` positioning of a smaller item against a larger one (default, explicit fraction pair, symbolic corners), and the empty-list edge case.
- [x] Added a Woxi Studio regression test (`manipulate_body_overlaying_two_plots`) exercising a `Manipulate` whose body composites two plots with `Overlay`, asserting it evaluates without error and produces a rendered graphic.
- [x] `cargo test` (full interpreter/CLI/misc suite): 25805 + 269 + 45 + 1262 + 576 tests passed, 0 failed.
- [x] `cargo test -p woxi-studio --release`: 216 tests passed, 0 failed.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdcieRmgx4XVxR9MCBLDqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdcieRmgx4XVxR9MCBLDqk)_