### PR TITLE
Fix spurious Manipulate::vsform warning for Tooltip-wrapped controls

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -17129,7 +17129,11 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // (a Demonstration lining up its whole control panel inside an outer
       // `Grid`), not a control itself. `OpenerView[{label, content}]` is the
       // same pattern for a collapsible disclosure widget (e.g. a "circuit
-      // diagram" aside tucked below the sliders).
+      // diagram" aside tucked below the sliders). `Tooltip[control, hint]`
+      // is the same pattern for a custom control (often a `DynamicModule`
+      // wrapping its own `Manipulator`/`EventHandler`) that shows a hover
+      // hint instead of a label — a Demonstration's zoom-point selector is
+      // commonly written this way.
       Expr::FunctionCall { name, .. }
         if matches!(
           name.as_str(),
@@ -17144,6 +17148,7 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             | "TabView"
             | "Item"
             | "OpenerView"
+            | "Tooltip"
         ) =>
       {
         out_args.push(spec.clone());

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -19661,6 +19661,27 @@ mod manipulate {
   }
 
   #[test]
+  fn tooltip_wrapped_control_arg_is_not_vsform() {
+    // A trailing `Tooltip[control, hint]` argument is a Demonstrations
+    // pattern for a custom widget (often a `DynamicModule` wrapping its own
+    // `Manipulator`/`EventHandler`) that shows a hover hint instead of a
+    // label, as in "Continuous Changes in Self-Similar Fractals"'s zoom-point
+    // selector. It is a control-panel content item, not a malformed variable
+    // specification, so wolframscript shows it with no Manipulate::vsform
+    // message.
+    let result = woxi::interpret_with_stdout(
+      "Manipulate[x, {x, 0, 1}, Tooltip[Manipulator[Dynamic[x]], \"pick a value\"]]",
+    )
+    .unwrap();
+    assert!(
+      !result.warnings.iter().any(|w| w.contains("vsform")),
+      "no vsform expected, got {:?}",
+      result.warnings
+    );
+    assert!(result.result.starts_with("Manipulate["));
+  }
+
+  #[test]
   fn row_control_and_button_args_are_not_vsform() {
     // wolframscript shows control objects and layout wrappers in the
     // control area without a Manipulate::vsform message.


### PR DESCRIPTION
## Summary

- Checked Woxi Studio against a random Wolfram Demonstration ("Continuous Changes in Self-Similar Fractals") as part of the recurring compatibility-check routine.
- Found that its `Manipulate` call raised a spurious `Manipulate::vsform` warning for one of its specification entries: `Tooltip[DynamicModule[...], Dynamic[...]]`, a Demonstrations idiom that wraps a custom control (built from `Manipulator`/`EventHandler`) in a `Tooltip` to show a hover hint instead of a label, used here for the zoom-point selector. Real Wolfram accepts this silently.
- Added `Tooltip` to the set of recognized layout-container heads in `manipulate_ast` (alongside `Row`, `Column`, `Control`, `Button`, `OpenerView`, etc.) so it passes through without the false-positive message, matching wolframscript's output exactly.

## Test plan

- [x] Added a regression unit test (`tooltip_wrapped_control_arg_is_not_vsform`) covering the general `Tooltip[control, hint]` pattern.
- [x] `make test` — all 28003 tests pass.
- [x] `make format`.
- [x] Re-ran the downloaded Demonstration notebook through `cargo run --example test_notebook` — no warnings, both input cells evaluate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZtGx6CSv2wYWARjMLP4E5

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZtGx6CSv2wYWARjMLP4E5)_