### PR TITLE
Fix Clip to accept Infinity as a range bound

### DIFF
--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -2799,10 +2799,13 @@ pub fn clip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (min_expr, max_expr, min_val, max_val) = if args.len() >= 2 {
     match &args[1] {
       Expr::List(bounds) if bounds.len() == 2 => {
-        let Some(min) = try_eval_to_f64(&bounds[0]) else {
+        // `±Infinity` is a common one-sided bound (e.g. `Clip[x, {0,
+        // Infinity}]` to only reject negatives), so bounds must accept it
+        // the same way the clipped value itself does just below.
+        let Some(min) = try_eval_to_f64_with_infinity(&bounds[0]) else {
           return unevaluated();
         };
-        let Some(max) = try_eval_to_f64(&bounds[1]) else {
+        let Some(max) = try_eval_to_f64_with_infinity(&bounds[1]) else {
           return unevaluated();
         };
         (bounds[0].clone(), bounds[1].clone(), min, max)

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -4262,6 +4262,23 @@ mod clip {
   }
 
   #[test]
+  fn clip_infinity_as_a_bound_evaluates() {
+    // Regression: the bounds themselves accept `±Infinity` for a one-sided
+    // range, the same way the clipped value does above. Previously only
+    // `try_eval_to_f64` (which rejects Infinity) was used on the bounds,
+    // so any `Clip[x, {.., Infinity}]` or `Clip[x, {-Infinity, ..}]` stayed
+    // unevaluated no matter what `x` was.
+    assert_eq!(interpret("Clip[5, {0, Infinity}]").unwrap(), "5");
+    assert_eq!(interpret("Clip[-5, {0, Infinity}]").unwrap(), "0");
+    assert_eq!(interpret("Clip[-5, {-Infinity, 0}]").unwrap(), "-5");
+    assert_eq!(interpret("Clip[5, {-Infinity, 0}]").unwrap(), "0");
+    assert_eq!(
+      interpret("Clip[{-5, 1, 3.5}, {0, Infinity}]").unwrap(),
+      "{0, 1, 3.5}"
+    );
+  }
+
+  #[test]
   fn clip_indeterminate_returns_indeterminate() {
     assert_eq!(interpret("Clip[Indeterminate]").unwrap(), "Indeterminate");
   }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -24226,4 +24226,141 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ 
       degenerate.graphics
     );
   }
+
+  /// A randomly-sampled Wolfram Demonstrations Project notebook ("Rolling
+  /// Two Dice with Weighted History") reweights each new random draw so
+  /// outcomes that have appeared less than a running target frequency get
+  /// picked more often, then plots the resulting frequencies against the
+  /// target ones once the run finishes. Independently written, not copied
+  /// from the original: this version draws from a 6-color urn (not dice),
+  /// reinforces weights from a `deficit` (target minus observed-so-far,
+  /// clipped non-negative) instead of the original's `2^(...)`
+  /// information-theoretic exponent, uses different helper and variable
+  /// names, a `Clip`-based instead of a division-based weighting, and a
+  /// `showTally` checkbox toggling a `Column` of `{color, count}` pairs
+  /// instead of the original's raw-rolls dump.
+  ///
+  /// The construct worth pinning down is a `Manipulate` `Initialization`
+  /// block defining a helper (`freqOf`) that closes over an
+  /// `Initialization`-scoped list (`colors$$`), called from a
+  /// `Module`-local `For`/`Increment` loop in the body that rebuilds a
+  /// weighted `RandomChoice` argument (`deficit -> colors$$`) fresh on
+  /// every iteration — together with `Tally[Sort[...]]` and a
+  /// `Riffle`/`Partition` comparison `ListPlot`.
+  #[test]
+  fn demonstration_urn_reinforcement_manipulate_builds_its_history() {
+    let code = r#"Manipulate[
+      SeedRandom[seed];
+      Module[{drawn = {}, k, deficit, picked},
+        For[k = 1, k <= draws, Increment[k],
+          deficit = Clip[base$$ - freqOf[drawn], {0, Infinity}] + 1;
+          picked =
+            If[k <= warmup || RandomReal[] < pRandom,
+              RandomChoice[base$$ -> colors$$],
+              RandomChoice[deficit -> colors$$]
+            ];
+          drawn = Append[drawn, picked]
+        ];
+        Pane[
+          Column[{
+            Style["last draw: " <> ToString[Last[drawn]], Bold],
+            If[showTally,
+              comparePlot[freqOf[drawn]],
+              ""
+            ],
+            Style["tally", Bold],
+            If[showTally, Tally[Sort[drawn]], ""]
+          }]
+        ]
+      ],
+      {{seed, 11, "seed"}, 1, 999999, 1, Appearance -> "Labeled", ImageSize -> 100},
+      {{draws, 40, "draws"}, 1, 300, 1, Appearance -> "Labeled", ImageSize -> 100},
+      {{warmup, 4, "warmup draws"}, 0, 20, 1, Appearance -> "Labeled", ImageSize -> 100},
+      {{pRandom, 0.15, "random fraction"}, 0, 1, Appearance -> "Labeled", ImageSize -> 100},
+      {{showTally, True, "show tally"}, {False, True}},
+      Initialization :> (
+        colors$$ = Range[1, 6];
+        base$$ = {2, 3, 5, 3, 2, 1};
+        freqOf[data_] := Table[Count[data, colors$$[[c]]], {c, 1, Length[colors$$]}];
+        comparePlot[f_] := ListPlot[{
+          Partition[Riffle[colors$$, base$$], 2],
+          Partition[Riffle[colors$$, f], 2]
+        }, PlotStyle -> {Gray, Darker[Green]}, PlotRange -> {{0.5, 6.5}, {0, 15}}];
+      )
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("four labelled sliders and a checkbox should build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: seed_name, ..
+        },
+        manipulate::ControlState::Continuous {
+          name: draws_name, ..
+        },
+        manipulate::ControlState::Continuous {
+          name: warmup_name, ..
+        },
+        manipulate::ControlState::Continuous {
+          name: prandom_name, ..
+        },
+        manipulate::ControlState::Discrete {
+          name: tally_name,
+          values: tally_values,
+          current_index: tally_index,
+          ..
+        },
+      ] => {
+        assert_eq!(seed_name, "seed");
+        assert_eq!(draws_name, "draws");
+        assert_eq!(warmup_name, "warmup");
+        assert_eq!(prandom_name, "pRandom");
+        assert_eq!(tally_name, "showTally");
+        assert_eq!(tally_values, &["False", "True"]);
+        assert_eq!(*tally_index, 1, "showTally defaults to True");
+      }
+      other => panic!("expected four sliders and a checkbox, got {other:?}"),
+    }
+
+    // With `warmup = 4` and `pRandom = 0.15`, most of the 40 draws pick
+    // from the reinforced `deficit` weights, which keep every color's
+    // count from drifting far below its `base$$` share — so all six
+    // colors must appear at least once. Checked independently against
+    // `woxi eval` on the same from-scratch helpers, seeded with 11.
+    let bindings: Vec<(String, String)> = state
+      .controls
+      .iter()
+      .map(|c| (c.name().to_string(), c.current_code()))
+      .collect();
+    let tally = woxi::with_scoped_globals(&bindings, || {
+      woxi::interpret_with_stdout(
+        r#"SeedRandom[seed];
+        Module[{drawn = {}, k, deficit, picked},
+          For[k = 1, k <= draws, Increment[k],
+            deficit = Clip[base$$ - freqOf[drawn], {0, Infinity}] + 1;
+            picked =
+              If[k <= warmup || RandomReal[] < pRandom,
+                RandomChoice[base$$ -> colors$$],
+                RandomChoice[deficit -> colors$$]
+              ];
+            drawn = Append[drawn, picked]
+          ];
+          Sort[Tally[drawn][[All, 1]]]
+        ]"#,
+      )
+    })
+    .expect("the reinforcement helpers must evaluate");
+    assert_eq!(
+      tally.result, "{1, 2, 3, 4, 5, 6}",
+      "every color must be drawn at least once over 40 reinforced draws"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Found via the scheduled Woxi Studio compatibility check: a randomly-sampled Wolfram Demonstrations Project notebook ("Rolling Two Dice with Weighted History") uses a weighted-`RandomChoice` pattern whose weight list is built with `Clip[…, {0, Infinity}]`.
- `Clip[x, {min, max}]` stayed unevaluated whenever `min` or `max` was `Infinity`: the bound values were read with `try_eval_to_f64`, which rejects infinities, while the clipped value itself already used `try_eval_to_f64_with_infinity`. Fixed both bounds to use the infinity-aware conversion, matching how one-sided ranges like `Clip[x, {0, Infinity}]` work in Wolfram Language (a common idiom to just reject negatives).
- Added a regression test (`clip_infinity_as_a_bound_evaluates`) covering both one-sided bounds, list input, and the previously-broken numeric-value cases.
- Added an independently-written Woxi Studio test (`demonstration_urn_reinforcement_manipulate_builds_its_history`) exercising the same construct category as the sampled Demonstration — a `Manipulate` `Initialization` block defining a weighted-`RandomChoice` helper closing over a `Module`-local `For`/`Increment` loop, with `Tally`/`Sort` and a `Riffle`/`Partition` comparison `ListPlot` — confirming Woxi Studio now builds and evaluates that widget cleanly. (Not copied from the sampled notebook, which is copyrighted material — different mechanic, names, ranges and layout throughout.)

## Test plan

- [x] `make test` (27965 unit tests passed)
- [x] `make test-studio` (216 tests passed, including the new demonstration test)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FSH7USCNTKTXZ19oMd5Bb

---
_Generated by [Claude Code](https://claude.ai/code/session_014FSH7USCNTKTXZ19oMd5Bb)_