### PR TITLE
Render EventHandler-wrapped Dynamic graphics in Woxi Studio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3437,7 +3437,10 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
     // meaning for an already-rendered graphic, so releasing the `Dynamic`
     // hold and dropping them is the same trade `render_event_handler_if_needed`
     // makes for the event rules it wraps.
-    "Dynamic" => render_dynamic_if_needed(inner),
+    // Releasing the `Dynamic` hold only gets as far as a symbolic
+    // `Graphics[…]`/`Image[…]` call — same as the top-level pipeline, it
+    // still needs a render pass to turn that into the drawn picture.
+    "Dynamic" => render_graphics_fc_if_needed(render_dynamic_if_needed(inner)),
     // Rebuild `Style[inner, directives…]` (with the outer wrappers now
     // stripped) rather than pushing the directives into each cell, so this
     // hits the same `Style[Grid[…], …]` arm of `render_grid_if_needed` a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2491,7 +2491,7 @@ fn format_top_level_result(result_expr: syntax::Expr, depth: usize) -> String {
   let result_expr = render_tabular_if_needed(result_expr);
   // In visual mode, render TableForm[list], MatrixForm[list], and Column[list] as SVGs
   let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
-    render_visual_display_pipeline(result_expr)
+    render_visual_display_pipeline(&result_expr)
   } else {
     result_expr
   };
@@ -3324,7 +3324,7 @@ fn render_event_handler_if_needed(expr: syntax::Expr) -> syntax::Expr {
     syntax::Expr::FunctionCall { name, args }
       if name == "EventHandler" && !args.is_empty() =>
     {
-      render_visual_display_pipeline(args[0].clone())
+      render_visual_display_pipeline(&args[0])
     }
     _ => expr,
   }
