### PR TITLE
Rework some factorial usage in Woxi

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -8535,7 +8535,11 @@ fn simplex_edges(pts: &[Expr]) -> Option<Vec<Expr>> {
 
 /// `n!` as an `i128` for small `n`.
 fn factorial_small(n: usize) -> i128 {
-  (1..=n as i128).product::<i128>().max(1)
+  let mut r = 1i128;
+  for i in 2..=n {
+    r *= i as i128;
+  }
+  r
 }
 
 /// Decompose Parallelogram arguments into (base point, v1, v2), applying the
@@ -8898,7 +8902,7 @@ fn triangle_moment_parts(
     times(vec![d1[0].clone(), d2[1].clone()]),
     times(vec![int_e(-1), d1[1].clone(), d2[0].clone()]),
   ]))?;
-  let factorial = |m: i128| -> i128 { (1..=m).product::<i128>().max(1) };
+  let factorial = |m: i128| factorial_small(m as usize);
   let multinom = |m: i128, a: i128, b: i128| -> i128 {
     factorial(m) / (factorial(a) * factorial(b) * factorial(m - a - b))
   };
@@ -11884,10 +11888,7 @@ fn try_polynomial(vals: &[(i128, i128)], var_name: &str) -> Option<Expr> {
       terms.push(rational_to_expr(diffs[k].0, diffs[k].1));
     } else {
       // Compute coefficient: diffs[k] / k!
-      let mut factorial: i128 = 1;
-      for j in 1..=k as i128 {
-        factorial *= j;
-      }
+      let factorial = factorial_small(k);
       let coeff = rat_div(diffs[k], (factorial, 1))?;
 
       // Build product (n-1)(n-2)...(n-k) as a polynomial

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -2886,7 +2886,10 @@ pub fn dispatch_math_functions(
         crate::functions::math_ast::plus_ast(&terms).ok()?
       };
       // Divide by d! (1 for d = 0).
-      let factorial: i128 = (1..=d).product::<i128>().max(1);
+      let mut factorial = 1i128;
+      for i in 2..=d {
+        factorial *= i;
+      }
       let result = crate::functions::math_ast::times_ast(&[
         sum,
         call("Rational", vec![Expr::Integer(1), Expr::Integer(factorial)]),

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -13995,11 +13995,11 @@ fn pdf_noncentral_chi_square(
       }
       // odd: x^((v-2)/2) / ((v-2)!! Sqrt[2 Pi] E^(x/2)), negative
       // powers of x move into the denominator
-      let dfact = (1..=(v - 2)).step_by(2).product::<i128>().max(1);
+      let vm2_fact2 = (1..=(v - 2)).step_by(2).product::<i128>().max(1);
       let sqrt_2pi = sqrt(call("Times", vec![int(2), pi()]));
       let mut den_factors: Vec<Expr> = Vec::new();
-      if dfact > 1 {
-        den_factors.push(int(dfact));
+      if vm2_fact2 > 1 {
+        den_factors.push(int(vm2_fact2));
       }
       den_factors.push(e_pow);
       den_factors.push(sqrt_2pi);

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -346,10 +346,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           // Positive half-integers: Gamma[(1+2n)/2] where n = (num-1)/2
           // Gamma[(2n+1)/2] = (2n)! * Sqrt[Pi] / (4^n * n!)
           let n = (num - 1) / 2;
-          let mut numer = BigInt::from(1);
-          for i in (n + 1)..=(2 * n) {
-            numer *= i;
-          }
+          let numer = rising(n as u64);
           let denom = BigInt::from(4).pow(n as u32);
           return Ok(gamma_half_expr(&numer, &denom, false));
         } else if num < 0 {
@@ -358,10 +355,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let n = (1 - num) / 2;
           let is_neg = n % 2 != 0;
           let numer = BigInt::from(4).pow(n as u32);
-          let mut denom = BigInt::from(1);
-          for i in (n + 1)..=(2 * n) {
-            denom *= i;
-          }
+          let denom = rising(n as u64);
           return Ok(gamma_half_expr(&numer, &denom, is_neg));
         }
       }
@@ -684,6 +678,15 @@ pub fn gamma_fn(x: f64) -> f64 {
     let t = x + g + 0.5;
     (2.0 * std::f64::consts::PI).sqrt() * t.powf(x + 0.5) * (-t).exp() * sum
   }
+}
+
+// (2n)! / n! = (n+1)(n+2)...(2n)
+fn rising(n: u64) -> BigInt {
+  let mut r = BigInt::from(1);
+  for i in (n + 1)..=(2 * n) {
+    r *= i;
+  }
+  r
 }
 
 /// Beta[a, b] - Euler beta function
@@ -1198,10 +1201,7 @@ fn gamma_half_integer_parts_big(k2: i128) -> Option<(BigInt, BigInt, i128)> {
     Some((factorial_big(m - 1), BigInt::from(1), 0))
   } else {
     let m = ((k2 - 1) / 2) as u64;
-    let mut numer = BigInt::from(1);
-    for i in (m + 1)..=(2 * m) {
-      numer *= i;
-    }
+    let numer = rising(m);
     let denom = BigInt::from(4).pow(m as u32);
     Some((numer, denom, 1))
   }

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1688,6 +1688,15 @@ pub fn weber_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(unevaluated("WeberE", args))
 }
 
