### PR TITLE
Fix Manipulate reconstruction for named-character control variables

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -21928,6 +21928,28 @@ fn parse_manipulate_control(
     });
   }
 
+  // A single bound that fully evaluates but is none of the above (a colour,
+  // a list of choices, a widget-building function) has no way to become a
+  // control — it is an internal helper value tagged with some marker
+  // Wolfram's front end doesn't expose as a real domain. A Demonstration's
+  // saved `ManipulateBoxes[…]` dump does this for a `Compile`d helper
+  // function only ever called from the body: `{{f$$, CompiledFunction[…]},
+  // "function"}` names no range, no choice list, and no colour — just a
+  // fixed value and an internal type tag. Bind it as a fixed constant
+  // instead of falling through to `None` below and dropping the whole
+  // spec — and with it the variable's only value — the way a bound that
+  // fails to evaluate (an unbound symbol the caller's post-body-bindings
+  // retry might still resolve to a real list) must keep doing.
+  if bounds.len() == 1
+    && crate::evaluator::evaluate_expr_to_expr(bounds[0]).is_ok()
+  {
+    let value = explicit_initial.as_ref().map_or_else(
+      || crate::syntax::expr_to_input_form(bounds[0]),
+      manipulate_value_to_input_form,
+    );
+    return Some(ParsedControl::Fixed { name, value });
+  }
+
   // No domain at all — `{u, uinit}` or `{{u, uinit, ulbl}, opts…}` with
   // nothing but options (`FieldSize -> n`, `Enabled -> cond`, …) after the
   // head. Wolfram's default widget for a bare variable with no min/max and

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -180,7 +180,7 @@ NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Pie
 // is parsed via the `Identifier` rule below). Matches wolframscript's
 // identifier-character semantics where named characters act like
 // identifier-character literals.
-NamedCharIdentifier = @{ NamedCharBase ~ (NamedCharBase | ASCII_ALPHANUMERIC | LETTER | PrivateUseLetter | "_")* }
+NamedCharIdentifier = @{ NamedCharBase ~ (NamedCharBase | ASCII_ALPHANUMERIC | LETTER | PrivateUseLetter | "_" | "$")* }
 // Identifiers may carry a context prefix using backticks, e.g. `Global`x` or
 // `Foo`Bar`x`. A leading backtick ` `x` ` is shorthand for the current
 // context (Global by default). Each segment after a backtick must begin

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -671,6 +671,27 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_named_character_identifier_keeps_trailing_dollar_signs() {
+    // Wolfram's FrontEnd names a Manipulate-tracked variable built from a
+    // named character with a trailing `$$` (e.g. `\[Delta]$$`); the whole
+    // thing must parse as one Symbol, not split into the bare named
+    // character and a separate `$$` symbol joined by implicit
+    // multiplication. This is exactly the shape a Demonstration's
+    // `{{\[Delta]$$, 0.015}, 0.01, 0.025, 0.001}` Manipulate control spec
+    // takes once its `$CellContext`` prefix is stripped when Woxi Studio
+    // rebuilds a saved widget from a notebook with no Input-cell source.
+    clear_state();
+    assert_eq!(interpret("Head[\\[Delta]$$]").unwrap(), "Symbol");
+    assert_eq!(interpret("\\[Delta]$$ = 3; \\[Delta]$$ + 1").unwrap(), "4");
+    clear_state();
+    // The same holds for a function-call head, not just a bare symbol.
+    assert_eq!(
+      interpret("\\[Theta]$$[x_] := x^2; \\[Theta]$$[5]").unwrap(),
+      "25"
+    );
+  }
+
+  #[test]
   fn test_expression_then_comment() {
     // Expression followed by comment should evaluate the expression
     clear_state();

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -20992,6 +20992,53 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
     assert!(state.graphics_handle.is_some());
   }
 