@@ -3335,12 +3335,12 @@ fn render_event_handler_if_needed(expr: syntax::Expr) -> syntax::Expr {
 /// `MatrixForm`, `Column`, `Row`, `Grid`, … wrappers into embedded SVGs.
 /// Used for a cell's top-level result and, recursively, for the content an
 /// `EventHandler[…]` wraps once its event rules have been dropped.
-fn render_visual_display_pipeline(expr: syntax::Expr) -> syntax::Expr {
+fn render_visual_display_pipeline(expr: &syntax::Expr) -> syntax::Expr {
   // Strip the wrappers that only say how to set what they hold, so the
   // passes below see the wrapped content (e.g. Pane[Column[{…,
   // Graphics[…]}]] renders the column with its embedded graphic). CLI
   // mode keeps the symbolic Pane[…] echo to match wolframscript.
-  let expr = unwrap_display_pass_through(&expr);
+  let expr = unwrap_display_pass_through(expr);
   let expr = render_interactive_pane_if_needed(expr);
   let expr = render_labeled_if_needed(expr);
   let expr = render_dynamic_if_needed(expr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2491,25 +2491,7 @@ fn format_top_level_result(result_expr: syntax::Expr, depth: usize) -> String {
   let result_expr = render_tabular_if_needed(result_expr);
   // In visual mode, render TableForm[list], MatrixForm[list], and Column[list] as SVGs
   let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
-    // Strip the wrappers that only say how to set what they hold, so the
-    // passes below see the wrapped content (e.g. Pane[Column[{…,
-    // Graphics[…]}]] renders the column with its embedded graphic). CLI
-    // mode keeps the symbolic Pane[…] echo to match wolframscript.
-    let result_expr = unwrap_display_pass_through(&result_expr);
-    let result_expr = render_interactive_pane_if_needed(result_expr);
-    let result_expr = render_labeled_if_needed(result_expr);
-    let result_expr = render_dynamic_if_needed(result_expr);
-    let result_expr = render_graphics_fc_if_needed(result_expr);
-    let result_expr = render_color_if_needed(result_expr);
-    let result_expr = render_tableform_if_needed(result_expr);
-    let result_expr = render_matrixform_if_needed(result_expr);
-    let result_expr = render_traditionalform_list_if_needed(result_expr);
-    let result_expr = render_styled_layout_if_needed(result_expr);
-    let result_expr = render_column_if_needed(result_expr);
-    let result_expr = render_row_if_needed(result_expr);
-    let result_expr = render_treeform_if_needed(result_expr);
-    let result_expr = render_framed_if_needed(result_expr);
-    render_highlighted_if_needed(result_expr)
+    render_visual_display_pipeline(result_expr)
   } else {
     result_expr
   };
@@ -3283,6 +3265,7 @@ fn render_inline_display_wrapper(expr: &syntax::Expr) -> syntax::Expr {
   let expr = unwrap_display_pass_through(expr);
   let expr = render_interactive_pane_if_needed(expr);
   let expr = render_dynamic_if_needed(expr);
+  let expr = render_event_handler_if_needed(expr);
   let expr = render_grid_if_needed(expr);
   let expr = render_dataset_if_needed(expr);
   let expr = render_tabular_if_needed(expr);
@@ -3324,6 +3307,55 @@ fn render_dynamic_if_needed(expr: syntax::Expr) -> syntax::Expr {
     }
     _ => expr,
   }
+}
+
+/// In visual (notebook) display mode, `EventHandler[content, event-rules…]`
+/// displays `content` — the front end wires the event rules to live mouse
+/// input, which Woxi's visual hosts don't wire through, but the wrapped
+/// content still renders exactly as it would on its own (a Demonstrations
+/// idiom wraps the whole `Dynamic[Show[…]]` display of a Manipulate in an
+/// `EventHandler` to make it click-to-toggle). Script/CLI mode keeps the
+/// symbolic `EventHandler[…]` echo to match wolframscript.
+fn render_event_handler_if_needed(expr: syntax::Expr) -> syntax::Expr {
+  if !is_visual_mode() {
+    return expr;
+  }
+  match &expr {
+    syntax::Expr::FunctionCall { name, args }
+      if name == "EventHandler" && !args.is_empty() =>
+    {
+      render_visual_display_pipeline(args[0].clone())
+    }
+    _ => expr,
+  }
+}
+
+/// The full visual-mode display-rendering pipeline: release `Dynamic[…]`
+/// holds, drop `EventHandler[…]` event rules, and render `TableForm`,
+/// `MatrixForm`, `Column`, `Row`, `Grid`, … wrappers into embedded SVGs.
+/// Used for a cell's top-level result and, recursively, for the content an
+/// `EventHandler[…]` wraps once its event rules have been dropped.
+fn render_visual_display_pipeline(expr: syntax::Expr) -> syntax::Expr {
+  // Strip the wrappers that only say how to set what they hold, so the
+  // passes below see the wrapped content (e.g. Pane[Column[{…,
+  // Graphics[…]}]] renders the column with its embedded graphic). CLI
+  // mode keeps the symbolic Pane[…] echo to match wolframscript.
+  let expr = unwrap_display_pass_through(&expr);
+  let expr = render_interactive_pane_if_needed(expr);
+  let expr = render_labeled_if_needed(expr);
+  let expr = render_dynamic_if_needed(expr);
+  let expr = render_event_handler_if_needed(expr);
+  let expr = render_graphics_fc_if_needed(expr);
+  let expr = render_color_if_needed(expr);
+  let expr = render_tableform_if_needed(expr);
+  let expr = render_matrixform_if_needed(expr);
+  let expr = render_traditionalform_list_if_needed(expr);
+  let expr = render_styled_layout_if_needed(expr);
+  let expr = render_column_if_needed(expr);
+  let expr = render_row_if_needed(expr);
+  let expr = render_treeform_if_needed(expr);
+  let expr = render_framed_if_needed(expr);
+  render_highlighted_if_needed(expr)
 }
 
 /// If `expr` is `Column[{…}]`, render it as an SVG column and return `-Graphics-`.
@@ -3383,7 +3415,7 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
     } => inner_name.as_str(),
     _ => return expr,
   };
-  if !matches!(inner_name, "Column" | "Row" | "Grid" | "TextGrid") {
+  if !matches!(inner_name, "Column" | "Row" | "Grid" | "TextGrid" | "Dynamic") {
     return expr;
   }
   let rendered = match inner_name {
@@ -3399,6 +3431,13 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
         render_row_if_needed(styled)
       }
     }
+    // `Style[Dynamic[…], directives…]` — a Demonstration idiom that styles
+    // (or, as with `DynamicEvaluationTimeout`, merely annotates) a live
+    // display rather than a static layout. The directives carry no visual
+    // meaning for an already-rendered graphic, so releasing the `Dynamic`
+    // hold and dropping them is the same trade `render_event_handler_if_needed`
+    // makes for the event rules it wraps.
+    "Dynamic" => render_dynamic_if_needed(inner),
     // Rebuild `Style[inner, directives…]` (with the outer wrappers now
     // stripped) rather than pushing the directives into each cell, so this
     // hits the same `Style[Grid[…], …]` arm of `render_grid_if_needed` a
@@ -3414,7 +3453,7 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
       render_grid_if_needed(restyled)
     }
   };
-  if matches!(rendered, syntax::Expr::Graphics { .. }) {
+  if matches!(rendered, syntax::Expr::Graphics { .. } | syntax::Expr::Image { .. }) {
     rendered
   } else {
     expr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3415,7 +3415,10 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
     } => inner_name.as_str(),
     _ => return expr,
   };
