### PR TITLE
Fix ListLinePlot rejecting a Tooltip-wrapped whole data series

### DIFF
--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -229,11 +229,18 @@ pub fn dispatch_plotting(
       // expression symbolic.
       match crate::evaluator::evaluate_expr_to_expr(&args[0]) {
         // A TimeSeries / TemporalData or an Association is a valid
-        // (non-List) data source.
+        // (non-List) data source, and so is a display wrapper
+        // (`Tooltip`, `Style`, ...) around any of those.
         Ok(evaluated)
-          if !matches!(evaluated, Expr::List(_) | Expr::Association(_))
-            && crate::functions::timeseries_ast::temporal_paths(&evaluated)
-              .is_none() =>
+          if !matches!(
+            crate::functions::list_plot::strip_plot_data_display_wrapper(
+              &evaluated
+            ),
+            Expr::List(_) | Expr::Association(_)
+          ) && crate::functions::timeseries_ast::temporal_paths(
+            &evaluated,
+          )
+          .is_none() =>
         {
           crate::emit_message(&format!(
             "ListLinePlot::lpn: {} is not a list of numbers or pairs of numbers.",

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -232,15 +232,15 @@ pub fn dispatch_plotting(
         // (non-List) data source, and so is a display wrapper
         // (`Tooltip`, `Style`, ...) around any of those.
         Ok(evaluated)
-          if !matches!(
-            crate::functions::list_plot::strip_plot_data_display_wrapper(
-              &evaluated
-            ),
-            Expr::List(_) | Expr::Association(_)
-          ) && crate::functions::timeseries_ast::temporal_paths(
-            &evaluated,
-          )
-          .is_none() =>
+          if {
+            let stripped =
+              crate::functions::list_plot::strip_plot_data_display_wrapper(
+                &evaluated,
+              );
+            !matches!(stripped, Expr::List(_) | Expr::Association(_))
+              && crate::functions::timeseries_ast::temporal_paths(&stripped)
+                .is_none()
+          } =>
         {
           crate::emit_message(&format!(
             "ListLinePlot::lpn: {} is not a list of numbers or pairs of numbers.",

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -201,12 +201,10 @@ pub fn strip_plot_data_display_wrapper(expr: &Expr) -> Expr {
 /// `{1, Style[2, Red], 3}` keeps its numbers. `Callout` is kept as a
 /// `Labeled` so its label still draws.
 fn canonicalize_element(e: &Expr) -> Expr {
-  match e {
+  let e = strip_plot_data_display_wrapper(e);
+  match &e {
     Expr::FunctionCall { name, args } if !args.is_empty() => {
       match name.as_str() {
-        _ if PLOT_DATA_DISPLAY_WRAPPER_HEADS.contains(&name.as_str()) => {
-          canonicalize_element(&args[0])
-        }
         "Callout" if args.len() >= 2 => Expr::FunctionCall {
           name: "Labeled".into(),
           args: vec![canonicalize_element(&args[0]), args[1].clone()].into(),
@@ -218,7 +216,7 @@ fn canonicalize_element(e: &Expr) -> Expr {
     Expr::List(inner) => {
       Expr::List(inner.iter().map(canonicalize_element).collect())
     }
-    _ => e.clone(),
+    _ => e,
   }
 }
 
@@ -247,6 +245,7 @@ fn weighted_data_values(args: &[Expr]) -> Expr {
 /// `Association`s. The `data -> labels` rule form is handled by the caller.
 fn canonicalize_plot_data(expr: &Expr, keys_label_points: bool) -> Expr {
   let e = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
+  let e = strip_plot_data_display_wrapper(&e);
   match &e {
     Expr::Association(pairs) => association_to_data(pairs, keys_label_points),
     Expr::List(items) => {
@@ -254,9 +253,6 @@ fn canonicalize_plot_data(expr: &Expr, keys_label_points: bool) -> Expr {
     }
     Expr::FunctionCall { name, args } if !args.is_empty() => {
       match name.as_str() {
-        _ if PLOT_DATA_DISPLAY_WRAPPER_HEADS.contains(&name.as_str()) => {
-          canonicalize_plot_data(&args[0], keys_label_points)
-        }
         "Callout" if args.len() >= 2 => Expr::FunctionCall {
           name: "Labeled".into(),
           args: vec![

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -164,6 +164,38 @@ fn association_to_data(
   Expr::List(pairs.iter().map(|(_, v)| v.clone()).collect())
 }
 
+/// Head names that ListPlot-family functions (and ordinary `Plot`) treat as
+/// transparent display wrappers around a data argument: `Tooltip[data,
+/// label]`, `Style[data, ...]`, etc. draw the underlying data with the
+/// wrapper's presentation but are otherwise invisible to data validation.
+pub const PLOT_DATA_DISPLAY_WRAPPER_HEADS: [&str; 8] = [
+  "Tooltip",
+  "Style",
+  "Legended",
+  "Annotation",
+  "PopupWindow",
+  "Mouseover",
+  "StatusArea",
+  "Button",
+];
+
+/// Peel a chain of [`PLOT_DATA_DISPLAY_WRAPPER_HEADS`] wrappers to expose
+/// the data expression underneath, e.g. `Tooltip[{1, 2, 3}, "cost"]` ->
+/// `{1, 2, 3}`. Used both to validate a data argument (is it a wrapper
+/// around a list?) and, via [`canonicalize_plot_data`]/[`canonicalize_element`],
+/// to actually strip it before parsing.
+pub fn strip_plot_data_display_wrapper(expr: &Expr) -> Expr {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if !args.is_empty()
+        && PLOT_DATA_DISPLAY_WRAPPER_HEADS.contains(&name.as_str()) =>
+    {
+      strip_plot_data_display_wrapper(&args[0])
+    }
+    _ => expr.clone(),
+  }
+}
+
 /// Strip display wrappers from a single list entry (a scalar, an `{x, y}`
 /// pair, or a nested series), recursing into inner lists so that
 /// `{1, Style[2, Red], 3}` keeps its numbers. `Callout` is kept as a
@@ -172,8 +204,7 @@ fn canonicalize_element(e: &Expr) -> Expr {
   match e {
     Expr::FunctionCall { name, args } if !args.is_empty() => {
       match name.as_str() {
-        "Tooltip" | "Style" | "Legended" | "Annotation" | "PopupWindow"
-        | "Mouseover" | "StatusArea" | "Button" => {
+        _ if PLOT_DATA_DISPLAY_WRAPPER_HEADS.contains(&name.as_str()) => {
           canonicalize_element(&args[0])
         }
         "Callout" if args.len() >= 2 => Expr::FunctionCall {
@@ -223,8 +254,7 @@ fn canonicalize_plot_data(expr: &Expr, keys_label_points: bool) -> Expr {
     }
     Expr::FunctionCall { name, args } if !args.is_empty() => {
       match name.as_str() {
-        "Tooltip" | "Style" | "Legended" | "Annotation" | "PopupWindow"
-        | "Mouseover" | "StatusArea" | "Button" => {
+        _ if PLOT_DATA_DISPLAY_WRAPPER_HEADS.contains(&name.as_str()) => {
           canonicalize_plot_data(&args[0], keys_label_points)
         }
         "Callout" if args.len() >= 2 => Expr::FunctionCall {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1944,7 +1944,7 @@ fn unary_condition_number(name: &str, x: f64) -> Option<f64> {
   use crate::functions::math_ast::number_theory::digamma;
   use crate::functions::math_ast::numeric_utils::{erf_f64, ln_gamma};
   // 2/Sqrt[Pi], the derivative constant of Erf/Erfc.
-  const TWO_OVER_SQRT_PI: f64 = 1.128_379_167_095_512_6;
+  const TWO_OVER_SQRT_PI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
   let c = match name {
     // Sinh' = Cosh, so cond = x*Cosh/Sinh = x/Tanh[x]. Csch = 1/Sinh shares it.
     "Sinh" | "Csch" => x / x.tanh(),

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2012,6 +2012,32 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_list_line_plot_accepts_whole_series_tooltip_wrapper() {
+    // `ListLinePlot[Tooltip[data, label], ...]` wraps the *entire* data
+    // series in a Tooltip (as opposed to `Tooltip` wrapping individual
+    // points) so hovering the line shows `label`. This must plot exactly
+    // like the bare series, not report `ListLinePlot::lpn` and stay
+    // unevaluated: the data-argument validity check only unwrapped
+    // `Tooltip` around single points, not around the whole list.
+    clear_state();
+    let bare = interpret_with_stdout("ListLinePlot[{1, 4, 9, 16}]").unwrap();
+    clear_state();
+    let wrapped = interpret_with_stdout(
+      "ListLinePlot[Tooltip[{1, 4, 9, 16}, \"squares\"]]",
+    )
+    .unwrap();
+    assert!(
+      wrapped.warnings.is_empty(),
+      "a whole-series Tooltip wrapper must not raise ListLinePlot::lpn: {:?}",
+      wrapped.warnings
+    );
+    assert_eq!(
+      wrapped.result, bare.result,
+      "a Tooltip-wrapped series should render identically to the bare series"
+    );
+  }
+
+  #[test]
   fn test_plot_label_style_sets_frame_label_size_and_color() {
     // LabelStyle -> {size, color} must restyle the FrameLabel/AxesLabel/
     // PlotLabel text; it used to be accepted and silently dropped, so a

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2038,6 +2038,33 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_list_line_plot_accepts_tooltip_wrapped_time_series() {
+    // Same whole-argument-wrapper bug as
+    // `test_list_line_plot_accepts_whole_series_tooltip_wrapper`, but for the
+    // non-List `TimeSeries` data source: the `ListLinePlot::lpn` guard must
+    // strip the `Tooltip` before checking for temporal data too, not just
+    // before the List/Association check.
+    clear_state();
+    let bare =
+      interpret_with_stdout("ListLinePlot[TimeSeries[{{1, 2}, {2, 4}}]]")
+        .unwrap();
+    clear_state();
+    let wrapped = interpret_with_stdout(
+      "ListLinePlot[Tooltip[TimeSeries[{{1, 2}, {2, 4}}], \"series\"]]",
+    )
+    .unwrap();
+    assert!(
+      wrapped.warnings.is_empty(),
+      "a Tooltip-wrapped TimeSeries must not raise ListLinePlot::lpn: {:?}",
+      wrapped.warnings
+    );
+    assert_eq!(
+      wrapped.result, bare.result,
+      "a Tooltip-wrapped TimeSeries should render identically to the bare one"
+    );
+  }
+
+  #[test]
   fn test_plot_label_style_sets_frame_label_size_and_color() {
     // LabelStyle -> {size, color} must restyle the FrameLabel/AxesLabel/
     // PlotLabel text; it used to be accepted and silently dropped, so a

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6997,6 +6997,43 @@ mod tests {
     assert_eq!(state.error, None, "the compiled body must evaluate cleanly");
   }
 
+  /// A supply/demand-style Manipulate whose body computes a running-average
+  /// series and plots it with `ListLinePlot[Tooltip[series, "label"], ...]`
+  /// alongside ordinary `Plot`s, mirroring the "wrap the whole data series in
+  /// a Tooltip so hovering shows a name" idiom common to Wolfram
+  /// Demonstrations Project economics notebooks (independently written, not
+  /// copied from any specific one). Regression: `ListLinePlot` treated the
+  /// `Tooltip[...]` wrapper as invalid data (it only unwrapped `Tooltip`
+  /// around individual points, not around the whole series), emitted
+  /// `ListLinePlot::lpn`, and left the call unevaluated — so this cell's
+  /// second panel came out blank in Woxi Studio.
+  #[test]
+  fn manipulate_list_line_plot_tooltip_wrapped_series() {
+    let code = r#"Manipulate[
+      GraphicsGrid[{{
+        Plot[a x, {x, 0, 10}],
+        ListLinePlot[Tooltip[Table[Accumulate[Range[n]][[i]]/i, {i, n}], "running average"]]
+      }}],
+      {{a, 1}, 0, 2},
+      {{n, 10}, 5, 20, 1}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "a Tooltip-wrapped ListLinePlot series should build a ManipulateState",
+    );
+
+    assert_eq!(
+      state.error, None,
+      "a whole-series Tooltip wrapper must not fail data validation: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the GraphicsGrid panel should still render"
+    );
+  }
+
   /// A dissection Manipulate assembling colored polygon pieces with
   /// `Translate`/`Rotate`, a boolean checkbox control (`{False, True}`
   /// domain) toggling a hint overlay, and several `Tiny` step sliders with


### PR DESCRIPTION
## Summary

- Fetched a random Wolfram Demonstration notebook (economics: a supply/demand Manipulate) and checked whether Woxi Studio fully supports it.
- Found that `ListLinePlot[Tooltip[data, "label"], ...]` — wrapping an entire data series in `Tooltip` (as opposed to wrapping individual points) — was rejected: the `ListLinePlot::lpn` data-validity guard only recognized `Tooltip`/`Style`/etc. wrapping around individual points, not around the whole series argument. It emitted the `lpn` message and left the call unevaluated, which is how that Demonstration's `ListLinePlot` panel rendered blank inside a `Manipulate` in Woxi Studio.
- Fixed by extracting the existing wrapper-head list (`Tooltip`, `Style`, `Legended`, `Annotation`, `PopupWindow`, `Mouseover`, `StatusArea`, `Button`) that was already duplicated across two unwrap sites in `list_plot.rs` into a shared `PLOT_DATA_DISPLAY_WRAPPER_HEADS` constant plus a `strip_plot_data_display_wrapper` helper, and used that helper in the `ListLinePlot::lpn` validity check in `plotting.rs` as well — so the guard and the actual data parser agree on what counts as valid data.

## Test plan

- [x] Added `test_list_line_plot_accepts_whole_series_tooltip_wrapper` in `tests/interpreter_tests.rs`, asserting a `Tooltip`-wrapped series renders identically to the bare series with no warnings.
- [x] Added `manipulate_list_line_plot_tooltip_wrapped_series` in `woxi-studio/src/main.rs`, an independently-written Manipulate exercising the same construct category as the source notebook (not copied verbatim, per repo guidelines).
- [x] `cargo nextest run` (core `woxi` crate): 27955 passed, 0 failed.
- [x] `cargo nextest run -p woxi-studio`: 216 passed, 0 failed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtBDSDg2NRdKs6Dq5KM9Sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtBDSDg2NRdKs6Dq5KM9Sm)_