### PR TITLE
Implement ImageHistogram and the TestImage catalogue in ExampleData

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -603,7 +603,7 @@ ColorFunctionScaling,Option to scale color function input,✅,none,4.0,559
 Values,Returns the values of an association (optionally wrapping each with a head),✅,pure,10.0,560
 Cuboid,3D graphics primitive representing a cuboid,✅,none,2.0,561
 AbsoluteTime,Total seconds since January 1 1900,✅,contextual,2.0,562
-ExampleData,Serves the bundled example datasets by type and name: the list of types; the entries of one type; a dataset itself; or one of its properties (only the NetworkGraph type is bundled so far with the classic empirical networks),✅,pure,6.0,563
+ExampleData,Serves the bundled example datasets by type and name: the list of types; the entries of one type; a dataset itself; or one of its properties (NetworkGraph data is bundled with the classic empirical networks; TestImage only bundles its name catalogue rather than pixel data),✅,pure,6.0,563
 TwoWayRule,Represent a two-way transformation rule,✅,none,11.2,564
 Initialization,Option for initialization code,✅,none,6.0,565
 StringCases,Returns substrings matching a pattern (threading over a list of strings; supports a count limit and the Overlaps and IgnoreCase options),✅,pure,5.1,566
@@ -2161,7 +2161,7 @@ BubbleChart3D,Creates a 3D bubble chart visualization,🚫,None,7.0,2170
 OverwriteTarget,Option specifying whether to overwrite an existing target file,🚫,None,11.0,2170
 EdgeDelete,Delete one or more edges from a graph while keeping all vertices,✅,pure,8.0,2172
 ImageValuePositions,Returns positions of pixels with a specified value in an image,🚫,None,9.0,2172
