### PR TITLE
Fix Range numeric contagion and Pi-sweep count gaps found via a random Demonstration

### DIFF
--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -508,6 +508,31 @@ fn table_over_iterator(
 
 use crate::functions::math_ast::expr_to_rational;
 
+/// Number of steps from `min` to `max` implied by `ratio = (max - min) /
+/// step`, tolerant of floating-point rounding at an exact integer
+/// boundary. Used by the symbolic/machine-real branches of [`range_ast`]
+/// below, where `min`/`max`/`step` are only reachable as `f64` (e.g. via
+/// `N[…]` on a `Pi`-based bound).
+///
+/// A ratio that is mathematically exactly integral can still land a hair
+/// under it in `f64` — e.g. `Range[Pi/n, 2 Pi - Pi/n, 2 Pi/n]` has a ratio
+/// of exactly `n - 1`, but computing it through `Pi`-based machine reals
+/// can produce `n - 1 - epsilon`. A plain `.floor()` then reads that as
+/// one step short and the range silently drops its last element (`Range[
+/// Pi/360, 2 Pi - Pi/360, 2 Pi/360]` returned 359 points instead of 360
+/// before this rounding tolerance was added). Snapping a ratio that is
+/// within a relative `1e-9` of an integer to that integer fixes the
+/// boundary without affecting a ratio that is genuinely non-integral
+/// (which still truncates towards `min` exactly as `Range` requires).
+fn range_step_count(ratio: f64) -> i128 {
+  let rounded = ratio.round();
+  if (ratio - rounded).abs() <= 1e-9 * rounded.abs().max(1.0) {
+    rounded as i128
+  } else {
+    ratio.floor() as i128
+  }
+}
+
 /// AST-based Range: generate a range of numbers.
 /// Range[n] -> {1, 2, ..., n}
 /// Range[min, max] -> {min, ..., max}
@@ -637,6 +662,24 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     || expr_to_f64(&step_expr).is_none();
 
   if has_symbolic {
+    // Numeric contagion: Range[start, stop, di] is computed as
+    // start + k*di for k = 0, 1, 2, .... When `di` (or `start` itself)
+    // is an inexact machine real, every element becomes inexact —
+    // including k=0, since `start + 0` still numericizes `start` via
+    // arithmetic with an inexact operand (`0*di` is inexact `0.`).
+    // `max`/`stop` never affects exactness — it only controls where the
+    // range terminates.
+    let any_real =
+      matches!(&min_expr, Expr::Real(_)) || matches!(&step_expr, Expr::Real(_));
+    let first_elem = |min_expr: &Expr| -> Result<Expr, InterpreterError> {
+      if any_real {
+        let n_expr = call1("N", min_expr.clone());
+        crate::evaluator::evaluate_expr_to_expr(&n_expr)
+      } else {
+        Ok(min_expr.clone())
+      }
+    };
+
     // Try to evaluate numerically to determine count
     let min_f = try_numeric(&min_expr);
     let max_f = try_numeric(&max_expr);
@@ -685,7 +728,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(ratio_val) = ratio_val
         && ratio_val.is_finite()
       {
-        let count = ratio_val.floor() as i128 + 1;
+        let count = range_step_count(ratio_val) + 1;
         if count <= 0 {
           return Ok(Expr::List(vec![].into()));
         }
@@ -697,7 +740,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let mut results = Vec::with_capacity(count as usize);
         for k in 0..count {
           let elem = if k == 0 {
-            min_expr.clone()
+            first_elem(&min_expr)?
           } else {
             let k_times_step =
               call("Times", vec![Expr::Integer(k), step_expr.clone()]);
@@ -724,7 +767,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         ));
         return Ok(call);
       }
-      let count = ((max_val - min_val) / step_val).floor() as i128 + 1;
+      let count = range_step_count((max_val - min_val) / step_val) + 1;
       if count <= 0 {
         return Ok(Expr::List(vec![].into()));
       }
@@ -737,7 +780,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for k in 0..count {
         // Generate min_expr + k * step_expr symbolically
         let elem = if k == 0 {
-          min_expr.clone()
+          first_elem(&min_expr)?
         } else {
           let k_times_step = times2(Expr::Integer(k), step_expr.clone());
           let sum = plus2(min_expr.clone(), k_times_step);

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -8907,6 +8907,126 @@ mod range_real {
       "{Sqrt[2], 2*Sqrt[2], 3*Sqrt[2], 4*Sqrt[2], 5*Sqrt[2]}"
     );
   }
+
+  // Numeric contagion: Range[start, stop, di] is computed as start + k*di.
+  // When `di` (or `start` itself) is an inexact machine real, every
+  // element becomes inexact — including k=0, since `start + 0*di` still
+  // numericizes `start` via arithmetic with an inexact operand. Regression
+  // test: the first element used to stay exact/symbolic while the rest
+  // became machine reals.
+  #[test]
+  fn range_symbolic_start_inexact_step_first_element_numericized() {
+    assert_eq!(
+      interpret("Range[Pi/4, 2 Pi - Pi/4, (2 Pi/4)//N]").unwrap(),
+      "{0.7853981633974483, 2.356194490192345, 3.9269908169872414, \
+       5.497787143782138}"
+    );
+  }
+
+  #[test]
+  fn range_integer_start_inexact_step_numericized() {
+    assert_eq!(
+      interpret("Range[1, 5, 1.0]").unwrap(),
+      "{1., 2., 3., 4., 5.}"
+    );
+  }
+
+  // Regression test: an exact Rational start (not just Integer/symbolic)
+  // with an inexact step used to leave the first element as the untouched
+  // Rational `1/2` instead of numericizing it to `0.5` — this exercises
+  // the plain f64 fallback path (both min and step have a numeric value,
+  // so `has_symbolic` is false) rather than the symbolic-endpoint path.
+  #[test]
+  fn range_rational_start_inexact_step_numericized() {
+    assert_eq!(
+      interpret("Range[1/2, 5, 0.5]").unwrap(),
+      "{0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5.}"
+    );
+  }
+
+  #[test]
+  fn range_zero_start_inexact_step_numericized() {
+    assert_eq!(
+      interpret("Range[0, 2 Pi, Pi/3.]").unwrap(),
+      "{0., 1.0471975511965976, 2.0943951023931953, 3.141592653589793, \
+       4.1887902047863905, 5.235987755982988, 6.283185307179586}"
+    );
+  }
+
+  #[test]
+  fn range_symbolic_pi_start_inexact_step_numericized() {
+    assert_eq!(
+      interpret("Range[Pi, 2 Pi, 0.5]").unwrap(),
+      "{3.141592653589793, 3.641592653589793, 4.141592653589793, \
+       4.641592653589793, 5.141592653589793, 5.641592653589793, \
+       6.141592653589793}"
+    );
+  }
+
+  // `max`/`stop` never affects exactness, only where the range terminates:
+  // an exact start with an exact step stays exact even when stop is Real.
+  #[test]
+  fn range_exact_start_step_inexact_stop_stays_exact() {
+    assert_eq!(
+      interpret("Range[Pi/4, 5.0, 1]").unwrap(),
+      "{Pi/4, 1 + Pi/4, 2 + Pi/4, 3 + Pi/4, 4 + Pi/4}"
+    );
+  }
+
+  // An unbound symbol has no numeric value, so N[] leaves it unchanged —
+  // numericizing the first element is a no-op here.
+  #[test]
+  fn range_unbound_symbol_start_inexact_step() {
+    assert_eq!(
+      interpret("Range[a, a + 5, 1.]").unwrap(),
+      "{a, 1. + a, 2. + a, 3. + a, 4. + a, 5. + a}"
+    );
+  }
+
+  // Start already past stop with an exact step: still empty, not affected
+  // by the contagion fix (regression guard for the ratio-based counting
+  // path staying correct).
+  #[test]
+  fn range_real_start_past_stop_empty() {
+    assert_eq!(interpret("Range[3.5, Pi, 1]").unwrap(), "{}");
+  }
+
+  // Off-by-one regression (found via the "Maurer Rose Chords" Wolfram
+  // Demonstration, which sweeps angles with exactly this idiom):
+  // `Range[Pi/n, 2 Pi - Pi/n, 2 Pi/n]` is mathematically exactly `n`
+  // evenly-spaced points, but computing `(max - min) / step` through
+  // `Pi`-based machine reals used to land a hair under the exact integer
+  // step count for several `n` — e.g. `Length[Range[Pi/360, 2 Pi -
+  // Pi/360, 2 Pi/360]]` silently returned 359, dropping the sweep's last
+  // point. Checked across a spread of `n`, not just the one that first
+  // exposed it, since only some values were affected (8, 16, 300 and 360
+  // under-counted by one; the others already happened to round the right
+  // way).
+  #[test]
+  fn range_pi_sweep_count_matches_n_for_every_n() {
+    for n in [
+      3, 6, 7, 8, 12, 16, 20, 60, 120, 180, 200, 300, 359, 360, 361,
+    ] {
+      let code = format!("Length[Range[Pi/{n}, 2 Pi - Pi/{n}, 2 Pi/{n}]]");
+      assert_eq!(
+        interpret(&code).unwrap(),
+        n.to_string(),
+        "Range[Pi/{n}, 2 Pi - Pi/{n}, 2 Pi/{n}] must have exactly {n} points"
+      );
+    }
+  }
+
+  // Same rounding tolerance, exercised through the separate
+  // fully-symbolic-endpoint path (an unbound `a` leaves `min`/`max`
+  // without a numeric value, so only the `(max - min) / step` ratio gets
+  // evaluated to determine the count).
+  #[test]
+  fn range_pi_sweep_count_matches_n_with_symbolic_endpoint() {
+    assert_eq!(
+      interpret("Length[Range[a, a + 2 Pi - 2 Pi/360, 2 Pi/360]]").unwrap(),
+      "360"
+    );
+  }
 }
 
 mod delete_duplicates_with_test {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -24504,4 +24504,145 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`count$$ = 3, $CellContext`offset$$ 
       after.graphics
     );
   }
+
+  /// A randomly-sampled Wolfram Demonstrations Project notebook ("Maurer
+  /// Rose Chords") draws three colored bundles of chords over a rose-like
+  /// curve: one helper turns a swept range of angles into `{x, y}` points
+  /// via a `{r Cos[theta], r Sin[theta]} &`-shaped pure function (both the
+  /// radius and the angle argument built by threading `Sin` over the whole
+  /// angle list at once), and a second helper `With`-binds that point list
+  /// and joins each point to a `RotateLeft`-shifted copy of itself with
+  /// `Line`, `Flatten`-ing the result into one drawable list. The
+  /// `Manipulate` wraps three such calls in a black-background `Graphics`,
+  /// driven by four `Appearance -> "Labeled"` sliders (an
+  /// envelope-frequency control plus one rotation offset per curve) and one
+  /// 2D paired-range control for the `{petal count, twist frequency}` pair
+  /// — the shape this codebase models as `ControlState::Slider2D`. Each
+  /// curve's angle-resolution argument is wrapped in `ControlActive[…]`
+  /// (reduced while a control is actively dragged, full resolution
+  /// otherwise). Independently written, not copied from any specific
+  /// Wolfram Demonstration: different helper/variable names, a different
+  /// point-generation formula (radius and rotation angle both threaded
+  /// through `Sin` over the full angle list rather than mapped
+  /// point-by-point), and different slider ranges/colors throughout.
+  #[test]
+  fn demonstration_maurer_rose_chords() {
+    let code = r#"Manipulate[
+  Graphics[{
+    Thickness[0.0015], RGBColor[0.85, 0.2, 0.25],
+    chordBundle$[ControlActive[60, 360], freqPair$, envFreq$, twistA$],
+    RGBColor[0.25, 0.8, 0.3],
+    chordBundle$[ControlActive[60, 360], freqPair$, envFreq$, twistB$],
+    RGBColor[0.3, 0.45, 0.9],
+    chordBundle$[ControlActive[60, 360], freqPair$, envFreq$, twistC$]
+  }, ImageSize -> {330, 330}, PlotRange -> 3, Background -> Black],
+  {{envFreq$, 7, "envelope frequency"}, 1, 20, 1, Appearance -> "Labeled"},
+  {{twistA$, 30}, 1, 360, 1, Appearance -> "Labeled"},
+  {{twistB$, 90}, 1, 360, 1, Appearance -> "Labeled"},
+  {{twistC$, 150}, 1, 360, 1, Appearance -> "Labeled"},
+  {{freqPair$, {16, 5}}, {1, 1}, {16, 16}, {1, 1}, ControlPlacement -> Left, ImageSize -> Small},
+  SaveDefinitions -> True,
+  Initialization :> (
+    rosePoints$[t_, count_Integer, freqA_Integer, freqB_Integer] :=
+      Module[{angles = Range[Pi/count, 2 Pi - Pi/count, 2 Pi/count]},
+        Transpose[({#1 Cos[#2], #1 Sin[#2]} &)[
+          Sin[freqA angles], Sin[freqB angles]/t]]
+      ] // N;
+    chordBundle$[count_Integer, {freqA_Integer, freqB_Integer}, envScale_, offset_Integer] :=
+      With[{pts = rosePoints$[envScale, count, freqA, freqB]},
+        Flatten[{Line[#] & /@ Transpose@{pts, RotateLeft[pts, offset]}}]
+      ]
+  )
+]"#;
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the Maurer-rose-chords Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "initial build must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: n0,
+          current: c0,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: n1,
+          current: c1,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: n2,
+          current: c2,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: n3,
+          current: c3,
+          ..
+        },
+        manipulate::ControlState::Slider2D { name: n4, x, y, .. },
+      ] => {
+        assert_eq!((n0.as_str(), *c0), ("envFreq$", 7.0));
+        assert_eq!((n1.as_str(), *c1), ("twistA$", 30.0));
+        assert_eq!((n2.as_str(), *c2), ("twistB$", 90.0));
+        assert_eq!((n3.as_str(), *c3), ("twistC$", 150.0));
+        assert_eq!(n4.as_str(), "freqPair$");
+        assert_eq!(
+          (*x, *y),
+          (16.0, 5.0),
+          "the {{petal count, twist frequency}} pair starts at {{16, 5}}"
+        );
+      }
+      other => panic!(
+        "expected four labeled sliders plus one 2D paired-range control, got {other:?}"
+      ),
+    }
+
+    // Drag all four 1D sliders and confirm the widget keeps rendering.
+    for idx in 0..4 {
+      if let manipulate::ControlState::Continuous { current, .. } =
+        &mut state.controls[idx]
+      {
+        *current += 1.0;
+      }
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "after 1D drags: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+
+    // Drag the 2D paired-range control too.
+    state.slider2d_change(4, 0, 9.0);
+    state.slider2d_change(4, 1, 12.0);
+    state.reevaluate();
+    assert!(state.error.is_none(), "after 2D drag: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+    match &state.controls[4] {
+      manipulate::ControlState::Slider2D { x, y, .. } => {
+        assert_eq!((*x, *y), (9.0, 12.0));
+      }
+      other => panic!("expected Slider2D, got {other:?}"),
+    }
+
+    // `ControlActive[60, 360]` must resolve to its steady-state (second,
+    // normal-form) argument outside an active drag — the same
+    // non-interactive state `reevaluate` above just rendered in — so a
+    // chord bundle draws 360 chords, not the reduced 60.
+    let call = format!(
+      "Length[chordBundle$[ControlActive[60, 360], {}, {}, {}]]",
+      state.controls[4].current_code(),
+      state.controls[0].current_code(),
+      state.controls[1].current_code(),
+    );
+    let rendered = woxi::interpret_with_stdout(&call)
+      .expect("chordBundle$ must evaluate with the widget's live bindings");
+    assert_eq!(
+      rendered.result, "360",
+      "ControlActive's steady-state (second) argument must be used outside a drag: {rendered:?}"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This run of the scheduled "check a random Wolfram Demonstration against Woxi Studio" routine downloaded [**Maurer Rose Chords**](https://demonstrations.wolfram.com/MaurerRoseChords/) by Michael Schreiber. Its Manipulate/Slider2D control shape was already fully supported by Woxi Studio, so no Studio-side fix was needed — only a regression test was added. But verifying it end-to-end surfaced two real `Range` bugs in the core interpreter, both triggered by the exact angle-sweep idiom the demo relies on (`Range[Pi/n, 2 Pi - Pi/n, 2 Pi/n]`):

- **Numeric contagion**: `Range[start, stop, step]` left the *first* element exact/symbolic instead of numericizing it whenever only `step` (or `start`) was inexact — e.g. `Range[Pi/4, 2 Pi - Pi/4, (2 Pi/4)//N]` returned `{Pi/4, 2.356..., 3.927..., 5.498...}` instead of numericizing all four elements. Wolfram's contagion rule numericizes every element, including `k=0`, once arithmetic touches an inexact operand.
- **Pi-sweep undercounting**: the ratio-based element count `(max - min) / step`, computed through `Pi`-based `f64` arithmetic, could land a hair under an integer boundary and `.floor()` then read one step short — silently dropping the last point of sweeps like `Range[Pi/360, 2 Pi - Pi/360, 2 Pi/360]`.

## Changes

- `src/functions/list_helpers_ast/construction.rs`: fixes both bugs — a `first_elem` helper numericizes the `k=0` element via `N[...]` whenever contagion applies, and a `range_step_count` helper snaps a ratio within relative `1e-9` of an integer to that integer before flooring.
- `tests/interpreter_tests/list.rs`: regression tests for both fixes (contagion across several start/step exactness combinations, and the Pi-sweep count across many `n`).
- `woxi-studio/src/main.rs`: one new regression test (`demonstration_maurer_rose_chords`) exercising the demo's shape — a `Manipulate` with 4 `Appearance -> "Labeled"` sliders plus a 2D paired-range (`Slider2D`) control, `ControlActive` in the body, and the `Range`/`RotateLeft`/`Transpose`/`Flatten`/`Line` chord-drawing idiom. Independently written (different names, formula, and slider values), per this repo's copyright convention for Demonstration-derived tests.

## Test plan

- [x] `make test` (core unit tests) — 27981 passed, 0 failed
- [x] `make test-studio` — 219 passed, 0 failed
- [x] `make format` — clean, no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vnr1EKzAjbCFNinGkZ88oQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnr1EKzAjbCFNinGkZ88oQ)_