+  /// A saved `ManipulateBoxes[…]` dump — the shape a Wolfram Demonstration
+  /// downloaded straight from a share link carries, with no Input-cell
+  /// source to fall back on (see [`instantiate_manipulate_from_box_dump`]) —
+  /// can declare a helper variable whose "Specifications" entry names no
+  /// range, no discrete choice list and no colour: just `{{var, value},
+  /// "someTag"}`, where the tag is an internal type marker the front end
+  /// uses (`"function"` for a `Compile`d helper only ever called from the
+  /// body) rather than a real control domain. Before this test's fix such a
+  /// spec matched none of `parse_manipulate_control`'s recognized shapes and
+  /// was dropped entirely — taking the variable's only binding with it — so
+  /// the body's call to it raised an evaluation error instead of running.
+  #[test]
+  fn tagged_helper_specification_binds_without_a_spurious_control() {
+    let dump = "DynamicModuleBox[{}, DynamicBox[Manipulate`ManipulateBoxes[\n\
+      1, StandardForm, \n\
+      \"Body\" :> $CellContext`helper$$[$CellContext`n$$], \n\
+      \"Specifications\" :> {\
+        {{$CellContext`helper$$, \
+          CompiledFunction[{1, 2, 3}, {Blank[Integer]}, {}, \
+            Function[{$CellContext`x}, $CellContext`x^2], Evaluate]}, \
+          \"function\"}, \
+        {{$CellContext`n$$, 3}, 1, 10}}, \n\
+      \"Options\" :> {}],\n\
+      DynamicModuleValues:>{}]]";
+    let state = instantiate_manipulate_from_box_dump(dump)
+      .expect("the reconstructed Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "the helper$$ binding must resolve instead of erroring: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state
+        .controls
+        .iter()
+        .map(|c| c.name().to_string())
+        .collect::<Vec<_>>(),
+      vec!["n$$"],
+      "the tagged helper spec must not create a spurious second control: \
+       {:?}",
+      state.controls
+    );
+    // helper$$ falls back to the embedded uncompiled `Function[{x}, x^2]`
+    // applied to n$$'s initial value 3.
+    assert_eq!(state.text_output.as_deref(), Some("9"));
+  }
+
   /// A synthetic "throw a dart at a target" Manipulate in the shape the
   /// "Dart Practice" Demonstration uses: the interactive picture lives in a
   /// `DynamicModule` wrapping the Manipulate body, and a `Button` embedded


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstration ("Mock Theta Functions", downloaded via the Wolfram Demonstrations Project's resource API), its saved `Manipulate` widget — reconstructed from the notebook's `ManipulateBoxes[…]` dump since the notebook carries no editable Input-cell source — failed with:

```
Table::iterb: Iterator {y, -0.999, 0.999, δ*$$} does not have appropriate bounds.
```

- **Grammar fix**: `NamedCharIdentifier`'s continuation character set omitted `"$"`, so a named character immediately followed by a dollar sign — Wolfram's own naming convention for FrontEnd-tracked `Manipulate` variables, e.g. `\[Delta]$$` — tokenized as two separate identifiers (`\[Delta]` and `$$`) joined by implicit multiplication instead of as one symbol. The plain `Identifier` rule already accepted `$` in this position; `NamedCharIdentifier` now matches it.
- **Manipulate spec fallback fix**: found via code review of the same area — `parse_manipulate_control` returned `None` (silently dropping the whole variable spec, and with it the variable's only binding) for a single-bound spec that evaluates cleanly but matches none of the recognized control shapes (colour, discrete choice list, custom-control builder) — e.g. `{{f$$, CompiledFunction[…]}, "function"}`, the shape a saved Demonstration dump uses to tag an internal `Compile`d helper. It's now bound as a fixed constant instead, the same way an already-recognized single-bound spec is handled.

With both fixes, the demonstration's interactive density/contour/3D plot now builds and renders correctly in Woxi Studio.

## Test plan

- [x] Added `test_named_character_identifier_keeps_trailing_dollar_signs` in `tests/interpreter_tests.rs`, covering both a bare symbol and a function-call head.
- [x] Added `tagged_helper_specification_binds_without_a_spurious_control` in `woxi-studio/src/main.rs`, a synthetic (not copied from the notebook) `ManipulateBoxes[…]` dump reproducing the tagged-helper spec shape end-to-end.
- [x] `cargo test` (core crate): all suites pass — 25803 + 1262 + 576 + 269 + 45 tests, 0 failed.
- [x] `cargo test -p woxi-studio --bin woxi-studio`: 216 passed, 0 failed.
- [x] `cargo fmt`.
- [x] Manually verified against the real downloaded notebook (not committed, per copyright) that the reconstructed `Manipulate` now builds a widget with `error: None` and a rendered graphic, and no other unrelated control names (e.g. `\[Delta]$$`) are ever created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8y1XXZvJYQPqa6fzQMSSw


---
_Generated by [Claude Code](https://claude.ai/code/session_01T8y1XXZvJYQPqa6fzQMSSw)_