-ImageHistogram,Plots the histogram of pixel values in an image,🚫,None,7.0,2174
+ImageHistogram,Plots the histogram of pixel values in an image,✅,pure,7.0,2174
 PasteButton,Represents a button that pastes content when clicked,🚫,None,6.0,2174
 FindGraphCommunities,Finds community structure in a graph,🚫,None,9.0,2179
 ImageSizeMultipliers,Option for scaling image display size,🚫,None,6.0,2179

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -712,6 +712,9 @@ pub fn dispatch_image_functions(
     "HistogramTransform" if !args.is_empty() => {
       return Some(crate::functions::image_ast::histogram_transform_ast(args));
     }
+    "ImageHistogram" if !args.is_empty() => {
+      return Some(crate::functions::image_ast::image_histogram_ast(args));
+    }
     "Pruning" if !args.is_empty() => {
       return Some(crate::functions::image_ast::pruning_ast(args));
     }

--- a/src/functions/example_data.rs
+++ b/src/functions/example_data.rs
@@ -9,12 +9,18 @@
 //! - `ExampleData[{"type", "name"}]` — the data itself.
 //! - `ExampleData[{"type", "name"}, "property"]` — one property of it.
 //!
-//! Only `"NetworkGraph"` is bundled so far, and only with the classic
+//! Only `"NetworkGraph"` data is bundled so far, and only with the classic
 //! networks listed in `resources/network_graphs.txt.gz`; a type or name
 //! that is not bundled stays unevaluated rather than returning wrong data.
 //! The bundled networks are assembled from the publications they come from
 //! and carry the names Wolfram's catalogue lists them under, so a script
 //! that asks for one of them by name gets the same data from either engine.
+//!
+//! `"TestImage"` is a partial exception: its name catalogue is bundled (see
+//! `TEST_IMAGE_NAMES`) so scripts that build UI from the catalogue — a
+//! `Control` popup, `Thread[...]` over the name list — see the real
+//! entries, but no photographic data is bundled, so
+//! `ExampleData[{"TestImage", name}]` stays unevaluated for every name.
 
 use std::sync::LazyLock;
 
@@ -208,7 +214,64 @@ fn network_graph_property(g: &NetworkGraph, property: &str) -> Option<Expr> {
 }
 
 /// The example-data types Woxi bundles.
-const TYPES: &[&str] = &["NetworkGraph"];
+const TYPES: &[&str] = &["NetworkGraph", "TestImage"];
+
+/// The `"TestImage"` catalogue of names. Woxi bundles no photographic data
+/// (there is no license to redistribute the actual pixels), so only the
+/// name catalogue is exposed: `ExampleData["TestImage"]` returns the same
+/// `{"TestImage", name}` pairs Wolfram lists, which is enough for scripts
+/// that build UI from the catalogue (a `Control` popup, `Thread[...]` over
+/// the name list, …). `ExampleData[{"TestImage", name}]` itself stays
+/// unevaluated for every name, same as an un-bundled `NetworkGraph`.
+const TEST_IMAGE_NAMES: &[&str] = &[
+  "Aerial",
+  "Aerial2",
+  "Airplane",
+  "Airplane2",
+  "Airport",
+  "APC",
+  "Apples",
+  "Boat",
+  "Bridge",
+  "CarAndAPC",
+  "CarAndAPC2",
+  "ChemicalPlant",
+  "Clock",
+  "Couple",
+  "Couple2",
+  "Elaine",
+  "F16",
+  "Flower",
+  "Girl",
+  "Girl2",
+  "Girl3",
+  "Gray21",
+  "House",
+  "House2",
+  "JellyBeans",
+  "JellyBeans2",
+  "Man",
+  "Mandrill",
+  "Marruecos",
+  "Moon",
+  "Peppers",
+  "RadcliffeCamera",
+  "ResolutionChart",
+  "Ruler",
+  "Sailboat",
+  "Splash",
+  "Stall",
+  "Tank",
+  "Tank2",
+  "Tank3",
+  "Tiffany",
+  "Tree",
+  "Truck",
+  "TruckAndAPC",
+  "TruckAndAPC2",
+  "U2",
+  "Volubilis",
+];
 
 /// `ExampleData[…]` — see the module documentation for the call forms.
 pub fn example_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -229,15 +292,17 @@ pub fn example_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::String(kind) = &args[0]
     && args.len() == 1
   {
-    if kind != "NetworkGraph" {
-      return unevaluated();
-    }
+    let names: Vec<&str> = match kind.as_str() {
+      "NetworkGraph" => NETWORK_GRAPHS.iter().map(|g| g.name).collect(),
+      "TestImage" => TEST_IMAGE_NAMES.to_vec(),
+      _ => return unevaluated(),
+    };
     return Ok(Expr::List(
-      NETWORK_GRAPHS
-        .iter()
-        .map(|g| {
+      names
+        .into_iter()
+        .map(|name| {
           Expr::List(
-            vec![Expr::String(kind.clone()), Expr::String(g.name.to_string())]
+            vec![Expr::String(kind.clone()), Expr::String(name.to_string())]
               .into(),
           )
         })

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -1741,6 +1741,130 @@ pub fn histogram_transform_ast(
   })
 }
 
+/// The colors `ImageHistogram` draws each channel's curve in: gray for a
+/// single-channel image, otherwise red/green/blue for the first three
+/// channels and gray for any beyond that (e.g. an alpha channel).
+fn image_histogram_channel_colors(
+  channels: usize,
+) -> Vec<crate::functions::graphics::Color> {
+  use crate::functions::graphics::Color;
+  if channels <= 1 {
+    return vec![Color::new(0.5, 0.5, 0.5)];
+  }
+  [
+    Color::new(1.0, 0.0, 0.0),
+    Color::new(0.0, 0.65, 0.0),
+    Color::new(0.0, 0.0, 1.0),
+  ]
+  .into_iter()
+  .chain(std::iter::repeat(Color::new(0.5, 0.5, 0.5)))
+  .take(channels)
+  .collect()
+}
+
+fn image_histogram_chart_options() -> crate::functions::chart::ChartOptions {
+  crate::functions::chart::ChartOptions {
+    svg_width: crate::functions::plot::DEFAULT_WIDTH,
+    svg_height: crate::functions::plot::DEFAULT_HEIGHT,
+    full_width: false,
+    chart_labels: Vec::new(),
+    chart_label_position: crate::functions::chart::LabelPosition::Below,
+    plot_label: None,
+    axes_label: None,
+    frame_label: None,
+    chart_style: Vec::new(),
+    chart_style_scheme: None,
+    chart_legends: Vec::new(),
+    chart_legends_auto: false,
+    plot_range_x: Some((0.0, 255.0)),
+    plot_range_y: None,
+    bar_origin_left: false,
+    labeling_function: None,
+    ticks_x: None,
+    ticks_y: None,
+    ticks: true,
+  }
+}
+
+/// ImageHistogram[image] / ImageHistogram[image, opts...] — the
+/// distribution of each channel's pixel values, scaled to the usual 0-255
+/// display range. `Appearance -> "Separated"` draws one histogram per
+/// channel side by side; any other setting (the default, `"RGB"`,
+/// `"Transparent"`, `"Stacked"`) overlays them translucently in one plot,
+/// the same treatment `Histogram` already gives several datasets.
+pub fn image_histogram_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.is_empty() {
+    return Ok(unevaluated("ImageHistogram", args));
+  }
+  let Expr::Image {
+    width,
+    height,
+    channels,
+    data,
+    ..
+  } = &args[0]
+  else {
+    crate::emit_message(&format!(
+      "ImageHistogram::imginv: Expecting an image or graphics instead of {}.",
+      crate::syntax::expr_to_string(&args[0])
+    ));
+    return Ok(unevaluated("ImageHistogram", args));
+  };
+
+  let separated = args[1..].iter().any(|opt| {
+    crate::functions::graphics::option_name_value(opt).is_some_and(
+      |(name, value)| {
+        name == "Appearance"
+          && matches!(value.as_ref(), Expr::String(s) if s == "Separated")
+      },
+    )
+  });
+
+  let w = *width as usize;
+  let h = *height as usize;
+  let ch = (*channels as usize).max(1);
+  let pixels = w * h;
+  let colors = image_histogram_channel_colors(ch);
+  let datasets: Vec<Vec<f64>> = (0..ch)
+    .map(|c| (0..pixels).map(|i| data[i * ch + c] * 255.0).collect())
+    .collect();
+  let bin_spec = crate::functions::plot::BinSpec::Width(1.0);
+
+  if separated {
+    let mut items = Vec::with_capacity(ch);
+    for (c, dataset) in datasets.iter().enumerate() {
+      let mut opts = image_histogram_chart_options();
+      opts.chart_style = vec![colors[c]];
+      let svg = crate::functions::plot::generate_histogram_svg(
+        std::slice::from_ref(dataset),
+        Some(&bin_spec),
+        crate::functions::plot::HistogramHeight::Count,
+        &mut opts,
+      )?;
+      items.push(Expr::Graphics {
+        svg,
+        is_3d: false,
+        source: None,
+        head: None,
+        structure: None,
+      });
+    }
+    return crate::functions::graphics::graphics_row_ast(&[Expr::List(
+      items.into(),
+    )]);
+  }
+
+  let mut opts = image_histogram_chart_options();
+  opts.chart_style = colors;
+  let svg = crate::functions::plot::generate_histogram_svg(
+    &datasets,
+    Some(&bin_spec),
+    crate::functions::plot::HistogramHeight::Count,
+    &mut opts,
+  )?;
+  Ok(crate::graphics_result(svg))
+}
+
 /// ImageReflect[img] / ImageReflect[img, side] / ImageReflect[img, s1 -> s2].
 /// Default: vertical (top↔bottom) flip. Horizontal / vertical sides reflect
 /// across the perpendicular axis; rules between perpendicular sides do the

--- a/tests/interpreter_tests/example_data.rs
+++ b/tests/interpreter_tests/example_data.rs
@@ -231,4 +231,85 @@ mod example_data_tests {
       "ExampleData[{NetworkGraph, ZacharyKarateClub}, Nope]"
     );
   }
+
+  /// Woxi bundles no photographic data, only the `"TestImage"` name
+  /// catalogue — enough for a script to build UI (a `Control` popup,
+  /// `Thread[...]` over the name list) from `ExampleData["TestImage"]`
+  /// without the actual pixels being available.
+  #[test]
+  fn lists_the_test_image_catalogue() {
+    clear_state();
+    assert_eq!(
+      interpret("MemberQ[ExampleData[], \"TestImage\"]").unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret("Length[ExampleData[\"TestImage\"]] > 0").unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret(
+        "And @@ (MatchQ[#, {_String, _String}] & /@ \
+         ExampleData[\"TestImage\"])"
+      )
+      .unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret("Union[First /@ ExampleData[\"TestImage\"]]").unwrap(),
+      "{TestImage}"
+    );
+    // The catalogue lists each name once.
+    assert_eq!(
+      interpret(
+        "Length[ExampleData[\"TestImage\"]] == \
+         Length[Union[Last /@ ExampleData[\"TestImage\"]]]"
+      )
+      .unwrap(),
+      "True"
+    );
+    for name in ["Couple", "Mandrill", "House", "Peppers"] {
+      assert_eq!(
+        interpret(&format!(
+          "MemberQ[ExampleData[\"TestImage\"], {{\"TestImage\", \"{name}\"}}]"
+        ))
+        .unwrap(),
+        "True",
+        "{name}"
+      );
+    }
+  }
+
+  /// The name catalogue is bundled, but no pixel data is: asking for one
+  /// of the catalogued images stays unevaluated rather than returning
+  /// invented pixels.
+  #[test]
+  fn test_image_pixel_data_stays_unbundled() {
+    clear_state();
+    assert_eq!(
+      interpret("ExampleData[{\"TestImage\", \"Couple\"}]").unwrap(),
+      "ExampleData[{TestImage, Couple}]"
+    );
+  }
+
+  /// The Wolfram Demonstration "Histogram Equalization" builds its image
+  /// picker from exactly this pattern:
+  /// `imageNames = ExampleData["TestImage"]; Thread[imageNames ->
+  /// imageNames[[All, 2]]]` — a rule list pairing each `{"TestImage",
+  /// name}` entry with its bare name. This regression test guards that
+  /// the catalogue is a concrete, evaluated list so `Thread` (and so the
+  /// `Control` popup built from it) actually has something to work with.
+  #[test]
+  fn thread_over_the_catalogue_builds_display_rules() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "imageNames = ExampleData[\"TestImage\"]; \
+         MatchQ[Thread[imageNames -> imageNames[[All, 2]]], \
+         {({_String, _String} -> _String) ..}]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
 }

--- a/tests/interpreter_tests/image.rs
+++ b/tests/interpreter_tests/image.rs
@@ -7614,6 +7614,59 @@ mod demonstration_image_filters {
     );
   }
 
