### PR TITLE
Fix Show dropping opaque graphics layers and TableForm-with-options combine

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11576,6 +11576,18 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // If we have pre-rendered Graphics but no primitives from Graphics[...],
   // return the rendered result directly. Single-arg Show just passes through.
   if merged_primitives.is_empty() && !rendered_graphics.is_empty() {
+    if rendered_graphics.len() == 1 {
+      return Ok(rendered_graphics[0].clone());
+    }
+    // More than one opaque pre-rendered graphic (e.g. `Show[{regionPlot,
+    // Graphics[{Text[…]}]}]`, the Demonstrations idiom that overlays a
+    // caption built separately onto a plot): none of them kept its
+    // primitives or plot-source series to merge symbolically, so the only
+    // way to combine them is to stack their already-rendered pictures. Only
+    // returning the first one silently dropped every other layer.
+    if let Some(svg) = overlay_rendered_graphics_svgs(&rendered_graphics) {
+      return Ok(crate::graphics_result(svg));
+    }
     return Ok(rendered_graphics[0].clone());
   }
 
@@ -11587,10 +11599,27 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut graphics_args = vec![content];
   graphics_args.extend(merged_options);
 
-  if is_3d {
+  let primitives_result = if is_3d {
     crate::functions::plot3d::graphics3d_ast(&graphics_args)
   } else {
     graphics_ast(&graphics_args)
+  }?;
+
+  if rendered_graphics.is_empty() {
+    return Ok(primitives_result);
+  }
+  // Opaque pre-rendered graphics (no primitives, no plot source — e.g. a
+  // `RegionPlot`) alongside `Graphics[…]` primitives that merged above:
+  // stack the primitives-rendered picture with each opaque layer, the same
+  // best-effort overlay used when there are no primitives at all. Without
+  // this, `rendered_graphics` was computed and then never looked at again
+  // once `merged_primitives` had anything in it, so a `Show[{regionPlot,
+  // labelGraphic}]` silently dropped `regionPlot` entirely.
+  let mut layers_to_overlay = vec![primitives_result.clone()];
+  layers_to_overlay.extend(rendered_graphics.iter().cloned());
+  match overlay_rendered_graphics_svgs(&layers_to_overlay) {
+    Some(svg) => Ok(crate::graphics_result(svg)),
+    None => Ok(primitives_result),
   }
 }
 
@@ -14074,6 +14103,64 @@ fn parse_svg_dimensions(svg: &str) -> Option<ParsedSvg> {
     nat_w,
     nat_h,
   })
+}
+
+/// Stack several already-rendered `Expr::Graphics` pictures on top of one
+/// another, for `Show[{g1, g2, …}]` where none of `g1, g2, …` kept
+/// primitives or plot-source series to merge symbolically (e.g. a
+/// `RegionPlot` shown together with a `Graphics[{Text[…]}]` caption built
+/// separately — both render straight to SVG with nothing left to combine
+/// at the expression level). Matching Wolfram's "the merged graphic takes
+/// its shape from the first graphic" rule, the first picture's natural
+/// size is the canvas every later layer is stretched to fit, so they all
+/// share one frame even when their own native sizes differ.
+///
+/// This is a best-effort visual overlay, not a coordinate-accurate merge:
+/// each layer keeps its own internal `PlotRange` (there is no shared
+/// coordinate data to reconcile once a graphic is only an SVG), so layers
+/// drawn against different ranges won't line up point-for-point. It still
+/// beats silently dropping every layer but the first, which is what
+/// `Show` did before this existed.
+fn overlay_rendered_graphics_svgs(graphics: &[Expr]) -> Option<String> {
+  let svgs: Vec<&str> = graphics
+    .iter()
+    .filter_map(|g| match g {
+      Expr::Graphics { svg, .. } => Some(svg.as_str()),
+      _ => None,
+    })
+    .collect();
+  let (first, rest) = svgs.split_first()?;
+  let canvas = parse_svg_dimensions(first)?;
+  let (canvas_w, canvas_h) = (canvas.nat_w, canvas.nat_h);
+
+  let mut out = String::with_capacity(4096);
+  out.push_str(&format!(
+    "<svg width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\" \
+     xmlns=\"http://www.w3.org/2000/svg\">\n",
+    canvas_w.ceil() as u32,
+    canvas_h.ceil() as u32,
+    canvas_w.ceil() as u32,
+    canvas_h.ceil() as u32,
+  ));
+  out.push_str(&format!(
+    "<svg x=\"0\" y=\"0\" width=\"{:.0}\" height=\"{:.0}\" viewBox=\"{}\">\n",
+    canvas_w, canvas_h, canvas.view_box,
+  ));
+  out.push_str(&canvas.inner_content);
+  out.push_str("</svg>\n");
+  for svg in rest {
+    let Some(layer) = parse_svg_dimensions(svg) else {
+      continue;
+    };
+    out.push_str(&format!(
+      "<svg x=\"0\" y=\"0\" width=\"{:.0}\" height=\"{:.0}\" viewBox=\"{}\">\n",
+      canvas_w, canvas_h, layer.view_box,
+    ));
+    out.push_str(&layer.inner_content);
+    out.push_str("</svg>\n");
+  }
+  out.push_str("</svg>");
+  Some(out)
 }
 
 /// Combine multiple SVG strings arranged as rows of cells into a single SVG.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3752,6 +3752,22 @@ fn composed_layout_svg(expr: &syntax::Expr) -> Option<String> {
   svg.starts_with("<svg").then_some(svg)
 }
 