-  if !matches!(inner_name, "Column" | "Row" | "Grid" | "TextGrid" | "Dynamic") {
+  if !matches!(
+    inner_name,
+    "Column" | "Row" | "Grid" | "TextGrid" | "Dynamic"
+  ) {
     return expr;
   }
   let rendered = match inner_name {
@@ -3456,7 +3459,10 @@ fn render_styled_layout_if_needed(expr: syntax::Expr) -> syntax::Expr {
       render_grid_if_needed(restyled)
     }
   };
-  if matches!(rendered, syntax::Expr::Graphics { .. } | syntax::Expr::Image { .. }) {
+  if matches!(
+    rendered,
+    syntax::Expr::Graphics { .. } | syntax::Expr::Image { .. }
+  ) {
     rendered
   } else {
     expr

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -762,6 +762,45 @@ mod interpreter_tests {
     );
   }
 
+  /// A Demonstration idiom wraps a Manipulate body's live picture in
+  /// `EventHandler[Style[Dynamic[graphic], opts], "MouseClicked" :> action]`
+  /// so clicking the picture toggles some state. Woxi's visual hosts don't
+  /// wire the click itself through to `MousePosition`, but the picture must
+  /// still render — before this fix, an unrecognized `EventHandler[…]` head
+  /// fell all the way through the display pipeline unresolved and the cell
+  /// showed its raw source text instead of the graphic. Independently
+  /// written, not copied from any specific Demonstration.
+  #[test]
+  fn test_event_handler_wrapped_dynamic_graphic_still_renders() {
+    clear_state();
+    let r = interpret_with_stdout(
+      "EventHandler[\
+         Style[Dynamic[Graphics[{Blue, Disk[]}]], \
+           DynamicEvaluationTimeout -> 20], \
+         \"MouseClicked\" :> Null\
+       ]",
+    )
+    .unwrap();
+    let svg = r.graphics.expect(
+      "expected the wrapped graphic to render instead of the raw \
+       EventHandler[...] source echo",
+    );
+    assert!(svg.contains("<svg"));
+  }
+
+  /// Script/CLI mode keeps EventHandler's canonical symbolic form, matching
+  /// wolframscript run without a front end — only Woxi's visual hosts
+  /// (Playground, Studio) release it to show the wrapped content.
+  #[test]
+  fn event_handler_stays_symbolic_in_script_mode() {
+    clear_state();
+    assert_eq!(
+      interpret("EventHandler[Graphics[{Circle[]}], \"MouseClicked\" :> 1]")
+        .unwrap(),
+      "EventHandler[-Graphics-, MouseClicked :> 1]"
+    );
+  }
+
   #[test]
   fn test_export_graphic_does_not_render_inline() {
     // Exporting a graphic (e.g. BarChart) to a file writes the file and
@@ -3010,6 +3049,12 @@ mod interpreter_tests {
       // undefined symbol that value is the symbol itself. The script-mode
       // echo `Dynamic[x]` is covered by dynamic_stays_symbolic_in_text_mode.
       ("Dynamic[x]", "x"),
+      // EventHandler displays its content in visual mode the same way —
+      // the front end wires the event rules to live input, which a
+      // notebook host still shows the content without. Script mode keeps
+      // the symbolic echo, covered by
+      // event_handler_stays_symbolic_in_script_mode below.
+      ("EventHandler[a, b]", "a"),
       ("Setter[a, b]", "Setter[a, b]"),
       ("Slider[0.5]", "Slider[0.5]"),
       ("Toggler[a, b]", "Toggler[a, b]"),


### PR DESCRIPTION
## Summary

- Checked Woxi Studio against a randomly sampled Wolfram Demonstration ("Network View of Conway's Game of Life"). Its `Manipulate` body wraps the live picture in `EventHandler[Style[Dynamic[Show[...]], opts], "MouseClicked" :> action]` (a click-to-toggle-cell idiom). Woxi Studio didn't recognize `EventHandler`/`Style[Dynamic[...]]` as display wrappers, so the cell fell back to showing its raw unevaluated source text instead of the picture.
- Added `EventHandler[content, event-rules]` and `Style[Dynamic[graphic], opts]` to the visual-mode display pipeline (`render_event_handler_if_needed`, extended `render_styled_layout_if_needed`) so both release to the wrapped content and render it, the same way `Dynamic[...]` and `Deploy[...]` already do. Woxi Studio's other controls (preset dropdown, buttons, sliders) already worked; only the picture itself needed this fix. Manually verified in Woxi Studio: the grid now renders, `CellularAutomaton` stepping and preset configurations work correctly.
- Script/CLI mode (`woxi eval` / `woxi run`, matching `wolframscript` without a front end) is unaffected — `EventHandler[...]` still echoes symbolically there.
- The downloaded Demonstration notebook itself is not included (copyrighted content); regression tests use independently written minimal repros instead.

## Test plan

- [x] `cargo test` (core crate): 25812 tests pass, including new tests `test_event_handler_wrapped_dynamic_graphic_still_renders`, `event_handler_stays_symbolic_in_script_mode`, and the `EventHandler[a, b]` case in `control_wrappers_stay_symbolic_without_warning`
- [x] `cargo test -p woxi-studio`: 215 tests pass
- [x] Manually opened the sampled Demonstration notebook in Woxi Studio (Xvfb), evaluated the `Manipulate` cell, selected the "Glider" preset, and stepped the simulation — the grid renders and updates correctly
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVRVGGNAnvTAiFYrSXaz2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVRVGGNAnvTAiFYrSXaz2k)_