### PR TITLE
Fix rational coefficient handling in Expand and PolynomialReduce

### DIFF
--- a/src/functions/polynomial_ast/expand.rs
+++ b/src/functions/polynomial_ast/expand.rs
@@ -934,6 +934,15 @@ fn is_numeric_scalar(e: &Expr) -> bool {
       matches!(args[0], Expr::Integer(_) | Expr::BigInteger(_))
         && matches!(args[1], Expr::Integer(_) | Expr::BigInteger(_))
     }
+    // A quotient of numeric literals is a number too: expansion builds
+    // `Divide` nodes (e.g. the leading-coefficient ratio in
+    // PolynomialReduce) that never went through the evaluator's
+    // Rational normalization.
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => is_numeric_scalar(left) && is_numeric_scalar(right),
     _ => false,
   }
 }
@@ -1293,11 +1302,32 @@ fn sort_var_factors_canonical(factors: &mut [Expr]) {
   });
 }
 
+/// Multiply two numeric coefficients, keeping rationals in normal form.
+/// `multiply_exprs` only folds integers, so `2 * 1/2` would stay an
+/// unevaluated `Times` and two terms that differ only in how their rational
+/// coefficient is spelled would never combine.
+fn multiply_numeric_coeff(a: &Expr, b: &Expr) -> Expr {
+  if matches!(a, Expr::Integer(1)) {
+    return b.clone();
+  }
+  if matches!(b, Expr::Integer(1)) {
+    return a.clone();
+  }
+  crate::evaluator::evaluate_function_call_ast("Times", &[a.clone(), b.clone()])
+    .unwrap_or_else(|_| multiply_exprs(a, b))
+}
+
 /// Decompose a term into (numeric_coefficient, sort_key, variable_factors).
 /// E.g. 3*x^2*y → (3, "x^2*y", [x^2, y])
 ///      -x → (-1, "x^1", [x])
 ///      5 → (5, "", [])
 pub(super) fn decompose_term(term: &Expr) -> (Expr, String, Vec<Expr>) {
+  // A bare number — including a Rational or a quotient of numeric literals —
+  // is a pure coefficient with an empty variable part, so `1/2` and `-1/2`
+  // land in the same bucket as any other constant.
+  if is_numeric_scalar(term) {
+    return (term.clone(), String::new(), vec![]);
+  }
   match term {
     Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_) => {
       (term.clone(), String::new(), vec![])
@@ -1325,19 +1355,18 @@ pub(super) fn decompose_term(term: &Expr) -> (Expr, String, Vec<Expr>) {
 
       for f in &factors {
         match f {
-          Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_) => {
-            numeric_coeff = multiply_exprs(&numeric_coeff, f);
+          _ if is_numeric_scalar(f) => {
+            numeric_coeff = multiply_numeric_coeff(&numeric_coeff, f);
           }
           Expr::UnaryOp {
             op: UnaryOperator::Minus,
             operand,
           } => {
             numeric_coeff = negate_term(&numeric_coeff);
-            match operand.as_ref() {
-              Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_) => {
-                numeric_coeff = multiply_exprs(&numeric_coeff, operand);
-              }
-              _ => var_factors.push(*operand.clone()),
+            if is_numeric_scalar(operand) {
+              numeric_coeff = multiply_numeric_coeff(&numeric_coeff, operand);
+            } else {
+              var_factors.push(*operand.clone());
             }
           }
           _ => var_factors.push(f.clone()),
@@ -1363,11 +1392,10 @@ pub(super) fn decompose_term(term: &Expr) -> (Expr, String, Vec<Expr>) {
       let mut var_factors: Vec<Expr> = Vec::new();
 
       for f in args {
-        match f {
-          Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_) => {
-            numeric_coeff = multiply_exprs(&numeric_coeff, f);
-          }
-          _ => var_factors.push(f.clone()),
+        if is_numeric_scalar(f) {
+          numeric_coeff = multiply_numeric_coeff(&numeric_coeff, f);
+        } else {
+          var_factors.push(f.clone());
         }
       }
 

--- a/src/functions/polynomial_ast/expand.rs
+++ b/src/functions/polynomial_ast/expand.rs
@@ -1002,11 +1002,7 @@ fn fold_term_numerics(expr: &Expr) -> Expr {
       let mut rest: Vec<Expr> = Vec::new();
       for f in &factors {
         if is_numeric_scalar(f) {
-          coeff = crate::evaluator::evaluate_function_call_ast(
-            "Times",
-            &[coeff.clone(), f.clone()],
-          )
-          .unwrap_or_else(|_| multiply_exprs(&coeff, f));
+          coeff = multiply_numeric_coeff(&coeff, f);
         } else {
           rest.push(f.clone());
         }

--- a/src/functions/polynomial_ast/polynomial_division.rs
+++ b/src/functions/polynomial_ast/polynomial_division.rs
@@ -116,9 +116,13 @@ pub fn polynomial_reduce_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
     return Ok(unevaluated());
   }
+  // A single divisor may be given without the surrounding list, the way the
+  // other polynomial-division functions take one; the result still reports
+  // its quotient inside a one-element list:
+  // PolynomialReduce[x^2, x, x] → {{x}, 0}.
   let divisors: Vec<Expr> = match &args[1] {
     Expr::List(items) => items.to_vec(),
-    _ => return Ok(unevaluated()),
+    other => vec![other.clone()],
   };
   // Multivariate form: {x1, x2, …} with two or more variables uses
   // lexicographic multivariate division (via the Gröbner machinery).

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -7017,14 +7017,6 @@ fn is_plus_expr(expr: &Expr) -> bool {
   }
 }
 
-thread_local! {
-  /// Guards the re-simplification of a sum that collapsed into a single
-  /// fraction, so the sum and quotient pipelines cannot hand a term back and
-  /// forth between their two shapes.
-  static RESIMPLIFYING_QUOTIENT: std::cell::Cell<bool> =
-    const { std::cell::Cell::new(false) };
-}
-
 /// Simplify a sum — `Plus[…]` or a `+`/`-` binary tree — by expanding and
 /// combining it, then offering the like-denominator, Together and
 /// trig-polynomial rewrites as candidates.
@@ -7055,16 +7047,21 @@ fn simplify_additive(expr: &Expr) -> Expr {
     }
   }
   // A sum that collapsed into a single fraction goes through the quotient
-  // pipeline too — the same one the already-combined spelling takes — so two
+  // stage too — the same one the already-combined spelling takes — so two
   // spellings of one value cannot simplify differently: `Simplify[12/13 -
   // (8x)/13]` used to stop at `(12 - 8x)/13` (which the later candidate
   // selection displayed as `-((-12 + 8x)/13)`) while `Simplify[(12 - 8x)/13]`
   // reached the content-extracted `(-4*(-3 + 2x))/13`.
   //
-  // Only when the numerator is still a plain sum: an already-factored
-  // numerator (`k*q*(1 + (1+s)^(15/4))`) would be re-expanded by the round
-  // trip, undoing a grouping the sum pipeline just found. RESIMPLIFYING_
-  // QUOTIENT keeps the two pipelines from handing the term back and forth.
+  // `simplify_division` is called directly rather than routing the quotient
+  // back through `simplify_expr`: the numerator and denominator here are
+  // already simplified, and re-entering the generic dispatcher would walk
+  // back into this function and risk the two pipelines handing the term back
+  // and forth.
+  //
+  // Only when the numerator is still a plain sum — an already-factored
+  // numerator (`k*q*(1 + (1+s)^(15/4))`) would be re-expanded by the
+  // quotient stage, undoing a grouping the sum pipeline just found.
   let (num, den) = super::together::extract_num_den(&best);
   let collapsed_to_quotient = !matches!(den, Expr::Integer(1))
     && (matches!(&num, Expr::FunctionCall { name, .. } if name == "Plus")
@@ -7075,12 +7072,8 @@ fn simplify_additive(expr: &Expr) -> Expr {
           ..
         }
       ));
-  if collapsed_to_quotient && !RESIMPLIFYING_QUOTIENT.with(std::cell::Cell::get)
-  {
-    RESIMPLIFYING_QUOTIENT.with(|f| f.set(true));
-    let requotiented = simplify_expr(&best);
-    RESIMPLIFYING_QUOTIENT.with(|f| f.set(false));
-    best = requotiented;
+  if collapsed_to_quotient {
+    best = simplify_division(&num, &den);
   }
   best
 }

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -7017,6 +7017,74 @@ fn is_plus_expr(expr: &Expr) -> bool {
   }
 }
 
+thread_local! {
+  /// Guards the re-simplification of a sum that collapsed into a single
+  /// fraction, so the sum and quotient pipelines cannot hand a term back and
+  /// forth between their two shapes.
+  static RESIMPLIFYING_QUOTIENT: std::cell::Cell<bool> =
+    const { std::cell::Cell::new(false) };
+}
+
+/// Simplify a sum — `Plus[…]` or a `+`/`-` binary tree — by expanding and
+/// combining it, then offering the like-denominator, Together and
+/// trig-polynomial rewrites as candidates.
+fn simplify_additive(expr: &Expr) -> Expr {
+  let combined = expand_and_combine(expr);
+  let trig = apply_trig_identities(&combined);
+  let mut best = trig;
+  let mut best_c = leaf_count(&best);
+  // Try combining like-denominator terms
+  let with_fracs = combine_like_denominator_terms(&best);
+  let c = leaf_count(&with_fracs);
+  if c < best_c {
+    best = with_fracs;
+    best_c = c;
+  }
+  // Try Together + factor + cancel
+  let together = try_together_simplify(&best);
+  let c = leaf_count(&together);
+  if c < best_c {
+    best = together;
+    best_c = c;
+  }
+  // Try trig polynomial simplification (Pythagorean sub + power reduction)
+  if let Some(trig_reduced) = try_trig_polynomial_simplify(&best) {
+    let c = leaf_count(&trig_reduced);
+    if c < best_c {
+      best = trig_reduced;
+    }
+  }
+  // A sum that collapsed into a single fraction goes through the quotient
+  // pipeline too — the same one the already-combined spelling takes — so two
+  // spellings of one value cannot simplify differently: `Simplify[12/13 -
+  // (8x)/13]` used to stop at `(12 - 8x)/13` (which the later candidate
+  // selection displayed as `-((-12 + 8x)/13)`) while `Simplify[(12 - 8x)/13]`
+  // reached the content-extracted `(-4*(-3 + 2x))/13`.
+  //
+  // Only when the numerator is still a plain sum: an already-factored
+  // numerator (`k*q*(1 + (1+s)^(15/4))`) would be re-expanded by the round
+  // trip, undoing a grouping the sum pipeline just found. RESIMPLIFYING_
+  // QUOTIENT keeps the two pipelines from handing the term back and forth.
+  let (num, den) = super::together::extract_num_den(&best);
+  let collapsed_to_quotient = !matches!(den, Expr::Integer(1))
+    && (matches!(&num, Expr::FunctionCall { name, .. } if name == "Plus")
+      || matches!(
+        &num,
+        Expr::BinaryOp {
+          op: BinaryOperator::Plus | BinaryOperator::Minus,
+          ..
+        }
+      ));
+  if collapsed_to_quotient && !RESIMPLIFYING_QUOTIENT.with(std::cell::Cell::get)
+  {
+    RESIMPLIFYING_QUOTIENT.with(|f| f.set(true));
+    let requotiented = simplify_expr(&best);
+    RESIMPLIFYING_QUOTIENT.with(|f| f.set(false));
+    best = requotiented;
+  }
+  best
+}
+
 /// Full simplification: expand, combine like terms, simplify.
 pub fn simplify_expr(expr: &Expr) -> Expr {
   let normal = simplify_expr_inner(expr);
@@ -7077,34 +7145,7 @@ fn simplify_expr_inner(expr: &Expr) -> Expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus | BinaryOperator::Minus,
       ..
-    } => {
-      let combined = expand_and_combine(expr);
-      let trig = apply_trig_identities(&combined);
-      let mut best = trig;
-      let mut best_c = leaf_count(&best);
-      // Try combining like-denominator terms
-      let with_fracs = combine_like_denominator_terms(&best);
-      let c = leaf_count(&with_fracs);
-      if c < best_c {
-        best = with_fracs;
-        best_c = c;
-      }
-      // Try Together + factor + cancel
-      let together = try_together_simplify(&best);
-      let c = leaf_count(&together);
-      if c < best_c {
-        best = together;
-        best_c = c;
-      }
-      // Try trig polynomial simplification (Pythagorean sub + power reduction)
-      if let Some(trig_reduced) = try_trig_polynomial_simplify(&best) {
-        let c = leaf_count(&trig_reduced);
-        if c < best_c {
-          best = trig_reduced;
-        }
-      }
-      best
-    }
+    } => simplify_additive(expr),
 
     Expr::UnaryOp { op, operand } => {
       let inner = simplify_expr(operand);
@@ -7116,32 +7157,7 @@ fn simplify_expr_inner(expr: &Expr) -> Expr {
 
     // Handle FunctionCall forms of Plus, Times, Power
     Expr::FunctionCall { name, args } => match name.as_str() {
-      "Plus" => {
-        let combined = expand_and_combine(expr);
-        let trig = apply_trig_identities(&combined);
-        let mut best = trig;
-        let mut best_c = leaf_count(&best);
-        let with_fracs = combine_like_denominator_terms(&best);
-        let c = leaf_count(&with_fracs);
-        if c < best_c {
-          best = with_fracs;
-          best_c = c;
-        }
-        let together = try_together_simplify(&best);
-        let c = leaf_count(&together);
-        if c < best_c {
-          best = together;
-          best_c = c;
-        }
-        // Try trig polynomial simplification
-        if let Some(trig_reduced) = try_trig_polynomial_simplify(&best) {
-          let c = leaf_count(&trig_reduced);
-          if c < best_c {
-            best = trig_reduced;
-          }
-        }
-        best
-      }
+      "Plus" => simplify_additive(expr),
       "Times" => {
         // Check for fraction form: Times[..., Power[den, -1]]
         let (num, den) = super::together::extract_num_den(expr);

--- a/tests/cli/symbolic/PolynomialReduce.md
+++ b/tests/cli/symbolic/PolynomialReduce.md
@@ -24,6 +24,20 @@ $ wo 'PolynomialReduce[x^2, {3 x + 1}, x]'
 {{-1/9 + x/3}, 1/9}
 ```
 
+A divisor with rational coefficients divides just as exactly:
+
+```scrut
+$ wo 'PolynomialReduce[1 - 2 x^3 + x^4, {(1 + x + x^2 - x^3)/2}, x]'
+{{2 - 2*x}, 0}
+```
+
+A single divisor may be given without the surrounding list:
+
+```scrut
+$ wo 'PolynomialReduce[x^2 + 1, x + 1, x]'
+{{-1 + x}, 2}
+```
+
 When no divisor can reduce the polynomial, it is returned as the remainder:
 
 ```scrut

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -509,6 +509,26 @@ mod expand {
     assert_eq!(interpret("Expand[5]").unwrap(), "5");
   }
 
+  // Regression (issue #766): terms whose rational coefficients are spelled
+  // differently still share one bucket, so they cancel instead of piling up
+  // as `1 - 1 + x - x`. A rational factor is part of the coefficient, not of
+  // the monomial's variable part.
+  #[test]
+  fn rational_coefficients_cancel() {
+    assert_eq!(interpret("Expand[1 + x - 2*(1/2 + x/2)]").unwrap(), "0");
+    assert_eq!(
+      interpret("Expand[(1 + x + x^2 - x^3) - 2*(1/2 + x/2 + x^2/2 - x^3/2)]")
+        .unwrap(),
+      "0"
+    );
+    assert_eq!(interpret("Expand[(1 + x) - 3*(1/3 + x/3)]").unwrap(), "0");
+    assert_eq!(interpret("Expand[(y + 1)*x/2 - x/2]").unwrap(), "(x*y)/2");
+    assert_eq!(
+      interpret("Expand[(49*(16 + 2*x))/26 - (19*(20 + 3*x))/13]").unwrap(),
+      "12/13 - (8*x)/13"
+    );
+  }
+
   #[test]
   fn difference_of_squares() {
     assert_eq!(interpret("Expand[(x + 2)*(x - 2)]").unwrap(), "-4 + x^2");
@@ -9323,6 +9343,35 @@ mod polynomial_reduce {
       "{{x + y}, x + y}"
     );
   }
+
+  /// A divisor with rational coefficients divides exactly (issue #766).
+  /// The reduction only terminates once the running remainder collapses to
+  /// the literal 0 — Expand used to leave `1/2 - 1/2 + x/2 - x/2 + …`
+  /// uncombined, so the loop hit its guard and gave up unevaluated.
+  #[test]
+  fn rational_divisor_divides_exactly() {
+    assert_eq!(
+      interpret(
+        "PolynomialReduce[1 - 2 x^3 + x^4, {(1 + x + x^2 - x^3)/2}, x]"
+      )
+      .unwrap(),
+      "{{2 - 2*x}, 0}"
+    );
+  }
+
+  /// A single divisor may be given without the surrounding list.
+  #[test]
+  fn divisor_without_list() {
+    assert_eq!(
+      interpret("PolynomialReduce[x^2 + 1, x + 1, x]").unwrap(),
+      "{{-1 + x}, 2}"
+    );
+    assert_eq!(
+      interpret("PolynomialReduce[1 - 2 x^3 + x^4, (1 + x + x^2 - x^3)/2, x]")
+        .unwrap(),
+      "{{2 - 2*x}, 0}"
+    );
+  }
 }
 
 mod solve_expression_target {
@@ -14806,9 +14855,12 @@ mod cases {
   }
   #[test]
   fn simplify_10() {
+    // The first component is `(12 - 8x)/13`; Simplify displays it with the
+    // sign pulled out, the same way it does for the already-combined
+    // spelling `Simplify[12/13 - (8 x)/13]`.
     assert_case(
       r#"LeastSquares[{{1, 2}, {2, 3}, {5, 6}}, {1, 5, 3}]; Simplify[LeastSquares[{{1, 2}, {2, 3}, {5, 6}}, {1, x, 3}]]"#,
-      r#"{(-4*(-3 + 2*x))/13, (-4 + 7*x)/13}"#,
+      r#"{-((-12 + 8*x)/13), (-4 + 7*x)/13}"#,
     );
   }
   #[test]

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -1492,6 +1492,24 @@ mod simplify {
     );
   }
 
+  // A sum that combines into a single fraction must simplify to the same
+  // form as the already-combined spelling of the same value: the sum used to
+  // stop at `(12 - 8x)/13` (displayed `-((-12 + 8x)/13)`) while the quotient
+  // reached the content-extracted `(-4*(-3 + 2x))/13`.
+  #[test]
+  fn sum_and_quotient_spellings_agree() {
+    for spelling in [
+      "Simplify[12/13 - (8*x)/13]",
+      "Simplify[(12 - 8*x)/13]",
+      "Simplify[(24 - 16*x)/26]",
+      "Simplify[24/26 - (16*x)/26]",
+    ] {
+      assert_eq!(interpret(spelling).unwrap(), "(-4*(-3 + 2*x))/13");
+    }
+    assert_eq!(interpret("Simplify[3/2 + x/2]").unwrap(), "(3 + x)/2");
+    assert_eq!(interpret("Simplify[(3 + x)/2]").unwrap(), "(3 + x)/2");
+  }
+
   #[test]
   fn trig_polynomial_cos_dominant() {
     assert_eq!(
@@ -14855,12 +14873,9 @@ mod cases {
   }
   #[test]
   fn simplify_10() {
-    // The first component is `(12 - 8x)/13`; Simplify displays it with the
-    // sign pulled out, the same way it does for the already-combined
-    // spelling `Simplify[12/13 - (8 x)/13]`.
     assert_case(
       r#"LeastSquares[{{1, 2}, {2, 3}, {5, 6}}, {1, 5, 3}]; Simplify[LeastSquares[{{1, 2}, {2, 3}, {5, 6}}, {1, x, 3}]]"#,
-      r#"{-((-12 + 8*x)/13), (-4 + 7*x)/13}"#,
+      r#"{(-4*(-3 + 2*x))/13, (-4 + 7*x)/13}"#,
     );
   }
   #[test]

--- a/tests/interpreter_tests/math/complex.rs
+++ b/tests/interpreter_tests/math/complex.rs
@@ -511,9 +511,12 @@ mod re_tests {
     );
     assert_eq!(interpret("Re[E^(I*Log[3])]").unwrap(), "Cos[Log[3]]");
     assert_eq!(interpret("Re[E^(I*E)]").unwrap(), "Cos[E]");
+    // Canonical Plus ordering puts the number (`I/3` is `Complex[0, 1/3]`)
+    // before the radical term, matching what plain evaluation of
+    // `I/3 + (2 Sqrt[2])/3` prints.
     assert_eq!(
       interpret("ComplexExpand[E^(I*ArcSin[1/3])]").unwrap(),
-      "(2*Sqrt[2])/3 + I/3"
+      "I/3 + (2*Sqrt[2])/3"
     );
     // A complex-valued argument has no real value and still stays put.
     assert_eq!(interpret("Re[E^(I*x)]").unwrap(), "Re[E^(I*x)]");


### PR DESCRIPTION
## Summary

Fixes #766. `PolynomialReduce[1 - 2 x^3 + x^4, (1 + x + x^2 - x^3)/2, x]` returned unevaluated.

The cause was not in `PolynomialReduce` but in `Expand`. `decompose_term` splits an additive term into a numeric coefficient and a variable part, but only recognised `Integer`/`BigInteger`/`Real` as numeric. A `Rational` — or a `Divide` of numeric literals, which expansion builds — was filed under the term's *variable* part, so `1` keyed as `""` while `2*(1/2)` keyed as `"1/2"` and the two never met in the same bucket to cancel:

```
Expand[(1 + x + x^2 - x^3) - 2*(1/2 + x/2 + x^2/2 - x^3/2)]
  ->  1 - 1 + x - x + x^2 - x^2 - x^3 + x^3      (should be 0)
```

`PolynomialReduce`'s division loop runs until the working remainder is the literal `0`, so it never terminated and hit its 100 000-iteration guard, returning unevaluated.

## Changes

**`expand.rs`** — `is_numeric_scalar` also covers a quotient of numeric literals; `decompose_term` folds every numeric scalar into the coefficient rather than the variable part, multiplying coefficients through the evaluator (`multiply_numeric_coeff`) so `2 * 1/2` normalises to `1`. `fold_term_numerics` delegates to the same helper instead of re-inlining it.

**`polynomial_division.rs`** — `PolynomialReduce` accepts a single divisor without the surrounding list, the form the issue uses and the one the other polynomial-division functions take.

**`simplify.rs`** — `Simplify` gave two different answers for one value depending on how it was spelled:

```
# before
Simplify[(12 - 8 x)/13]      ->  (-4*(-3 + 2*x))/13
Simplify[12/13 - (8 x)/13]   ->  -((-12 + 8*x)/13)
```

The `Plus` branch combines like-denominator terms into a single fraction and then stopped, so the quotient sign/content-extraction stage never ran on the result. A collapsed fraction now goes through `simplify_division` directly, gated on the numerator still being a plain sum — an already-factored numerator like `k*q*(1 + (1+s)^(15/4))` would be re-expanded by that stage. The two byte-identical `Plus` arms of `simplify_expr_inner` now share one `simplify_additive`.

This surfaced through this PR rather than being caused by it: with `Expand` combining correctly, the `simplify_10` input reaches the sum spelling and took the second (wrong) branch. With the inconsistency fixed, that test keeps its original expectation.

## Side effects

`Expand[(y + 1) x/2 - x/2]` was `x*-1/2 + x/2 + (x*y)/2`, now `(x*y)/2`.

One expectation moved and is **not verified against `wolframscript`** (it isn't installed in the container this was developed in): `ComplexExpand[E^(I ArcSin[1/3])]` now prints `I/3 + (2*Sqrt[2])/3` rather than `(2*Sqrt[2])/3 + I/3`. This is a canonical `Plus` ordering question — on `main`, plain evaluation of `Plus[I/3, (2 Sqrt[2])/3]` already put the number first, so `ComplexExpand` was disagreeing with woxi's own `Plus`, and the change makes them consistent. Worth a `wolframscript -code 'ComplexExpand[E^(I*ArcSin[1/3])]'` check before merge.

## Tests

Regression tests for the issue example, the scalar-divisor form, the `Expand` cancellation cases, and `sum_and_quotient_spellings_agree` pinning both spellings to one output; doc-test entries in `tests/cli/symbolic/PolynomialReduce.md`. 28051 unit tests and 3712 CLI doc tests pass; clippy clean; `make format` applied.

https://claude.ai/code/session_01TZYpWLUzyK5ufxqmRHAMq9