+/// The SVG an already-evaluated graphics item carries on itself — from
+/// `Expr::Graphics { svg, .. }`, peeling a `Style[…]` wrapper first. `None`
+/// for the bare `-Graphics-`/`-Image-` text placeholder, which carries no
+/// data of its own.
+fn item_embedded_svg(expr: &syntax::Expr) -> Option<String> {
+  match expr {
+    syntax::Expr::Graphics { svg, .. } => Some(svg.clone()),
+    syntax::Expr::FunctionCall { name, args }
+      if name == "Style" && !args.is_empty() =>
+    {
+      item_embedded_svg(&args[0])
+    }
+    _ => None,
+  }
+}
+
 /// If the result is a list (1D, 2D, or 3D) of `-Graphics-` items,
 /// or a `TableForm` wrapping such a list, combine captured SVGs into a grid.
 fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
@@ -3759,10 +3775,17 @@ fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
   let has_tableform = has_form_wrapper(&expr, "TableForm");
   let inner = unwrap_form_wrappers(&expr);
 
+  // NB: an empty buffer does *not* mean there's nothing to combine — a
+  // Woxi Studio Manipulate runs its `Initialization` and body as separate
+  // `interpret_with_stdout` calls (each starting with a fresh, empty
+  // buffer), so a body that merely returns an already-built value (e.g.
+  // `pickShow[choice]` handing back a `TableForm[{panelA, panelB}, …]`
+  // assembled during Initialization) triggers no new graphics-producing
+  // calls at all — the items below carry their own embedded SVGs instead
+  // (see `item_embedded_svg`) and don't need the buffer. Only the
+  // positional-slice fallbacks further down actually require it, and they
+  // already guard their own use of `all_svgs`.
   let all_svgs = get_all_captured_graphics();
-  if all_svgs.is_empty() {
-    return expr;
-  }
 
   // A layout that holds pictures — `Grid[{{plot1, plot2}, …}]`, a `Column`
   // of them, a `Pane` around either — is one picture in a notebook, laid
