### PR TITLE
Fix bare-symbol pattern args matching as unconstrained wildcards

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -3194,6 +3194,39 @@ pub fn set_delayed_ast(
             }
           }
         }
+        // A bare symbol with no `_` in this slot (e.g. `f[j_, Np]` where
+        // `Np` already holds a value, from `Np = Npp - 1` inside a Module)
+        // is not a pattern at all — WL requires an explicit `_` to
+        // introduce a pattern variable, so a plain symbol here is evaluated
+        // to its current value and matched literally, the same as a
+        // numeric literal (`f[j_, 5]`). Without this, the symbol became an
+        // unconstrained second wildcard slot indistinguishable in
+        // specificity from a fully generic `f[j_, k_]` overload, so the
+        // wrong rule could fire and return `Null` instead of the intended
+        // literal-argument overload.
+        //
+        // Exempt slot 0 of `Default[sym, …] := …`: that's the redirected
+        // storage for `sym`'s DefaultValues (see `belongs_to` in
+        // symbol_values.rs and `definition_text` in
+        // dispatch/complex_and_special.rs), both of which identify "this
+        // Default entry is sym's" by literal name — `params.first() ==
+        // sym` — rather than by evaluating a condition. Turning that slot
+        // into a `_dv0`/SameQ pair would hide the entry from
+        // `Definition[sym]`, `ClearAll[sym]`, and `Block`'s save/restore.
+        Expr::Identifier(name)
+          if !name.contains('_') && !(func_name == "Default" && i == 0) =>
+        {
+          let param_name = format!("_dv{i}");
+          let eval_arg = evaluate_expr_to_expr(arg)?;
+          conditions.push(Some(Expr::Comparison {
+            operands: vec![Expr::Identifier(param_name.clone()), eval_arg],
+            operators: vec![ComparisonOp::SameQ],
+          }));
+          params.push(param_name);
+          blank_types.push(1);
+          defaults.push(None);
+          heads.push(None);
+        }
         // Simple pattern: x_ or x_Head
         _ => {
           let (pat_name, head, blank_type) = extract_pattern_info(arg);

--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -3214,7 +3214,7 @@ pub fn set_delayed_ast(
         // into a `_dv0`/SameQ pair would hide the entry from
         // `Definition[sym]`, `ClearAll[sym]`, and `Block`'s save/restore.
         Expr::Identifier(name)
-          if !name.contains('_') && !(func_name == "Default" && i == 0) =>
+          if !(name.contains('_') || (func_name == "Default" && i == 0)) =>
         {
           let param_name = format!("_dv{i}");
           let eval_arg = evaluate_expr_to_expr(arg)?;

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -395,6 +395,45 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_bare_symbol_pattern_arg_matches_its_current_value() {
+    // A bare symbol with no `_` in a pattern-argument slot is not a pattern
+    // variable — WL requires an explicit `_` to introduce one — so it is
+    // evaluated to its current value and matched literally, the same as a
+    // numeric literal written directly. This is the idiom demonstrations
+    // commonly use inside a `Module`: `n = 5; f[x_, n] := ...` only matches
+    // when the second argument is `5`. Before the fix, the bare symbol
+    // became an unconstrained second wildcard, indistinguishable in
+    // specificity from a fully generic `f[x_, y_]` overload, so calls meant
+    // for the literal-argument rule fell through to the generic one instead
+    // (concretely, `Null` from an `If[cond, then]` with no `else` whose
+    // `cond` referenced the never-bound outer symbol).
+    clear_state();
+    interpret("n = 5;").unwrap();
+    interpret("f[x_, n] := matchedLiteral[x]").unwrap();
+    interpret("f[x_, y_] := general[x, y]").unwrap();
+    assert_eq!(interpret("f[1, 5]").unwrap(), "matchedLiteral[1]");
+    assert_eq!(interpret("f[1, 6]").unwrap(), "general[1, 6]");
+    clear_state();
+  }
+
+  #[test]
+  fn test_bare_symbol_pattern_arg_both_positions() {
+    // Same idiom with the literal-valued symbol in the first slot instead,
+    // and a second overload using the symbol in the last slot — mirroring
+    // the `d[j_, Np]` / `d[Np, j_]` pair from the Frank-Kamenetskii
+    // Demonstration's collocation-matrix construction.
+    clear_state();
+    interpret("np = 3;").unwrap();
+    interpret("d[np, j_] := fromNp[j]").unwrap();
+    interpret("d[j_, np] := toNp[j]").unwrap();
+    interpret("d[j_, k_] := generic[j, k]").unwrap();
+    assert_eq!(interpret("d[3, 7]").unwrap(), "fromNp[7]");
+    assert_eq!(interpret("d[7, 3]").unwrap(), "toNp[7]");
+    assert_eq!(interpret("d[2, 7]").unwrap(), "generic[2, 7]");
+    clear_state();
+  }
+
+  #[test]
   fn test_list_pattern_head_constraint() {
     // Issue #119: per-element head constraints inside a list pattern must be
     // enforced — `g[{n1_Integer, n2_Integer}]` must NOT match a non-integer


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstrations notebook ("The Frank-Kamenetskii Problem"), I found that its `Manipulate` body silently returned `Null` instead of the expected numeric solution.

- `f[x_, n] := ...`, where `n` already holds a value (e.g. a Module-local symbol like `Np = Npp - 1`), is not a pattern in Wolfram Language — an explicit `_` is required to introduce a pattern variable. A plain symbol in that argument slot must be evaluated to its current value and matched literally, the same as a numeric literal (`f[x_, 5]`).
- `set_delayed_ast` was instead treating any bare identifier reaching its generic argument-processing fallback as a named wildcard blank, so it became a second unconstrained slot indistinguishable in specificity from a fully generic `f[x_, y_]` overload. Definitions relying on this idiom — a common pattern in Wolfram Demonstrations that build a collocation matrix via `d[j_, Np]` / `d[Np, j_]` style overloads — could dispatch to the wrong overload and silently return `Null` (from an `If[cond, then]` with no `else`) instead of the intended literal-argument rule.
- `Default[sym, ...] := ...` keeps its existing slot-0 name-based storage, since `Definition[]`/`ClearAll[]`/`Block[]` identify a symbol's `DefaultValues` entries by literal name (`params.first() == sym`) rather than by evaluating a condition.

With the fix, the Demonstration's `FindRoot`-based collocation solve now completes correctly (previously it hung/timed out on the default 30-point grid due to `Null`-poisoned equations), and Woxi Studio can render its `Manipulate` output.

## Test plan

- [x] Added `test_bare_symbol_pattern_arg_matches_its_current_value` and `test_bare_symbol_pattern_arg_both_positions` regression tests in `tests/interpreter_tests.rs`
- [x] `cargo test --test interpreter_tests` — 25846 passed, 0 failed
- [x] `cargo build -p woxi-studio` — builds cleanly
- [x] Manually verified the downloaded Demonstration notebook's `Manipulate` body now evaluates to `Graphics` output (previously hung/timed out)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJazzwedtmopjQM5fVtiUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJazzwedtmopjQM5fVtiUg)_