+// (2n)!/n! = (n+1)(n+2) ... (2n)
+fn rising(n: i128) -> BigInt {
+  let mut r = BigInt::from(1);
+  for i in (n + 1)..=(2 * n) {
+    r *= i;
+  }
+  r
+}
+
 /// WeberE[n, z] for an integer order n and exact argument z, as the finite
 /// polynomial-in-z over Pi minus StruveH[|n|, z]. See [`weber_e_ast`].
 fn weber_e_integer_closed_form(
@@ -1695,15 +1704,6 @@ fn weber_e_integer_closed_form(
   z: &Expr,
 ) -> Result<Expr, InterpreterError> {
   let m = n.unsigned_abs() as i128; // |n|
-  let fact = |k: i128| -> BigInt {
-    let mut r = BigInt::from(1);
-    let mut i = 2i128;
-    while i <= k {
-      r *= i;
-      i += 1;
-    }
-    r
-  };
   let pi = Expr::Constant("Pi".to_string());
   let pi_inv = pow2(pi, Expr::Integer(-1));
 
@@ -1713,9 +1713,8 @@ fn weber_e_integer_closed_form(
   if m >= 1 {
     let kmax = (m - 1) / 2;
     for k in 0..=kmax {
-      let raw_num =
-        fact(2 * k) * fact(m - k) * BigInt::from(2).pow((m - 2 * k + 1) as u32);
-      let raw_den = fact(2 * (m - k)) * fact(k);
+      let raw_num = rising(k) * BigInt::from(2).pow((m - 2 * k + 1) as u32);
+      let raw_den = rising(m - k);
       let coeff = make_rational_expr(&raw_num, &raw_den);
       let p = m - 2 * k - 1;
       let mut factors = vec![coeff];
@@ -1990,8 +1989,7 @@ fn wigner_d_small_symbolic(
     }
     let sign_exp = m1mm2 + s;
     let sign: i128 = if sign_exp.rem_euclid(2) == 0 { 1 } else { -1 };
-    let denom: i128 =
-      fact(jpm1 - s) * fact(s) * fact(s - m1mm2) * fact(jmm2 - s);
+    let denom = fact(jpm1 - s) * fact(s) * fact(s - m1mm2) * fact(jmm2 - s);
 
     let cos_term = if cos_power == 0 {
       Expr::Integer(1)

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -424,8 +424,8 @@ fn jacobi_p_rational_ab(
   let mut terms: Vec<Expr> = Vec::with_capacity(n + 1);
   for s in 0..=n {
     // Denominator 2^s · s! · (n-s)!.
-    let s_fact: i128 = (1..=s as i128).product::<i128>().max(1);
-    let ns_fact: i128 = (1..=(n - s) as i128).product::<i128>().max(1);
+    let s_fact = fact(s);
+    let ns_fact = fact(n - s);
     let Some(den) = (1i128 << s)
       .checked_mul(s_fact)
       .and_then(|v| v.checked_mul(ns_fact))
@@ -2499,13 +2499,20 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
+fn fact(n: usize) -> i128 {
+  let mut r = 1i128;
+  for i in 2..=n {
+    r *= i as i128;
+  }
+  r
+}
+
 /// GegenbauerC[n, λ, x] for a non-negative integer n and a symbolic order λ,
 /// built from the explicit series
 ///   C_n^λ(x) = Σ_{k=0}^{⌊n/2⌋} (-1)^k · Pochhammer[λ, n-k]/(k! (n-2k)!) · (2x)^{n-2k}.
 /// The Pochhammer factors λ(1+λ)…(n-k-1+λ) are kept as an unexpanded product so
 /// the result matches wolframscript's factored form.
 fn gegenbauer_symbolic_lambda(n: usize, lambda: &Expr, x: &Expr) -> Expr {
-  let fact = |m: usize| (1..=m).map(|v| v as i128).product::<i128>().max(1);
   let mut terms: Vec<Expr> = Vec::new();
   for k in 0..=(n / 2) {
     let power = n - 2 * k; // exponent of x
@@ -3099,7 +3106,7 @@ fn generalized_laguerre_l_ast(
   let pow = |b: Expr, e: i128| call("Power", vec![b, Expr::Integer(e)]);
   let mut sum_terms: Vec<Expr> = Vec::with_capacity(n + 1);
   for k in 0..=n {
-    let k_fact: i128 = (1..=k as i128).product::<i128>().max(1);
+    let k_fact = fact(k);
     sum_terms.push(call(
       "Times",
       vec![

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -3240,7 +3240,11 @@ fn skellam_params(dist: &Expr) -> Option<(Expr, Expr)> {
 }
 
 fn fact_i128(n: i128) -> i128 {
-  (1..=n).product::<i128>().max(1)
+  let mut r = 1i128;
+  for i in 2..=n {
+    r *= i;
+  }
+  r
 }
 
 /// Integer partitions of `n` into parts >= 2 (each part non-increasing).
@@ -4318,7 +4322,7 @@ fn factorial_moment_of_distribution(
   r: i128,
 ) -> Option<Expr> {
   let times = |fs: Vec<Expr>| call("Times", fs);
-  let r_factorial: i128 = (1..=r).product::<i128>().max(1);
+  let r_factorial = fact_i128(r);
   match (name, dargs) {
     // Poisson: E[X^(r)] = lambda^r (the defining property).
     ("PoissonDistribution", [lam]) => Some(pow2(lam.clone(), Expr::Integer(r))),

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -1094,13 +1094,10 @@ fn polygamma_numeric(n: usize, mut z: f64) -> f64 {
   }
 
   let sign = if n.is_multiple_of(2) { -1.0 } else { 1.0 }; // (-1)^{n+1}
-  let nfact = {
-    let mut f = 1.0_f64;
-    for i in 2..=n {
-      f *= i as f64;
-    }
-    f
-  };
+  let mut nfact = 1.0_f64;
+  for i in 2..=n {
+    nfact *= i as f64;
+  }
 
   // Use recurrence to shift z to a large value
   let mut shift_sum = 0.0;


### PR DESCRIPTION
This PR does some minor cleanup where factorials are used in Woxi. It uses rising(n) for (2n)!/n! in a few places to eliminate some multiplications. It also rewrites some factorial functions to avoid needing max(1).