@@ -3777,14 +3800,31 @@ fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
 
   // 1D list of Graphics
   if let syntax::Expr::List(items) = inner {
-    if items.iter().all(is_graphics_placeholder)
-      && items.len() > 1
-      && items.len() <= all_svgs.len()
-    {
-      // Take the last N SVGs (they correspond to the list items)
-      let start = all_svgs.len() - items.len();
-      let row: Vec<String> = all_svgs[start..].to_vec();
-      if let Some(combined) = functions::graphics::graphics_list_svg(&row) {
+    if items.iter().all(is_graphics_placeholder) && items.len() > 1 {
+      // Each item's own embedded SVG is authoritative when present. The
+      // shared capture buffer accumulates every graphic created during the
+      // whole statement sequence (e.g. every intermediate assignment in an
+      // Initialization block), and an earlier statement that itself
+      // combined-and-cleared a graphics list (a nested TableForm assigned
+      // to its own variable, say) leaves the buffer's tail no longer
+      // aligned with these items — so a positional "last N" slice of it
+      // can silently pick up stale entries. Only fall back to that
+      // heuristic when an item is a bare `-Graphics-`/`-Image-`
+      // placeholder with no SVG of its own.
+      let row = items
+        .iter()
+        .map(item_embedded_svg)
+        .collect::<Option<Vec<String>>>()
+        .or_else(|| {
+          (items.len() <= all_svgs.len()).then(|| {
+            // Take the last N SVGs (they correspond to the list items)
+            let start = all_svgs.len() - items.len();
+            all_svgs[start..].to_vec()
+          })
+        });
+      if let Some(row) = row
+        && let Some(combined) = functions::graphics::graphics_list_svg(&row)
+      {
         // Clear and re-capture with the combined SVG
         clear_captured_graphics();
         return graphics_result(combined);
@@ -3810,24 +3850,42 @@ fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
           }
         })
         .sum();
-      if total_cells <= all_svgs.len() {
-        let start = all_svgs.len() - total_cells;
-        let mut offset = start;
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        for item in items {
-          if let syntax::Expr::List(inner) = item {
-            let row: Vec<String> =
-              all_svgs[offset..offset + inner.len()].to_vec();
-            offset += inner.len();
-            rows.push(row);
-          }
-        }
-        if let Some(combined) =
+      // Prefer each item's own embedded SVG (see the 1D case above for why
+      // the shared capture buffer's positional tail can be stale); fall
+      // back to the buffer heuristic only when some item has no SVG of its
+      // own.
+      let rows = items
+        .iter()
+        .map(|item| match item {
+          syntax::Expr::List(inner) => inner
+            .iter()
+            .map(item_embedded_svg)
+            .collect::<Option<Vec<_>>>(),
+          _ => None,
+        })
+        .collect::<Option<Vec<Vec<String>>>>()
+        .or_else(|| {
+          (total_cells <= all_svgs.len()).then(|| {
+            let start = all_svgs.len() - total_cells;
+            let mut offset = start;
+            let mut rows: Vec<Vec<String>> = Vec::new();
+            for item in items {
+              if let syntax::Expr::List(inner) = item {
+                let row: Vec<String> =
+                  all_svgs[offset..offset + inner.len()].to_vec();
+                offset += inner.len();
+                rows.push(row);
+              }
+            }
+            rows
+          })
+        });
+      if let Some(rows) = rows
+        && let Some(combined) =
           functions::graphics::combine_graphics_svgs(&rows)
-        {
-          clear_captured_graphics();
-          return graphics_result(combined);
-        }
+      {
+        clear_captured_graphics();
+        return graphics_result(combined);
       }
     }
 
@@ -3928,10 +3986,21 @@ fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
 }
 
 /// Check if an expression has a specific form wrapper (e.g. "TableForm")
+///
+/// `TableForm` carries its data as the first argument with any options
+/// (`TableDirections -> Row`, `TableSpacing -> {0}`, …) trailing it, so this
+/// looks at `args[0]` rather than requiring exactly one argument — a
+/// `TableForm[data, opts…]` wrapping graphics is the shape every
+/// Demonstrations-style "assemble the panel, TableDirections -> Row" idiom
+/// actually uses. `Style[…]` is peeled through the same way (its directives
+/// carry no meaning for the already-rendered picture this unwrap feeds into,
+/// same trade `is_graphics_placeholder` already makes for individual items)
+/// so a body like `Style[dispatcher[choice], Background -> …]` that resolves
+/// to a `TableForm` of graphics is still recognized.
 fn has_form_wrapper(expr: &syntax::Expr, target: &str) -> bool {
   match expr {
     syntax::Expr::FunctionCall { name, args }
-      if args.len() == 1
+      if !args.is_empty()
         && matches!(
           name.as_str(),
           "TableForm"
@@ -3940,6 +4009,7 @@ fn has_form_wrapper(expr: &syntax::Expr, target: &str) -> bool {
             | "InputForm"
             | "OutputForm"
             | "TraditionalForm"
+            | "Style"
         ) =>
     {
       name == target || has_form_wrapper(&args[0], target)
@@ -3949,10 +4019,12 @@ fn has_form_wrapper(expr: &syntax::Expr, target: &str) -> bool {
 }
 
 /// Unwrap form wrappers like TableForm, MathMLForm, StandardForm, etc.
+/// See `has_form_wrapper` for why this looks at `args[0]` rather than
+/// requiring exactly one argument.
 fn unwrap_form_wrappers(expr: &syntax::Expr) -> &syntax::Expr {
   match expr {
     syntax::Expr::FunctionCall { name, args }
-      if args.len() == 1
+      if !args.is_empty()
         && matches!(
           name.as_str(),
           "TableForm"
@@ -3961,6 +4033,7 @@ fn unwrap_form_wrappers(expr: &syntax::Expr) -> &syntax::Expr {
             | "InputForm"
             | "OutputForm"
             | "TraditionalForm"
+            | "Style"
         ) =>
     {
       unwrap_form_wrappers(&args[0])

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -8844,6 +8844,58 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    /// Regression: `RegionPlot` (like several other plot heads — anything
+    /// that renders straight to SVG without keeping a plot-source series or
+    /// a symbolic primitives `structure`) landed in `Show`'s
+    /// `rendered_graphics` bucket, and a `Graphics[{Text[…]}]` caption
+    /// layered alongside it merged into `merged_primitives` instead (a bare
+    /// `Graphics[…]` keeps its primitives). `Show` only ever consulted
+    /// `rendered_graphics` when `merged_primitives` was completely empty, so
+    /// once *both* buckets held something, the `RegionPlot` layer was
+    /// silently dropped and only the caption drew — the "shade a region,
+    /// caption it separately, `Show` them together" idiom several Wolfram
+    /// Demonstrations Project notebooks use for combined figures.
+    #[test]
+    fn show_merges_region_plot_with_a_separately_built_caption() {
+      let svg = export_svg(
+        "Show[{RegionPlot[x^2 + y^2 < 1, {x, -2, 2}, {y, -2, 2}], \
+           Graphics[{Text[\"caption\", {0, 0}]}]}, ImageSize -> {200, 200}]",
+      );
+      assert!(
+        svg.contains("rgb(94,129,181)"),
+        "the shaded region must still draw: {svg}"
+      );
+      assert!(
+        svg.contains("caption"),
+        "the caption must still draw: {svg}"
+      );
+    }
+
+    /// The same drop happened with two `RegionPlot`-like opaque graphics and
+    /// *no* primitives at all — `Show` returned only the first of
+    /// `rendered_graphics` unconditionally. `x^2 + y^2 < 1` and its
+    /// complement `x^2 + y^2 > 1` together fill nearly all of the plot
+    /// range (everything but a thin boundary ring), so overlaying both
+    /// region fills draws far more of the default region colour than
+    /// either one alone.
+    #[test]
+    fn show_merges_two_opaque_region_plots() {
+      let single =
+        export_svg("RegionPlot[x^2 + y^2 < 1, {x, -2, 2}, {y, -2, 2}]");
+      let combined = export_svg(
+        "Show[{RegionPlot[x^2 + y^2 < 1, {x, -2, 2}, {y, -2, 2}], \
+           RegionPlot[x^2 + y^2 > 1, {x, -2, 2}, {y, -2, 2}]}]",
+      );
+      let fill = "rgb(94,129,181)";
+      let single_count = single.matches(fill).count();
+      let combined_count = combined.matches(fill).count();
+      assert!(
+        combined_count > single_count * 3 / 2,
+        "expected both regions' fills (combined {combined_count} vs one \
+         region's {single_count}), not just the first one kept"
+      );
+    }
+
     // wolframscript accepts arbitrarily many curves in
     // `ParametricPlot[{{fx1,fy1}, {fx2,fy2}, …}, {t, …}]`. Woxi
     // previously rejected 3+ curves with a fatal error because
@@ -13409,6 +13461,94 @@ mod graphics_list {
     let svg = result.graphics.unwrap();
     let nested_count = svg.matches("<svg x=").count();
     assert_eq!(nested_count, 4, "Expected 4 nested SVGs for TableForm list");
+  }
+
+  /// Regression: `has_form_wrapper`/`unwrap_form_wrappers` only recognized a
+  /// bare `TableForm[data]` (exactly one argument), so a `TableForm[data,
+  /// opts…]` wrapping graphics — the shape every Demonstrations-style
+  /// "assemble two panels side by side" idiom actually uses, e.g.
+  /// `TableForm[{panelA, panelB}, TableDirections -> Row, TableSpacing ->
+  /// {0}]` — never got unwrapped to its list, so the list-of-graphics
+  /// combine pass never ran and only a single stray panel rendered instead
+  /// of both.
+  #[test]
+  fn tableform_wrapping_1d_graphics_list_with_options() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "TableForm[Table[Graphics[{Disk[]}], {i, 1, 2}], TableDirections -> Row, TableSpacing -> {0}]",
+    )
+    .unwrap();
+    assert_eq!(result.result, "-Graphics-");
+    assert!(result.graphics.is_some());
+    let svg = result.graphics.unwrap();
+    let nested_count = svg.matches("<svg x=").count();
+    assert_eq!(
+      nested_count, 2,
+      "Expected both panels combined despite the trailing TableForm options: {svg}"
+    );
+  }
+
+  /// Regression: a `Style[…, opts]` wrapping a `TableForm` of graphics (the
+  /// common `Style[dispatcher[choice], Background -> …]` idiom, where
+  /// `dispatcher` resolves to a `TableForm[{panelA, panelB}, …]`) was never
+  /// unwrapped either, for the same reason — only `TableForm`/`MathMLForm`/…
+  /// heads were peeled, not `Style`.
+  #[test]
+  fn style_wrapped_tableform_graphics_list_combines() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "Style[TableForm[Table[Graphics[{Disk[]}], {i, 1, 2}], TableDirections -> Row], Background -> Red]",
+    )
+    .unwrap();
+    assert!(result.graphics.is_some());
+    let svg = result.graphics.unwrap();
+    let nested_count = svg.matches("<svg x=").count();
+    assert_eq!(
+      nested_count, 2,
+      "Expected both panels combined through the Style wrapper: {svg}"
+    );
+  }
+
+  /// Regression: the list-of-graphics combine pass picked its SVGs by
+  /// slicing the last N entries off the *shared* capture buffer, assuming
+  /// they lined up positionally with the current list's items. An
+  /// intervening statement that itself combined-and-cleared a graphics list
+  /// (e.g. an `Initialization` block building several `TableForm[{panelA,
+  /// panelB}, …]`-valued helper variables before the one actually
+  /// displayed) left that buffer holding a *different* combine's leftovers,
+  /// so the final display combined the wrong panels — or, once too few were
+  /// left, silently fell back to a single stray one. Each list item already
+  /// carries its own rendered SVG (`Expr::Graphics { svg, .. }`), which is
+  /// now used directly instead of trusting the buffer's tail.
+  #[test]
+  fn tableform_graphics_list_survives_intervening_combine() {
+    clear_state();
+    let result = interpret_with_stdout(
+      r#"
+      panelA = Graphics[Text["Alpha"]];
+      panelB = Graphics[Text["Bravo"]];
+      decoy = TableForm[{panelA, panelB}, TableDirections -> Row];
+      panelC = Graphics[Text["Charlie"]];
+      panelD = Graphics[Text["Delta"]];
+      TableForm[{panelC, panelD}, TableDirections -> Row]
+      "#,
+    )
+    .unwrap();
+    assert!(result.graphics.is_some());
+    let svg = result.graphics.unwrap();
+    let nested_count = svg.matches("<svg x=").count();
+    assert_eq!(
+      nested_count, 2,
+      "Expected the final pair (panelC/panelD), not leftovers from the decoy combine: {svg}"
+    );
+    assert!(
+      svg.contains("Charlie") && svg.contains("Delta"),
+      "expected the final pair's own labels: {svg}"
+    );
+    assert!(
+      !svg.contains("Alpha") && !svg.contains("Bravo"),
+      "must not leak the decoy combine's panels: {svg}"
+    );
   }
 
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -9445,6 +9445,150 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`fig$$ = 1, $CellContext`k$$ = 0}, D
     }
   }
 
+  /// A logic-diagram picker Manipulate: a single `PopupMenu`-style control
+  /// whose choice list mixes plain-string labels with `Row[{Style[…,
+  /// Italic], " …", Style[…, Italic]}]` labels, and whose body is a
+  /// `Style[…, Background -> …]`-wrapped dispatcher built entirely inside
+  /// `Initialization` from `RegionPlot`-based components assembled with
+  /// `TableForm[…, TableDirections -> Row]` — the general shape of the
+  /// "boolean-logic circuit Venn diagrams" family of Wolfram Demonstrations
+  /// Project notebooks (independently written, not copied from any specific
+  /// one). Also exercises the "stack two lines of text via `Divide` and
+  /// `TableForm`" captioning idiom those notebooks use for figure labels.
+  #[test]
+  fn manipulate_region_plot_popup_with_row_styled_choice_labels() {
+    let code = r#"Manipulate[
+      Style[
+        pickShow[choice],
+        Background -> Lighter[ColorData["Legacy", "Goldenrod"], 0.25]
+      ],
+      {{choice, 3, "select option"},
+       {1 -> "plain label",
+        2 -> Row[{Style["p", Italic], " implies ", Style["q", Italic]}],
+        3 -> Style["p", Italic]}},
+      Initialization :> (
+        regionA = p^2 + q^2 < 1;
+        regionB = (p - 1)^2 + q^2 < 1;
+        leftPic = RegionPlot[regionA && regionB, {p, -2, 2}, {q, -2, 2},
+          BoundaryStyle -> Directive[Black, Thick], Frame -> True,
+          FrameTicks -> False,
+          ColorFunction -> ColorData["SouthwestColors"],
+          PerformanceGoal -> "Quality"];
+        rightPic = RegionPlot[regionA || regionB, {p, -2, 2}, {q, -2, 2},
+          BoundaryStyle -> Directive[Black, Thick], Frame -> True,
+          FrameTicks -> False, Mesh -> 15, MeshStyle -> Opacity[0.3],
+          ColorFunction -> ColorData["SouthwestColors"],
+          PerformanceGoal -> "Quality"];
+        captionRow = Row[{Subscript[Style["f", Italic], "1"], "  {0,1}"}];
+        captionLabel = Graphics[{Text[
+          Style[TableForm[PadLeft[{"Header" / captionRow}, 1, " "],
+            TableDirections -> Row], Bold, Medium],
+          {1.15, -1.75}]}];
+        show1 = TableForm[
+          {Show[{leftPic, captionLabel}, ImageSize -> {200, 200}],
+           Show[{rightPic, captionLabel}, ImageSize -> {200, 200}]},
+          TableDirections -> Row, TableSpacing -> {0}];
+        show2 = TableForm[
+          {Show[{rightPic, captionLabel}, ImageSize -> {200, 200}],
+           Show[{leftPic, captionLabel}, ImageSize -> {200, 200}]},
+          TableDirections -> Row, TableSpacing -> {0}];
+        show3 = show1;
+        pickShow[n_] := Return[Which[n == 1, show1, n == 2, show2, n == 3, show3]];
+      )
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "the popup-with-Row-labels notebook should build a ManipulateState",
+    );
+    assert_eq!(
+      state.error, None,
+      "the body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the assembled RegionPlot table should render"
+    );
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name,
+          values,
+          value_labels,
+          current_index,
+          ..
+        },
+      ] => {
+        assert_eq!(name, "choice");
+        assert_eq!(values, &["1", "2", "3"]);
+        // Row[{Style[…, Italic], " implies ", Style[…, Italic]}] and a bare
+        // Style[…] both flatten to plain text for the choice label.
+        assert_eq!(value_labels, &["plain label", "p implies q", "p"]);
+        // Explicit initial value 3 is the last choice.
+        assert_eq!(*current_index, 2);
+      }
+      other => panic!("expected a single popup control, got {other:?}"),
+    }
+
+    // Switching the picker must actually change what's rendered — show1 and
+    // show2 assemble the same two panels in opposite order.
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      let code = match w.initialization.as_deref() {
+        Some(init) => format!("{init}; {}", w.body),
+        None => w.body.clone(),
+      };
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&code)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the assembled table must render")
+    };
+
+    let third = render(&state);
+    match &mut state.controls[0] {
+      manipulate::ControlState::Discrete { current_index, .. } => {
+        *current_index = 0
+      }
+      other => panic!("expected the popup control, got {other:?}"),
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "choice 1 must evaluate cleanly: {:?}",
+      state.error
+    );
+    let first = render(&state);
+
+    match &mut state.controls[0] {
+      manipulate::ControlState::Discrete { current_index, .. } => {
+        *current_index = 1
+      }
+      other => panic!("expected the popup control, got {other:?}"),
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "choice 2 must evaluate cleanly: {:?}",
+      state.error
+    );
+    let second = render(&state);
+
+    assert_ne!(
+      first, second,
+      "the swapped panel order must change the render"
+    );
+    assert_ne!(third, second);
+  }
+
   #[test]
   fn two_circular_windows_notebook_opens_with_its_widget() {
     // End-to-end regression for the "Two Circular Windows" Demonstration.


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully opens a random Wolfram Demonstration ("Venn Diagrams for Two-Variable Boolean Logic Circuits") end to end, I found and fixed three related defects in how graphics get combined for display:

- **`Show[{g1, g2, …}]` silently dropped every opaque pre-rendered graphic but the first.** A layer like `RegionPlot[…]` that keeps neither symbolic primitives nor a plot-source series to merge (unlike `Plot`/`Graphics[…]`) went into a `rendered_graphics` bucket that `Show` only ever consulted when it was the *sole* content — so `Show[{regionPlot, Graphics[{Text[…]}]}]` (a plot with a separately-built caption, common in Demonstrations) rendered only whichever one happened to end up in the other bucket, and `Show[{regionPlot1, regionPlot2}]` rendered only the first. Both cases now overlay the rendered SVGs instead of discarding data.
- **`TableForm[data, opts…]` (any trailing options, e.g. `TableDirections -> Row`) and `Style[…]`-wrapped `TableForm`/`MatrixForm`/etc. were never unwrapped by the visual-mode graphics-list combiner**, which only recognized a bare single-argument form. A Manipulate body built as `Style[dispatcher[choice], Background -> …]` resolving to a `TableForm` of graphics — the shape this Demonstration (and others like it) uses to assemble its panels — rendered as a single stray panel instead of the combined picture.
- The combiner also now reads each list item's own embedded SVG directly rather than slicing a shared capture buffer by position: an unrelated statement's own combine-and-clear (e.g. another `TableForm`-valued helper variable built earlier in an `Initialization` block) could leave that buffer out of alignment with the current list. It no longer bails out early just because the buffer happens to be empty, either — a Woxi Studio Manipulate evaluates its `Initialization` and body as two separate calls, each starting with a fresh, empty buffer.

Verified against the actual downloaded notebook: with all three fixes, Woxi Studio's `Manipulate` widget for it now builds and renders with no error.

## Test plan

- [x] Added unit tests for the `TableForm`-with-options / `Style`-wrapped-`TableForm` combine paths and the "buffer staleness" scenario (`tests/interpreter_tests/graphics.rs`)
- [x] Added unit tests for `Show` combining opaque pre-rendered graphics, both alone and alongside primitives (`tests/interpreter_tests/graphics.rs`)
- [x] Added a Woxi Studio regression test exercising the popup-control / `RegionPlot` / `TableForm` shape end to end (`woxi-studio/src/main.rs`)
- [x] `make test` — 28007 tests passed
- [x] `cargo test -p woxi-studio --release` — 225 tests passed
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdcmNQQEA5as16f56BgwoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdcmNQQEA5as16f56BgwoZ)_