+  #[test]
+  fn image_histogram_returns_graphics() {
+    clear_state();
+    assert_eq!(
+      interpret("Head[ImageHistogram[Image[{{0., 0.5, 1.}}]]]").unwrap(),
+      "Graphics"
+    );
+    // A color image's histogram is Graphics too, regardless of Appearance.
+    assert_eq!(
+      interpret(
+        "Head[ImageHistogram[Image[{{{0., 0., 0.}, {1., 1., 1.}}}], \
+         Appearance -> \"Separated\"]]"
+      )
+      .unwrap(),
+      "Graphics"
+    );
+  }
+
+  // The Appearance -> "Separated" form is the one the "Histogram
+  // Equalization" Demonstration actually uses to compare an image against
+  // its equalized version side by side — a regression guard for the bug
+  // where the underlying function was simply unimplemented.
+  #[test]
+  fn image_histogram_separated_renders_one_panel_per_channel() {
+    clear_state();
+    let svg = interpret(
+      "ExportString[ImageHistogram[\
+       Image[{{{0., 0., 1.}, {1., 0., 0.}}}], \
+       Appearance -> \"Separated\"], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(svg.starts_with("<svg"));
+    // Three channels means three side-by-side <svg> panels nested in the
+    // combined GraphicsRow output.
+    assert_eq!(svg.matches("<svg").count(), 4);
+  }
+
+  #[test]
+  fn image_histogram_grayscale_renders_a_single_panel() {
+    clear_state();
+    let svg = interpret(
+      "ExportString[ImageHistogram[Image[{{0., 0.5, 1.}}]], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(svg.starts_with("<svg"));
+  }
+
+  #[test]
+  fn image_histogram_reports_a_non_image() {
+    clear_state();
+    assert_eq!(interpret("ImageHistogram[5]").unwrap(), "ImageHistogram[5]");
+  }
+
   /// A five-pixel bar with a one-pixel spur growing out of its middle.
   const BAR: &str = "Image[{{0, 0, 1, 0, 0}, {1, 1, 1, 1, 1}}]";
 


### PR DESCRIPTION
## Summary

This is a scheduled-routine run of the Wolfram Demonstration random check: it fetched the [Histogram Equalization](https://demonstrations.wolfram.com/HistogramEqualization/) Demonstration notebook and checked whether Woxi Studio fully supports it. It didn't — two gaps surfaced:

- **`ImageHistogram` was entirely unimplemented.** Both calls in the Demonstration's `Manipulate` body (comparing an image's histogram against its equalized version) errored out with "not yet implemented in Woxi". It's now implemented: each channel's pixel-value distribution renders as `Graphics`, reusing the existing `Histogram`/chart machinery (colored per channel, translucently overlaid by default). `Appearance -> "Separated"` — the form this Demonstration actually uses — draws one panel per channel via `GraphicsRow` instead.

- **`ExampleData["TestImage"]` returned nothing.** The Demonstration builds its image-picker `Control` with `imageNames = ExampleData["TestImage"]; Thread[imageNames -> imageNames[[All, 2]]]`. With `ExampleData["TestImage"]` unevaluated, `Thread[...]` produced garbage and Woxi Studio's `Manipulate` widget silently dropped that control (it correctly rendered the other two controls). Woxi has no license to redistribute the actual photographs, so only the standard 47-name `TestImage` catalogue is now bundled — `ExampleData[{"TestImage", name}]` itself still stays unevaluated for every name, the same treatment an un-bundled `NetworkGraph` already gets.

Together these fix the `Manipulate` widget so it builds all three controls (image picker, color-space setter bar, dither slider) instead of silently dropping one, and replace the "function not implemented" error with the correct `ImageHistogram::imginv` message once real pixel data is unavailable — the one remaining gap (no bundled photographs) is a deliberate, documented limitation rather than a bug.

## Test plan

- [x] `make test` (27,978 tests, all passing)
- [x] `make test-studio` (218 tests, all passing)
- [x] `make format`
- [x] New unit tests: `ImageHistogram` (Graphics output, `Appearance -> "Separated"` panel count, grayscale, non-image error) and `ExampleData["TestImage"]` (catalogue shape/membership, pixel data staying unevaluated, the exact `Thread[...]` pattern the Demonstration uses)
- [x] Re-ran `cargo run --example dump_manipulate -p woxi-studio` against the downloaded notebook before/after: confirmed the image-picker control now appears with all 47 entries and the `ImageHistogram::imginv` errors are the correct not-an-image errors rather than "not yet implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JirDuebdr9UtDSPruqdK4

---
_Generated by [Claude Code](https://claude.ai/code/session_019JirDuebdr9UtDSPruqdK4)_