### PR TITLE
Remove unnecessary crate::syntax:: prefixes

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -432,10 +432,8 @@ pub fn rule_dominates(
   }
   // Every guard of `b` must also guard `a`, else `a` accepts inputs `b` rejects.
   // Compare guards by their string form (Expr has no PartialEq).
-  let a_guard_strs: Vec<String> =
-    a_guards.iter().map(crate::syntax::expr_to_string).collect();
-  let b_guard_strs: Vec<String> =
-    b_guards.iter().map(crate::syntax::expr_to_string).collect();
+  let a_guard_strs: Vec<String> = a_guards.iter().map(expr_to_string).collect();
+  let b_guard_strs: Vec<String> = b_guards.iter().map(expr_to_string).collect();
   for g in &b_guard_strs {
     if !a_guard_strs.contains(g) {
       return false;
@@ -636,7 +634,7 @@ fn pattern_var_key(name: &str, expr: &Expr) -> String {
   if !name.is_empty() {
     return name.to_string();
   }
-  let shape: String = crate::syntax::expr_to_string(expr)
+  let shape: String = expr_to_string(expr)
     .chars()
     .map(|c| if c.is_ascii_alphanumeric() { c } else { 'x' })
     .collect();
@@ -1058,10 +1056,7 @@ pub fn get_attributes(expr: &Expr) -> Option<u32> {
 
 /// Helper for Attributes[f] = value / Attributes[f] := value
 /// Extracts attribute symbols from value, validates, and sets them on the symbol.
-fn set_attributes_from_value(
-  sym_name: &str,
-  rhs_value: &Expr,
-) -> crate::syntax::Expr {
+fn set_attributes_from_value(sym_name: &str, rhs_value: &Expr) -> Expr {
   // Check if symbol is locked
   let is_locked = crate::func_attrs_contains(sym_name, Attributes::Locked);
   if is_locked {
@@ -1174,11 +1169,11 @@ pub(crate) fn clear_upvalues_of(sym: &str) {
   for (outer_func, params, _conds, _defaults, _heads, body, _lhs, _rhs) in
     &up_defs
   {
-    let body_str = crate::syntax::expr_to_string(body);
+    let body_str = expr_to_string(body);
     crate::FUNC_DEFS.with(|m| {
       if let Some(entry) = m.borrow_mut().get_mut(outer_func) {
         entry.retain(|(p, _, _, _, _, b)| {
-          !(p == params && crate::syntax::expr_to_string(b) == body_str)
+          !(p == params && expr_to_string(b) == body_str)
         });
       }
     });
@@ -1369,10 +1364,7 @@ fn set_downvalues_from_rules(
 }
 
 /// Helper for Options[f] = value — set options for symbol f
-fn set_options_from_value(
-  sym_name: &str,
-  rhs_value: &Expr,
-) -> crate::syntax::Expr {
+fn set_options_from_value(sym_name: &str, rhs_value: &Expr) -> Expr {
   // Extract rules from the value
   let rules = match rhs_value {
     Expr::List(items) => items.clone(),
@@ -1481,7 +1473,7 @@ fn seed_system_variable(name: &str) {
     Expr::Association(items) => StoredValue::Association(
       items
         .iter()
-        .map(|(k, v)| (crate::syntax::expr_to_string(k), v.clone()))
+        .map(|(k, v)| (expr_to_string(k), v.clone()))
         .collect(),
     ),
     Expr::List(_) => StoredValue::ExprVal(value.clone()),
@@ -2252,7 +2244,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "Set::write: Tag {} in {} is Protected.",
         func_name,
-        crate::syntax::expr_to_string(lhs)
+        expr_to_string(lhs)
       ));
       return Ok(rhs_value);
     }
@@ -2349,7 +2341,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       if arg_exprs.len() == conditions.len() {
         let key = arg_exprs
           .iter()
-          .map(crate::syntax::expr_to_string)
+          .map(expr_to_string)
           .collect::<Vec<_>>()
           .join("\u{1}");
         crate::MEMO_VALUES.with(|m| {
@@ -2374,16 +2366,14 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         // semantics. Compare on params + conditions structurally.
         let cond_strs: Vec<Option<String>> = conditions
           .iter()
-          .map(|c| c.as_ref().map(crate::syntax::expr_to_string))
+          .map(|c| c.as_ref().map(expr_to_string))
           .collect();
         entry.retain(|(p, c, _, _, _, _)| {
           if p != &params {
             return true;
           }
-          let other_strs: Vec<Option<String>> = c
-            .iter()
-            .map(|c| c.as_ref().map(crate::syntax::expr_to_string))
-            .collect();
+          let other_strs: Vec<Option<String>> =
+            c.iter().map(|c| c.as_ref().map(expr_to_string)).collect();
           other_strs != cond_strs
         });
         let pos = entry
@@ -2511,11 +2501,8 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         // matching `DownValues` and how a Demonstration's Manipulate body
         // re-evaluates (and thus re-defines) its SubValues on every control
         // change.
-        let lhs_str = crate::syntax::expr_to_string(&evaluated_lhs);
-        match rules
-          .iter()
-          .position(|(l, _)| crate::syntax::expr_to_string(l) == lhs_str)
-        {
+        let lhs_str = expr_to_string(&evaluated_lhs);
+        match rules.iter().position(|(l, _)| expr_to_string(l) == lhs_str) {
           Some(idx) => rules[idx] = (evaluated_lhs, rhs_value.clone()),
           None => rules.push((evaluated_lhs, rhs_value.clone())),
         }
@@ -2714,7 +2701,7 @@ pub fn set_delayed_ast(
       crate::emit_message(&format!(
         "SetDelayed::write: Tag {} in {} is Protected.",
         t,
-        crate::syntax::expr_to_string(lhs)
+        expr_to_string(lhs)
       ));
       return Ok(Expr::Identifier("$Failed".to_string()));
     }
@@ -2945,7 +2932,7 @@ pub fn set_delayed_ast(
     // Messages, Format rules, …) are exempt — see
     // `is_value_redirect_head`.
     if is_downvalue_head_protected(func_name) {
-      let lhs_str = crate::syntax::expr_to_string(lhs);
+      let lhs_str = expr_to_string(lhs);
       crate::emit_message(&format!(
         "SetDelayed::write: Tag {func_name} in {lhs_str} is Protected."
       ));
@@ -3468,11 +3455,8 @@ pub fn set_delayed_ast(
         // matching `DownValues`, and how a Demonstration's Manipulate body
         // re-evaluates on every control change, redefining each SubValue
         // with an identical LHS on every one of those re-evaluations.
-        let lhs_str = crate::syntax::expr_to_string(&evaluated_lhs);
-        match rules
-          .iter()
-          .position(|(l, _)| crate::syntax::expr_to_string(l) == lhs_str)
-        {
+        let lhs_str = expr_to_string(&evaluated_lhs);
+        match rules.iter().position(|(l, _)| expr_to_string(l) == lhs_str) {
           Some(idx) => rules[idx] = (evaluated_lhs, body.clone()),
           None => rules.push((evaluated_lhs, body.clone())),
         }
@@ -4315,7 +4299,7 @@ pub fn tag_set_delayed_ast(
       } else {
         "TagSetDelayed"
       },
-      crate::syntax::expr_to_string(lhs)
+      expr_to_string(lhs)
     ));
     return Ok(if evaluate_rhs {
       body
@@ -4616,13 +4600,13 @@ pub fn tag_set_delayed_ast(
   // Store in UPVALUES for introspection and cleanup.
   // If an upvalue with the same original LHS already exists, replace it.
   // Use original_lhs (with Condition wrapper) for display purposes.
-  let lhs_str = crate::syntax::expr_to_string(original_lhs);
+  let lhs_str = expr_to_string(original_lhs);
   crate::UPVALUES.with(|m| {
     let mut defs = m.borrow_mut();
     let entry = defs.entry(tag_name).or_insert_with(Vec::new);
     if let Some(pos) =
       entry.iter().position(|(_, _, _, _, _, _, orig_lhs, _)| {
-        crate::syntax::expr_to_string(orig_lhs) == lhs_str
+        expr_to_string(orig_lhs) == lhs_str
       })
     {
       entry[pos] = (
@@ -4656,10 +4640,7 @@ pub fn tag_set_delayed_ast(
   let blank_types = vec![1u8; params.len()];
   let cond_strs: Vec<String> = conditions
     .iter()
-    .map(|c| {
-      c.as_ref()
-        .map_or(String::new(), crate::syntax::expr_to_string)
-    })
+    .map(|c| c.as_ref().map_or(String::new(), expr_to_string))
     .collect();
   crate::FUNC_DEFS.with(|m| {
     let mut defs = m.borrow_mut();
@@ -4669,11 +4650,7 @@ pub fn tag_set_delayed_ast(
         // Only remove if conditions also match
         let existing_cond_strs: Vec<String> = c
           .iter()
-          .map(|cond| {
-            cond
-              .as_ref()
-              .map_or(String::new(), crate::syntax::expr_to_string)
-          })
+          .map(|cond| cond.as_ref().map_or(String::new(), expr_to_string))
           .collect();
         existing_cond_strs != cond_strs
       } else {
@@ -4725,7 +4702,7 @@ pub fn tag_unset_ast(tag: &Expr, lhs: &Expr) -> Result<Expr, InterpreterError> {
     _ => return Ok(Expr::Identifier("Null".to_string())),
   };
 
-  let lhs_str = crate::syntax::expr_to_string(lhs);
+  let lhs_str = expr_to_string(lhs);
 
   // Remove matching entries from UPVALUES
   let removed = crate::UPVALUES.with(|m| {
@@ -4743,10 +4720,9 @@ pub fn tag_unset_ast(tag: &Expr, lhs: &Expr) -> Result<Expr, InterpreterError> {
           orig_lhs,
           _orig_body,
         )| {
-          let orig_lhs_str = crate::syntax::expr_to_string(orig_lhs);
+          let orig_lhs_str = expr_to_string(orig_lhs);
           if orig_lhs_str == lhs_str {
-            removed_entries
-              .push((rule_params.clone(), crate::syntax::expr_to_string(body)));
+            removed_entries.push((rule_params.clone(), expr_to_string(body)));
             false
           } else {
             true
@@ -4766,7 +4742,7 @@ pub fn tag_unset_ast(tag: &Expr, lhs: &Expr) -> Result<Expr, InterpreterError> {
       if let Some(entry) = m.borrow_mut().get_mut(&outer_func) {
         for (params, body_str) in &removed {
           entry.retain(|(p, _, _, _, _, b)| {
-            !(p == params && crate::syntax::expr_to_string(b) == *body_str)
+            !(p == params && expr_to_string(b) == *body_str)
           });
         }
       }
@@ -4819,8 +4795,8 @@ pub fn upset_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
     // aborting with an InterpreterError.
     crate::emit_message(&format!(
       "UpSet::normal: Nonatomic expression expected at position 1 in {} ^= {}.",
-      crate::syntax::expr_to_string(lhs),
-      crate::syntax::expr_to_string(rhs)
+      expr_to_string(lhs),
+      expr_to_string(rhs)
     ));
     return Ok(call("UpSet", vec![lhs.clone(), rhs.clone()]));
   };
@@ -4899,7 +4875,7 @@ pub fn upset_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
   if tags.is_empty() {
     return Err(InterpreterError::EvaluationError(format!(
       "UpSet::nosym: {} does not contain a symbol to attach a rule to.",
-      crate::syntax::expr_to_string(lhs)
+      expr_to_string(lhs)
     )));
   }
 
@@ -4924,8 +4900,8 @@ pub fn upset_delayed_ast(
     _ => {
       return Err(InterpreterError::EvaluationError(format!(
         "UpSetDelayed::normal: Nonatomic expression expected at position 1 in {} ^:= {}",
-        crate::syntax::expr_to_string(lhs),
-        crate::syntax::expr_to_string(rhs)
+        expr_to_string(lhs),
+        expr_to_string(rhs)
       )));
     }
   };
@@ -4950,7 +4926,7 @@ pub fn upset_delayed_ast(
   if tags.is_empty() {
     return Err(InterpreterError::EvaluationError(format!(
       "UpSetDelayed::nosym: {} does not contain a symbol to attach a rule to.",
-      crate::syntax::expr_to_string(lhs)
+      expr_to_string(lhs)
     )));
   }
 

--- a/src/evaluator/binary_ops.rs
+++ b/src/evaluator/binary_ops.rs
@@ -213,7 +213,7 @@ pub fn thread_binary_op(
         };
         crate::emit_message(&format!(
           "Thread::tdlen: Objects of unequal length in {} cannot be combined.",
-          crate::syntax::expr_to_string(&unevaluated)
+          expr_to_string(&unevaluated)
         ));
         return Ok(unevaluated);
       }

--- a/src/evaluator/contexts.rs
+++ b/src/evaluator/contexts.rs
@@ -441,7 +441,7 @@ fn message_symbols() -> Vec<String> {
         operators,
       }) = cond
         && operators.len() == 1
-        && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+        && matches!(operators[0], ComparisonOp::SameQ)
         && operands.len() == 2
         && matches!(&operands[0], Expr::Identifier(p) if params.first() == Some(p))
         && let Expr::Identifier(symbol) = &operands[1]

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -9,7 +9,7 @@ fn emit_rvalue(fname: &str, target: &Expr) {
     "{}::rvalue: {} is not a variable with a value, so its value cannot be \
      changed.",
     fname,
-    crate::syntax::expr_to_output(target)
+    expr_to_output(target)
   ));
 }
 
@@ -717,8 +717,8 @@ pub(crate) fn reject_invalid_replace_rules(head: &str, rules: &Expr) -> bool {
     return false;
   }
   let shown = match rules {
-    Expr::List(_) => crate::syntax::expr_to_output(rules),
-    _ => format!("{{{}}}", crate::syntax::expr_to_output(rules)),
+    Expr::List(_) => expr_to_output(rules),
+    _ => format!("{{{}}}", expr_to_output(rules)),
   };
   crate::emit_message(&format!(
     "{head}::reps: {shown} is neither a list of replacement rules nor a \
@@ -1202,8 +1202,8 @@ pub fn evaluate_expr_to_expr_inner(
             // to the built-in handler. `Expr` doesn't impl `PartialEq` so
             // compare via the canonical InputForm rendering.
             let original = unevaluated("SetDelayed", args);
-            let unchanged = crate::syntax::expr_to_string(&result)
-              == crate::syntax::expr_to_string(&original);
+            let unchanged =
+              expr_to_string(&result) == expr_to_string(&original);
             if !unchanged {
               return Ok(result);
             }
@@ -1268,7 +1268,7 @@ pub fn evaluate_expr_to_expr_inner(
             ENV.with(|e| {
               e.borrow_mut().insert(
                 var_name.clone(),
-                StoredValue::Raw(crate::syntax::expr_to_string(&new_val)),
+                StoredValue::Raw(expr_to_string(&new_val)),
               );
             });
             // Post-increment/decrement returns old value; pre returns new value
@@ -1302,7 +1302,7 @@ pub fn evaluate_expr_to_expr_inner(
           crate::emit_message(&format!(
             "{}::rvalue: {} is not a variable with a value, so its value cannot be changed.",
             name,
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Ok(Expr::FunctionCall {
             name: name.clone(),
@@ -1405,7 +1405,7 @@ pub fn evaluate_expr_to_expr_inner(
               m.borrow().get(head).is_some_and(|defs| !defs.is_empty())
             });
             if !had_any {
-              let lhs_str = crate::syntax::expr_to_string(&args[0]);
+              let lhs_str = expr_to_string(&args[0]);
               crate::emit_message(&format!(
                 "Unset::norep: Assignment on {head} for {lhs_str} not found."
               ));
@@ -1416,7 +1416,7 @@ pub fn evaluate_expr_to_expr_inner(
             // outer head can have different inner patterns (e.g.
             // `MakeBoxes[F[x__], fmt_]` vs `MakeBoxes[G[x___], fmt_]`); we
             // need per-entry comparison so unsetting one keeps the other.
-            let target_lhs_str = crate::syntax::expr_to_string(&args[0]);
+            let target_lhs_str = expr_to_string(&args[0]);
             let mut removed_any = false;
             crate::FUNC_DEFS.with(|m| {
               let mut map = m.borrow_mut();
@@ -1462,8 +1462,7 @@ pub fn evaluate_expr_to_expr_inner(
                       name: head.clone(),
                       args: pattern_args.into(),
                     };
-                    let entry_lhs_str =
-                      crate::syntax::expr_to_string(&entry_lhs);
+                    let entry_lhs_str = expr_to_string(&entry_lhs);
                     entry_lhs_str != target_lhs_str
                   },
                 );
@@ -1474,7 +1473,7 @@ pub fn evaluate_expr_to_expr_inner(
               }
             });
             if !removed_any {
-              let lhs_str = crate::syntax::expr_to_string(&args[0]);
+              let lhs_str = expr_to_string(&args[0]);
               crate::emit_message(&format!(
                 "Unset::norep: Assignment on {head} for {lhs_str} not found."
               ));
@@ -1530,7 +1529,7 @@ pub fn evaluate_expr_to_expr_inner(
           }
           crate::emit_message(&format!(
             "ApplyTo::rvalue: {} is not a variable with a value, so its value cannot be changed.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Ok(Expr::FunctionCall {
             name: name.clone(),
@@ -1618,9 +1617,7 @@ pub fn evaluate_expr_to_expr_inner(
           ) {
             let target = evaluated_call_target(&args[0])?;
             let current_val = evaluate_expr_to_expr(&target)?;
-            if crate::syntax::expr_to_string(&current_val)
-              == crate::syntax::expr_to_string(&target)
-            {
+            if expr_to_string(&current_val) == expr_to_string(&target) {
               emit_rvalue(name, &args[0]);
               return Ok(Expr::FunctionCall {
                 name: name.clone(),
@@ -1684,7 +1681,7 @@ pub fn evaluate_expr_to_expr_inner(
                 "{}::normal: Nonatomic expression expected at position 1 in \
                  {}.",
                 name,
-                crate::syntax::expr_to_output(&unevaluated(name, args))
+                expr_to_output(&unevaluated(name, args))
               ));
               return Ok(unevaluated(name, args));
             }
@@ -1703,8 +1700,7 @@ pub fn evaluate_expr_to_expr_inner(
         {
           let is_append = name == "AppendTo";
           let mut current = evaluate_expr_to_expr(&args[0])?;
-          let has_value = crate::syntax::expr_to_string(&current)
-            != crate::syntax::expr_to_string(&args[0]);
+          let has_value = expr_to_string(&current) != expr_to_string(&args[0]);
           if has_value {
             let elem = evaluate_expr_to_expr(&args[1])?;
             let new_val = match &mut current {
@@ -1738,7 +1734,7 @@ pub fn evaluate_expr_to_expr_inner(
                   "{}::normal: Nonatomic expression expected at position 1 \
                    in {}.",
                   name,
-                  crate::syntax::expr_to_output(&unevaluated(name, args))
+                  expr_to_output(&unevaluated(name, args))
                 ));
                 return Ok(unevaluated(name, args));
               }
@@ -1960,7 +1956,7 @@ pub fn evaluate_expr_to_expr_inner(
           let pairs: Vec<(String, Expr)> = match &new_val {
             Expr::Association(items) => items
               .iter()
-              .map(|(k, v)| (crate::syntax::expr_to_string(k), v.clone()))
+              .map(|(k, v)| (expr_to_string(k), v.clone()))
               .collect(),
             _ => unreachable!(),
           };
@@ -2015,7 +2011,7 @@ pub fn evaluate_expr_to_expr_inner(
           let pairs: Vec<(String, Expr)> = match &new_val {
             Expr::Association(items) => items
               .iter()
-              .map(|(k, v)| (crate::syntax::expr_to_string(k), v.clone()))
+              .map(|(k, v)| (expr_to_string(k), v.clone()))
               .collect(),
             _ => unreachable!(),
           };
@@ -2304,8 +2300,7 @@ pub fn evaluate_expr_to_expr_inner(
             }
             _ => {
               let shown = evaluated.as_ref().unwrap_or(&args[0]);
-              let call_str =
-                crate::syntax::expr_to_string(&call1("Pause", shown.clone()));
+              let call_str = expr_to_string(&call1("Pause", shown.clone()));
               crate::emit_message(&format!(
                 "Pause::numnm: Non-negative machine-sized number expected at position 1 in {call_str}."
               ));
@@ -2339,10 +2334,10 @@ pub fn evaluate_expr_to_expr_inner(
               Expr::FunctionCall { name, args }
                 if name == "MessageName" && args.len() == 2 =>
               {
-                let sym = crate::syntax::expr_to_string(&args[0]);
+                let sym = expr_to_string(&args[0]);
                 let tag = match &args[1] {
                   Expr::String(s) => s.clone(),
-                  other => crate::syntax::expr_to_string(other),
+                  other => expr_to_string(other),
                 };
                 out.push(format!("{sym}::{tag}"));
               }
@@ -2698,9 +2693,7 @@ pub fn evaluate_expr_to_expr_inner(
               name: name.clone(),
               args: evaluated_args.to_vec().into(),
             };
-            if crate::syntax::expr_to_string(&dispatched)
-              != crate::syntax::expr_to_string(&untouched)
-            {
+            if expr_to_string(&dispatched) != expr_to_string(&untouched) {
               return Ok(dispatched);
             }
           }
@@ -3091,10 +3084,7 @@ pub fn evaluate_expr_to_expr_inner(
                   if real {
                     None
                   } else {
-                    Some(format!(
-                      "{} Infinity",
-                      crate::syntax::expr_to_string(&args[0])
-                    ))
+                    Some(format!("{} Infinity", expr_to_string(&args[0])))
                   }
                 }
                 _ => None,

--- a/src/evaluator/dispatch/association_functions.rs
+++ b/src/evaluator/dispatch/association_functions.rs
@@ -64,10 +64,10 @@ pub fn dispatch_association_functions(
             let keys_str = if args.is_empty() {
               String::new()
             } else {
-              crate::syntax::expr_to_string(&args[0])
+              expr_to_string(&args[0])
             };
             let vals_str = if args.len() >= 2 {
-              crate::syntax::expr_to_string(&args[1])
+              expr_to_string(&args[1])
             } else {
               String::new()
             };

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -2746,7 +2746,7 @@ fn collect_dirac_like_terms(terms: Vec<Expr>) -> Vec<Expr> {
 
     let base_key = base_parts
       .iter()
-      .map(crate::syntax::expr_to_string)
+      .map(expr_to_string)
       .collect::<Vec<_>>()
       .join("*");
 
@@ -3056,10 +3056,9 @@ fn inverse_mellin_inner(
           // The 1/n prefactor must be among the constants.
           let inv_n =
             call("Rational", vec![Expr::Integer(1), Expr::Integer(*nn)]);
-          let pos = consts.iter().position(|c| {
-            crate::syntax::expr_to_string(c)
-              == crate::syntax::expr_to_string(&inv_n)
-          })?;
+          let pos = consts
+            .iter()
+            .position(|c| expr_to_string(c) == expr_to_string(&inv_n))?;
           let mut rest = consts.clone();
           rest.remove(pos);
           let result = e_pow(neg(make_power(x.clone(), Expr::Integer(*nn))));
@@ -3177,13 +3176,12 @@ fn inverse_mellin_inner(
         };
         if neg_s_ok && !depends_on(a_part, sv) {
           // Require the 1/Gamma[a] constant.
-          let inv_gamma = crate::syntax::expr_to_string(&call(
+          let inv_gamma = expr_to_string(&call(
             "Power",
             vec![call1("Gamma", a_part.clone()), Expr::Integer(-1)],
           ));
-          let pos = consts
-            .iter()
-            .position(|c| crate::syntax::expr_to_string(c) == inv_gamma)?;
+          let pos =
+            consts.iter().position(|c| expr_to_string(c) == inv_gamma)?;
           let mut rest = consts.clone();
           rest.remove(pos);
           let result = pow2(
@@ -4880,7 +4878,7 @@ fn symbolic_series_coefficient(f: &Expr, spec: &Expr) -> Option<Expr> {
     is_int(&residual, 0).then_some(a)
   };
   // `(a)` string with parentheses so a negative `a` keeps its sign inside a power.
-  let paren = |a: &Expr| format!("({})", crate::syntax::expr_to_string(a));
+  let paren = |a: &Expr| format!("({})", expr_to_string(a));
 
   // Build and parse `Piecewise[{{coeff, cond}}, 0]`.
   let build = |coeff_src: String, cond: &str| -> Option<Expr> {
@@ -4976,7 +4974,7 @@ fn symbolic_series_coefficient(f: &Expr, spec: &Expr) -> Option<Expr> {
       if !is_int(&residual, 0) {
         return None;
       }
-      let p_str = crate::syntax::expr_to_string(exp);
+      let p_str = expr_to_string(exp);
       let cond = match exp.as_ref() {
         Expr::Integer(p) => {
           format!("Inequality[0, LessEqual, {nvar}, LessEqual, {p}]")
@@ -5136,7 +5134,7 @@ fn gf_inner(
     && fargs.len() == 1
     && matches!(&fargs[0], Expr::Identifier(v) if v == n)
   {
-    let xs = crate::syntax::expr_to_string(x);
+    let xs = expr_to_string(x);
     let src = match fname.as_str() {
       "Fibonacci" => Some(format!("-({xs}/(-1 + {xs} + {xs}^2))")),
       "LucasL" => Some(format!("(-2 + {xs})/(-1 + {xs} + {xs}^2)")),
@@ -5295,7 +5293,7 @@ fn gf_power(
   exp: &Expr,
   n: &str,
   x: &Expr,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   // Case: a^n where a doesn't depend on n => 1/(1 - a*x)
   if matches!(exp, Expr::Identifier(name) if name == n) && !depends_on(base, n)
   {
@@ -5352,7 +5350,7 @@ fn gf_power(
 /// Generating function for n^k: Sum[n^k * x^n, {n, 0, inf}]
 /// Uses the formula involving Eulerian numbers: result = Sum[A(k,j) * x^(j+1), j=0..k-1] / (1-x)^(k+1)
 /// where A(k,j) are the Eulerian numbers.
-fn gf_n_power_k(k: i128, x: &Expr) -> crate::syntax::Expr {
+fn gf_n_power_k(k: i128, x: &Expr) -> Expr {
   // Compute Eulerian numbers A(k, j) for j = 0..k-1
   let k_usize = k as usize;
   let eulerian = compute_eulerian_numbers(k_usize);
@@ -5525,9 +5523,7 @@ fn gf_times(
   // Try expanding the product and handling as a sum
   // e.g. n*(-1+n) → -n + n^2
   let expanded = crate::functions::polynomial_ast::expand_expr(&recombined);
-  if crate::syntax::expr_to_string(&expanded)
-    != crate::syntax::expr_to_string(&recombined)
-  {
+  if expr_to_string(&expanded) != expr_to_string(&recombined) {
     return gf_inner(&expanded, n, x);
   }
 
@@ -5559,7 +5555,7 @@ fn gf_binomial(
   bottom: &Expr,
   n: &str,
   x: &Expr,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   // Binomial[n, k] where k is constant: x^k/(-1+x)^(k+1) (with sign adjustment)
   // Canonical Wolfram form uses (-1+x) as base.
   // (1-x)^(k+1) = (-1)^(k+1) * (-1+x)^(k+1), so negate numerator when (k+1) is odd.
@@ -5643,7 +5639,7 @@ fn gf_divide(
       if let Some(k) =
         n_and_k(fargs[0], fargs[1]).or_else(|| n_and_k(fargs[1], fargs[0]))
       {
-        let xs = crate::syntax::expr_to_string(x);
+        let xs = expr_to_string(x);
         let km1 = k - 1;
         let src = format!(
           "(-Log[1 - {xs}]/{xs} - Sum[{xs}^(m - 1)/m, {{m, 1, {km1}}}])/{xs}^{km1}"
@@ -5686,10 +5682,8 @@ fn gf_divide(
     // and leave the generating function unevaluated instead.
     let (pnum, pden) =
       crate::functions::polynomial_ast::together::extract_num_den(&product);
-    if crate::syntax::expr_to_string(&pnum)
-      == crate::syntax::expr_to_string(num)
-      && crate::syntax::expr_to_string(&pden)
-        == crate::syntax::expr_to_string(den)
+    if expr_to_string(&pnum) == expr_to_string(num)
+      && expr_to_string(&pden) == expr_to_string(den)
     {
       return Ok(None);
     }
@@ -6040,7 +6034,7 @@ fn egf_power(
   exp: &Expr,
   n: &str,
   x: &Expr,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   // Case: c^n where c doesn't depend on n => e^(c*x)
   if !depends_on(base, n) && matches!(exp, Expr::Identifier(name) if name == n)
   {

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -376,7 +376,7 @@ pub fn dispatch_complex_and_special(
     }
     "Echo" if !args.is_empty() && args.len() <= 3 => {
       let label = if args.len() >= 2 {
-        crate::syntax::expr_to_output(&args[1])
+        expr_to_output(&args[1])
       } else {
         ">> ".to_string()
       };
@@ -392,9 +392,9 @@ pub fn dispatch_complex_and_special(
           Ok(v) => v,
           Err(e) => return Some(Err(e)),
         };
-        crate::syntax::expr_to_output(&result)
+        expr_to_output(&result)
       } else {
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       };
       let line = if args.len() >= 2 {
         format!(">> {label} {display_expr}")
@@ -1943,7 +1943,7 @@ pub fn dispatch_complex_and_special(
         .iter()
         .map(|a| match a {
           Expr::String(s) => s.clone(),
-          _ => crate::syntax::expr_to_string(a),
+          _ => expr_to_string(a),
         })
         .collect::<String>();
       return Some(Ok(Expr::Raw(rendered)));
@@ -1968,8 +1968,8 @@ pub fn dispatch_complex_and_special(
         // First try the position-less form.
         let one_arg_call = call1("Default", args[0].clone());
         if let Ok(result) = evaluate_expr_to_expr(&one_arg_call) {
-          let original = crate::syntax::expr_to_string(&one_arg_call);
-          let after = crate::syntax::expr_to_string(&result);
+          let original = expr_to_string(&one_arg_call);
+          let after = expr_to_string(&result);
           if after != original {
             return Some(Ok(result));
           }
@@ -2039,7 +2039,7 @@ fn tag_matches_pattern(tag: &Expr, patt: &Expr) -> bool {
   if crate::evaluator::pattern_matching::contains_pattern(patt) {
     crate::evaluator::pattern_matching::match_pattern(tag, patt).is_some()
   } else {
-    crate::syntax::expr_to_string(tag) == crate::syntax::expr_to_string(patt)
+    expr_to_string(tag) == expr_to_string(patt)
   }
 }
 
@@ -2854,7 +2854,7 @@ fn expr_to_full_box_form(expr: &Expr) -> Expr {
       "Times".to_string(),
       vec![Expr::Integer(-1), *operand.clone()],
     ),
-    _ => return Expr::String(crate::syntax::expr_to_string(expr)),
+    _ => return Expr::String(expr_to_string(expr)),
   };
   let mut parts: Vec<Expr> =
     vec![Expr::String(head), Expr::String("[".to_string())];
@@ -4152,7 +4152,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
       // formatted shape (e.g. `Format[F[x_, y_], InputForm] := {…}`
       // turns `InputForm[F[1., "l"]]` into `{"In", GG[…]}` text).
       let formatted_inner = apply_format_recursively(&args[0], "InputForm");
-      let inner_str = crate::syntax::expr_to_string(&formatted_inner);
+      let inner_str = expr_to_string(&formatted_inner);
       Expr::FunctionCall {
         name: "InterpretationBox".to_string(),
         args: vec![
@@ -5638,7 +5638,7 @@ fn join_with_dot(parts: Vec<Expr>) -> Expr {
 
 /// Convert an expression to a string box (for expressions we don't have explicit box forms for)
 fn box_as_output_string(expr: &Expr) -> Expr {
-  let s = crate::syntax::expr_to_output(expr);
+  let s = expr_to_output(expr);
   // If it's a simple identifier-like string, return as Identifier
   if s
     .chars()
@@ -6366,7 +6366,7 @@ fn disjoint_shapes_intersect(a: &DisjointShape, b: &DisjointShape) -> bool {
 /// RegionDisjoint[reg1, reg2, …] — True when the regions are pairwise
 /// disjoint. Zero regions are vacuously disjoint; a single supported
 /// region is too. Unsupported arguments leave the call unevaluated.
-fn compute_region_disjoint(args: &[Expr]) -> crate::syntax::Expr {
+fn compute_region_disjoint(args: &[Expr]) -> Expr {
   let shapes: Option<Vec<DisjointShape>> = args
     .iter()
     .map(|a| disjoint_shape(strip_region_wrapper(a)))
@@ -7891,7 +7891,7 @@ fn compute_region_dimension(expr: &Expr) -> Result<Expr, InterpreterError> {
 /// RegionEmbeddingDimension[region] — the dimension of the ambient space the
 /// region lives in, i.e. the number of coordinates. This equals the number of
 /// `{min, max}` pairs in the region's bounding box.
-fn compute_region_embedding_dimension(expr: &Expr) -> crate::syntax::Expr {
+fn compute_region_embedding_dimension(expr: &Expr) -> Expr {
   if let Expr::FunctionCall { name, args } = expr {
     match name.as_str() {
       "StadiumShape" if stadium_parts(args).is_some() => {
@@ -7938,7 +7938,7 @@ fn compute_region_embedding_dimension(expr: &Expr) -> crate::syntax::Expr {
 
 /// Compute the axis-aligned bounding box of a geometric region as a list of
 /// `{min, max}` pairs, one per dimension.
-fn compute_region_bounds(expr: &Expr) -> crate::syntax::Expr {
+fn compute_region_bounds(expr: &Expr) -> Expr {
   let unevaluated = || call("RegionBounds", vec![expr.clone()]);
   // HalfLine[{p1, p2}] — half-line from p1 toward p2. Each dimension's
   // bounds depend on the sign of (p2 - p1)[d]:
@@ -12515,13 +12515,13 @@ fn normalize_region(expr: &Expr) -> Option<Expr> {
 /// Normalize polygon vertices to a canonical sorted form for comparison.
 /// We sort vertices lexicographically by their string representation to get
 /// a rotation/order-independent comparison.
-fn normalize_polygon_vertices(mut vertices: Vec<Expr>) -> crate::syntax::Expr {
+fn normalize_polygon_vertices(mut vertices: Vec<Expr>) -> Expr {
   vertices.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
   call1("Polygon", Expr::List(vertices.into()))
 }
 
 /// Compute RegionEqual[r1, r2, ...].
-fn compute_region_equal(args: &[Expr]) -> crate::syntax::Expr {
+fn compute_region_equal(args: &[Expr]) -> Expr {
   // RegionEqual[] and RegionEqual[r] → True
   if args.len() <= 1 {
     return bool_expr(true);
@@ -13151,7 +13151,7 @@ fn compute_circumscribed_ball(expr: &Expr) -> Result<Expr, InterpreterError> {
     if !is_region_head(expr) {
       crate::emit_message(&format!(
         "CircumscribedBall::spec: {} is not a valid CircumscribedBall specification.",
-        crate::syntax::expr_to_string(expr)
+        expr_to_string(expr)
       ));
     }
     return uneval();
@@ -13190,7 +13190,7 @@ fn compute_bounding_region(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Some(coords) = region_point_list(&args[0], true) else {
     crate::emit_message(&format!(
       "BoundingRegion::regl: The argument {} should be a region or a list of points.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return uneval();
   };
@@ -13204,7 +13204,7 @@ fn compute_bounding_region(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let bad_spec = || {
     let shown = match &args[1] {
       Expr::String(s) => s.clone(),
-      other => crate::syntax::expr_to_string(other),
+      other => expr_to_string(other),
     };
     crate::emit_message(&format!(
       "BoundingRegion::spec: {shown} is not a valid type specification for bounding regions."
@@ -13853,7 +13853,7 @@ fn compute_insphere(expr: &Expr) -> Result<Expr, InterpreterError> {
         };
         crate::emit_message(&format!(
           "Insphere::indep: Insphere does not exist for {}.",
-          crate::syntax::expr_to_string(&normalized)
+          expr_to_string(&normalized)
         ));
         Ok(call1("Insphere", normalized))
       }
@@ -15009,7 +15009,7 @@ fn region_product_pair(a: &Expr, b: &Expr) -> Option<Expr> {
 /// `RegionProduct[reg1, reg2, …]` — the Cartesian product of its arguments,
 /// taken two at a time from the left. A product Wolfram does not name is left
 /// standing over whatever has been combined so far.
-fn compute_region_product(args: &[Expr]) -> crate::syntax::Expr {
+fn compute_region_product(args: &[Expr]) -> Expr {
   if args.is_empty() {
     crate::emit_message(
       "RegionProduct::argm: RegionProduct called with 0 arguments; \

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -180,7 +180,7 @@ pub fn dispatch_datetime_functions(
         } else {
           crate::emit_message(&format!(
             "TimeZoneOffset::zone: Time zone specification {} should be a real number, integer or time zone string.",
-            crate::syntax::expr_to_output(zone)
+            expr_to_output(zone)
           ));
           return unevaluated();
         }
@@ -234,7 +234,7 @@ pub fn dispatch_datetime_functions(
       }
       crate::emit_message(&format!(
         "DateInterval::arg: Argument {} cannot be interpreted as a date or time input.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Some(Ok(unevaluated("DateInterval", args)));
     }
@@ -420,8 +420,8 @@ pub fn dispatch_datetime_functions(
         && let Expr::List(items) = &args[0]
         && let Some(normalized) =
           crate::functions::datetime_ast::normalize_date_components(items)
-        && crate::syntax::expr_to_string(&Expr::List(normalized.clone().into()))
-          != crate::syntax::expr_to_string(&args[0])
+        && expr_to_string(&Expr::List(normalized.clone().into()))
+          != expr_to_string(&args[0])
       {
         let mut new_args = vec![Expr::List(normalized.into())];
         new_args.extend(args[1..].iter().cloned());

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -174,9 +174,7 @@ fn resolve_param_default(default: &Expr) -> Option<Expr> {
     return Some(default.clone());
   }
   let evaluated = crate::evaluator::evaluate_expr_to_expr(default).ok()?;
-  if crate::syntax::expr_to_string(&evaluated)
-    == crate::syntax::expr_to_string(default)
-  {
+  if expr_to_string(&evaluated) == expr_to_string(default) {
     return None;
   }
   Some(evaluated)
@@ -998,7 +996,7 @@ fn evaluate_function_call_ast_inner(
     }
     let key = args
       .iter()
-      .map(crate::syntax::expr_to_string)
+      .map(expr_to_string)
       .collect::<Vec<_>>()
       .join("\u{1}");
     cache.get(&key).map(|(_, v)| v.clone())
@@ -1612,7 +1610,7 @@ fn evaluate_function_call_ast_inner(
               if !is_identifier_like(name))
             {
               cond_ok = matches!(
-                crate::interpret(&crate::syntax::expr_to_string(
+                crate::interpret(&expr_to_string(
                   &substituted_cond
                 )),
                 Ok(ref s) if s == "True"
@@ -2999,7 +2997,7 @@ fn evaluate_function_call_ast_inner(
         if !is_perm {
           crate::emit_message(&format!(
             "PermutationList::permlist: Invalid permutation list {}.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Ok(unevaluated(name, args));
         }
@@ -3015,7 +3013,7 @@ fn evaluate_function_call_ast_inner(
                 "PermutationList::lowlen: Required length {} is smaller than maximum {} of support of {}.",
                 n,
                 support_max,
-                crate::syntax::expr_to_string(&args[0])
+                expr_to_string(&args[0])
               ));
               return Ok(unevaluated(name, args));
             }
@@ -3600,16 +3598,15 @@ fn evaluate_function_call_ast_inner(
       if !is_opt {
         crate::emit_message(&format!(
           "HararyGraph::nonopt: Options expected (instead of {}) beyond position 2 in {}. An option must be a rule or a list of rules.",
-          crate::syntax::expr_to_string(extra),
-          crate::syntax::expr_to_string(&unevaluated("HararyGraph", args))
+          expr_to_string(extra),
+          expr_to_string(&unevaluated("HararyGraph", args))
         ));
         return Ok(unevaluated("HararyGraph", args));
       }
     }
     // Positive machine-sized integers required (intpm); reals, zero, and
     // negative integers warn, symbolic arguments stay silent.
-    let call_str =
-      || crate::syntax::expr_to_string(&unevaluated("HararyGraph", args));
+    let call_str = || expr_to_string(&unevaluated("HararyGraph", args));
     let classify = |e: &Expr| -> Option<Option<i128>> {
       // Some(Some(v)): positive integer; Some(None): invalid numeric
       // (emit intpm); None: symbolic (stay unevaluated silently)
@@ -4470,8 +4467,7 @@ fn evaluate_function_call_ast_inner(
     } = &mix_args[1]
     && param_dist_name == "BetaDistribution"
     && param_dist_args.len() == 2
-    && crate::syntax::expr_to_string(&mix_args[0])
-      == crate::syntax::expr_to_string(&dist_args[1])
+    && expr_to_string(&mix_args[0]) == expr_to_string(&dist_args[1])
   {
     return Ok(Expr::FunctionCall {
       name: "BetaBinomialDistribution".to_string(),
@@ -9616,7 +9612,7 @@ fn evaluate_function_call_ast_inner(
     // Non-string / non-list-of-strings argument: emit the
     // wolframscript-style type-error message and leave the call
     // unevaluated.
-    let arg_str = crate::syntax::expr_to_string(&args[0]);
+    let arg_str = expr_to_string(&args[0]);
     crate::emit_message(&format!(
       "DeleteFile::strs: A string or nonempty list of strings is expected at position 1 in DeleteFile[{arg_str}]."
     ));
@@ -9687,7 +9683,7 @@ fn evaluate_function_call_ast_inner(
     let path = if let Expr::String(s) = &args[0] {
       s.clone()
     } else {
-      let arg_str = crate::syntax::expr_to_string(&args[0]);
+      let arg_str = expr_to_string(&args[0]);
       crate::emit_message(&format!(
         "DeleteDirectory::strs: A string or nonempty list of strings is expected at position 1 in DeleteDirectory[{arg_str}]."
       ));
@@ -10993,7 +10989,7 @@ fn evaluate_function_call_ast_inner(
       crate::emit_message(&format!(
         "{}::arg1: The first argument {} should be a rectangular array, image or video.",
         name,
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Ok(unevaluated(name, args));
     }
@@ -11151,8 +11147,8 @@ fn evaluate_function_call_ast_inner(
       let unevaluated_call = unevaluated("Play", args);
       crate::emit_message(&format!(
         "Play::nonopt: Options expected (instead of {}) beyond position 2 in {}. An option must be a rule or a list of rules.",
-        crate::syntax::expr_to_string(bad),
-        crate::syntax::expr_to_string(&unevaluated_call)
+        expr_to_string(bad),
+        expr_to_string(&unevaluated_call)
       ));
       return Ok(unevaluated_call);
     }
@@ -12091,8 +12087,8 @@ fn evaluate_blend(args: &[Expr]) -> Option<Expr> {
       let colors_expr = Expr::List(colors.clone());
       crate::emit_message(&format!(
         "Blend::argl: {} should be a real number or a list of non-negative numbers, which has the same length as {}.",
-        crate::syntax::expr_to_string(&args[1]),
-        crate::syntax::expr_to_string(&colors_expr),
+        expr_to_string(&args[1]),
+        expr_to_string(&colors_expr),
       ));
       return None;
     }
@@ -12375,7 +12371,7 @@ fn blend_two_rational(
   t_num: i128,
   t_den: i128,
   as_graylevel: bool,
-) -> crate::syntax::Expr {
+) -> Expr {
   // (1-t) = (t_den - t_num) / t_den
   let one_minus_t_num = t_den - t_num;
 
@@ -12401,7 +12397,7 @@ fn blend_two_rational(
 
 /// FunctionInterpolation[expr, {x, xmin, xmax}] — sample a function and build
 /// an InterpolatingFunction with cubic spline interpolation.
-fn function_interpolation_ast(args: &[Expr]) -> crate::syntax::Expr {
+fn function_interpolation_ast(args: &[Expr]) -> Expr {
   if let Expr::List(spec) = &args[1]
     && spec.len() == 3
     && let Expr::Identifier(var_name) = &spec[0]
@@ -12934,7 +12930,7 @@ fn find_maximum_flow_impl(
   source: &Expr,
   sink: &Expr,
   args: &[Expr],
-) -> crate::syntax::Expr {
+) -> Expr {
   let vertex_idx = |v: &Expr| -> Option<usize> {
     verts
       .iter()
@@ -13138,10 +13134,7 @@ fn find_graph_isomorphism_impl(
 }
 
 /// FindSpanningTree using petgraph's min_spanning_tree (unit weights)
-fn find_spanning_tree_impl(
-  verts: &[Expr],
-  edges: &[Expr],
-) -> crate::syntax::Expr {
+fn find_spanning_tree_impl(verts: &[Expr], edges: &[Expr]) -> Expr {
   if verts.is_empty() {
     return call(
       "Graph",

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -24,7 +24,7 @@ pub(crate) fn history_line_index(
     [_] => {
       crate::emit_message(&format!(
         "{name}::intm: Machine-sized integer expected at position 1 in {}.",
-        crate::syntax::expr_to_output(&unevaluated(name, args))
+        expr_to_output(&unevaluated(name, args))
       ));
       return None;
     }
@@ -686,7 +686,7 @@ pub fn dispatch_evaluation_control(
         _ => {
           crate::emit_message(&format!(
             "ByteArray::lend: The argument at position 1 in ByteArray[{}] should be a vector of unsigned byte values or a Base64-encoded string.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Some(Ok(unevaluated("ByteArray", args)));
         }
@@ -887,8 +887,8 @@ pub fn dispatch_evaluation_control(
         Err(e) => return Some(Err(e)),
       };
       // Compare via printed form since Expr doesn't implement PartialEq.
-      let orig_str = crate::syntax::expr_to_string(&original);
-      let eval_str = crate::syntax::expr_to_string(&evaluated);
+      let orig_str = expr_to_string(&original);
+      let eval_str = expr_to_string(&evaluated);
       if orig_str == eval_str {
         return Some(Ok(Expr::List(vec![].into())));
       }

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -178,7 +178,7 @@ fn gradient_strip_image(controls: &[(f64, f64, f64)]) -> Expr {
           option(
             "AspectRatio",
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(Expr::Integer(1)),
               right: Box::new(Expr::Integer(8)),
             },
@@ -385,7 +385,7 @@ fn import_json(
 /// `$Failed` after the magic-byte check passes — but without the error
 /// message, mirroring wolframscript's silent success on a valid file.
 #[cfg(not(target_arch = "wasm32"))]
-fn import_netpbm(path: &str) -> crate::syntax::Expr {
+fn import_netpbm(path: &str) -> Expr {
   if !crate::vfs::exists(path) {
     // wolframscript prints Import::nffil to stdout for a missing file.
     crate::emit_message_to_stdout(&format!(
@@ -1661,7 +1661,7 @@ pub fn dispatch_image_functions(
         // string — match that message format.
         crate::emit_message(&format!(
           "ImportString::string: First argument {} is not a string.",
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Some(Ok(unevaluated("ImportString", args)));
       };

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -411,7 +411,7 @@ fn write_string_to_channel(
   for arg in &args[1..] {
     match arg {
       Expr::String(s) => text.push_str(s),
-      other => text.push_str(&crate::syntax::expr_to_string(other)),
+      other => text.push_str(&expr_to_string(other)),
     }
   }
   text.push_str(terminator);
@@ -818,12 +818,12 @@ pub fn dispatch_io_functions(
       {
         let sym_name = match &mn_args[0] {
           Expr::Identifier(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         let tag = match &mn_args[1] {
           Expr::String(s) => s.clone(),
           Expr::Identifier(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         // Evaluate MessageName[sym, tag]. If it resolves to a String, use it
         // as the text; otherwise treat the text as unset.
@@ -969,7 +969,7 @@ pub fn dispatch_io_functions(
           _ => {
             eprintln!(
               "SetEnvironment::setraw: {} must be a string or None.",
-              crate::syntax::expr_to_string(val)
+              expr_to_string(val)
             );
             Some(false)
           }
@@ -1054,7 +1054,7 @@ pub fn dispatch_io_functions(
         Some(other) => {
           crate::emit_message(&format!(
             "ReadString::iterm: Invalid terminator value {}.",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           return Some(Ok(unevaluated("ReadString", args)));
         }
@@ -1321,7 +1321,7 @@ pub fn dispatch_io_functions(
       let exprs = &args[..args.len() - 1];
       let content = exprs
         .iter()
-        .map(crate::syntax::expr_to_string)
+        .map(expr_to_string)
         .collect::<Vec<_>>()
         .join("\n");
       let to_write = if exprs.is_empty() {
@@ -1357,7 +1357,7 @@ pub fn dispatch_io_functions(
       let exprs = &args[..args.len() - 1];
       let content = exprs
         .iter()
-        .map(crate::syntax::expr_to_string)
+        .map(expr_to_string)
         .collect::<Vec<_>>()
         .join("\n");
       if !exprs.is_empty() {
@@ -1400,7 +1400,7 @@ pub fn dispatch_io_functions(
         other => {
           return Some(Err(InterpreterError::EvaluationError(format!(
             "Export: first argument must be a filename string, got {}",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ))));
         }
       };
@@ -1664,7 +1664,7 @@ pub fn dispatch_io_functions(
           }
         }
         Expr::String(s) => s.clone(),
-        other => crate::syntax::expr_to_string(other),
+        other => expr_to_string(other),
       };
       if let Err(e) = std::fs::write(crate::vfs::resolve(&filename), &content)
         .map_err(|e| InterpreterError::EvaluationError(format!("Export: {e}")))
@@ -1685,7 +1685,7 @@ pub fn dispatch_io_functions(
         other => {
           return Some(Err(InterpreterError::EvaluationError(format!(
             "Export: first argument must be a filename string, got {}",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ))));
         }
       };
@@ -2016,7 +2016,7 @@ pub fn dispatch_io_functions(
           }
         }
         _ => {
-          let arg_str = crate::syntax::expr_to_string(&args[0]);
+          let arg_str = expr_to_string(&args[0]);
           crate::emit_message(&format!(
             "Find::stream: {arg_str} is not a string, SocketObject, InputStream[ ] or OutputStream[ ]."
           ));
@@ -2051,8 +2051,7 @@ pub fn dispatch_io_functions(
       // $Failed with the matching wolframscript message; a failed file in
       // a file LIST contributes a $Failed element instead.
       let failed = || Some(Ok(Expr::Identifier("$Failed".to_string())));
-      let call_display =
-        || crate::syntax::expr_to_output(&unevaluated("FindList", args));
+      let call_display = || expr_to_output(&unevaluated("FindList", args));
       if args.len() < 2 {
         let (tag, noun) = if args.len() == 1 {
           ("argtu", "1 argument")
@@ -2073,7 +2072,7 @@ pub fn dispatch_io_functions(
           if !is_opt {
             crate::emit_message(&format!(
               "FindList::nonopt: Options expected (instead of {}) beyond position 3 in {}. An option must be a rule or a list of rules.",
-              crate::syntax::expr_to_string(extra),
+              expr_to_string(extra),
               call_display()
             ));
             return failed();
@@ -2119,7 +2118,7 @@ pub fn dispatch_io_functions(
         other => {
           crate::emit_message(&format!(
             "FindList::stream: {} is not a string, SocketObject, InputStream[ ] or OutputStream[ ].",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           return failed();
         }
@@ -2133,7 +2132,7 @@ pub fn dispatch_io_functions(
         let Expr::String(path) = f else {
           crate::emit_message(&format!(
             "FindList::stream: {} is not a string, SocketObject, InputStream[ ] or OutputStream[ ].",
-            crate::syntax::expr_to_string(f)
+            expr_to_string(f)
           ));
           if !is_list {
             return failed();
@@ -2430,7 +2429,7 @@ pub fn dispatch_io_functions(
           for item in items {
             match item {
               Expr::String(s) => strs.push(s.clone()),
-              other => strs.push(crate::syntax::expr_to_string(other)),
+              other => strs.push(expr_to_string(other)),
             }
           }
           strs
@@ -2473,11 +2472,11 @@ pub fn dispatch_io_functions(
                 } => {
                   let key = match pattern.as_ref() {
                     Expr::String(s) => s.clone(),
-                    other => crate::syntax::expr_to_string(other),
+                    other => expr_to_string(other),
                   };
                   let val = match replacement.as_ref() {
                     Expr::String(s) => s.clone(),
-                    other => crate::syntax::expr_to_string(other),
+                    other => expr_to_string(other),
                   };
                   pairs.push((key, val));
                 }
@@ -2887,7 +2886,7 @@ pub fn dispatch_io_functions(
         other => {
           return Some(Err(InterpreterError::EvaluationError(format!(
             "StringToStream: argument must be a string, got {}",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ))));
         }
       };
@@ -2945,7 +2944,7 @@ pub fn dispatch_io_functions(
               return Some(Ok(Expr::String(name)));
             }
             None => {
-              let stream_str = crate::syntax::expr_to_string(&args[0]);
+              let stream_str = expr_to_string(&args[0]);
               crate::emit_message(&format!("{stream_str} is not open."));
               return Some(Ok(unevaluated("Close", args)));
             }
@@ -2957,7 +2956,7 @@ pub fn dispatch_io_functions(
         }
         _ => {
           // Anything else is a type error — match wolframscript's message.
-          let arg_str = crate::syntax::expr_to_string(&args[0]);
+          let arg_str = expr_to_string(&args[0]);
           crate::emit_message_to_stdout(&format!(
             "Close::stream: {arg_str} is not a string, SocketObject, InputStream[ ] or OutputStream[ ]."
           ));
@@ -2980,7 +2979,7 @@ pub fn dispatch_io_functions(
             if let Some(pos) = get_stream_position(*id as usize) {
               return Some(Ok(Expr::Integer(pos as i128)));
             }
-            let stream_str = crate::syntax::expr_to_string(stream);
+            let stream_str = expr_to_string(stream);
             crate::emit_message(&format!(
               "StreamPosition::openx: {stream_str} is not open."
             ));
@@ -3031,7 +3030,7 @@ pub fn dispatch_io_functions(
                   if p > stream_len {
                     // wolframscript emits SetStreamPosition::stmrng
                     // and clamps the position to the end of stream.
-                    let stream_str = crate::syntax::expr_to_string(stream);
+                    let stream_str = expr_to_string(stream);
                     crate::emit_message(&format!(
                       "SetStreamPosition::stmrng: Cannot set the current point in {stream_str} to position {p}; the requested position exceeds the length of the stream."
                     ));
@@ -3045,7 +3044,7 @@ pub fn dispatch_io_functions(
               set_stream_position(id_usize, pos);
               return Some(Ok(Expr::Integer(pos as i128)));
             }
-            let stream_str = crate::syntax::expr_to_string(stream);
+            let stream_str = expr_to_string(stream);
             crate::emit_message(&format!(
               "SetStreamPosition::openx: {stream_str} is not open."
             ));
@@ -3240,7 +3239,7 @@ pub fn dispatch_io_functions(
       };
       let mut content = String::new();
       for arg in &args[1..] {
-        content.push_str(&crate::syntax::expr_to_string(arg));
+        content.push_str(&expr_to_string(arg));
       }
       content.push('\n');
       if let Err(e) = write_targets_bytes(&targets, content.as_bytes(), "Write")
@@ -3323,14 +3322,14 @@ pub fn dispatch_io_functions(
             {
               let params_str = pattern_args
                 .iter()
-                .map(crate::syntax::expr_to_string)
+                .map(expr_to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
               sym_lines.push(format!(
                 "{}[{}] := {}",
                 sym,
                 params_str,
-                crate::syntax::expr_to_string(&display_body)
+                expr_to_string(&display_body)
               ));
               continue;
             }
@@ -3351,7 +3350,7 @@ pub fn dispatch_io_functions(
                   && operands.len() == 2
                 {
                   // Literal value dispatch: use the value directly
-                  return crate::syntax::expr_to_string(&operands[1]);
+                  return expr_to_string(&operands[1]);
                 }
 
                 let head = heads.get(i).and_then(|h| h.as_ref());
@@ -3365,19 +3364,12 @@ pub fn dispatch_io_functions(
                 };
 
                 if let Some(def) = default {
-                  param_str = format!(
-                    "{}:{}",
-                    param_str,
-                    crate::syntax::expr_to_string(def)
-                  );
+                  param_str = format!("{}:{}", param_str, expr_to_string(def));
                 }
 
                 if let Some(cond) = condition {
-                  param_str = format!(
-                    "{} /; {}",
-                    param_str,
-                    crate::syntax::expr_to_string(cond)
-                  );
+                  param_str =
+                    format!("{} /; {}", param_str, expr_to_string(cond));
                 }
 
                 param_str
@@ -3385,7 +3377,7 @@ pub fn dispatch_io_functions(
               .collect::<Vec<_>>()
               .join(", ");
 
-            let body_str = crate::syntax::expr_to_string(body);
+            let body_str = expr_to_string(body);
 
             // Use = for literal-dispatch (all params are _dvN), := otherwise
             let is_literal_dispatch = params
@@ -3405,14 +3397,12 @@ pub fn dispatch_io_functions(
         });
         if let Some(stored) = own_value {
           let val_str = match stored {
-            crate::StoredValue::ExprVal(e) => crate::syntax::expr_to_string(&e),
+            crate::StoredValue::ExprVal(e) => expr_to_string(&e),
             crate::StoredValue::Raw(val) => val,
             crate::StoredValue::Association(items) => {
               let parts: Vec<String> = items
                 .iter()
-                .map(|(k, v)| {
-                  format!("{} -> {}", k, crate::syntax::expr_to_string(v))
-                })
+                .map(|(k, v)| format!("{} -> {}", k, expr_to_string(v)))
                 .collect();
               format!("<|{}|>", parts.join(", "))
             }
@@ -3428,7 +3418,7 @@ pub fn dispatch_io_functions(
         {
           let opts_str = opts
             .iter()
-            .map(crate::syntax::expr_to_string)
+            .map(expr_to_string)
             .collect::<Vec<_>>()
             .join(", ");
           sym_lines.push(format!("Options[{sym}] = {{{opts_str}}}"));
@@ -3718,7 +3708,7 @@ pub fn dispatch_io_functions(
         other => {
           crate::emit_message(&format!(
             "FileSize::badfile: The specified argument, {}, should be a valid string or File object.",
-            crate::syntax::expr_to_output(other)
+            expr_to_output(other)
           ));
           return unevaluated();
         }
@@ -3912,7 +3902,7 @@ pub fn dispatch_io_functions(
       if let Some(arg) = args.first() {
         let prompt = match arg {
           Expr::String(p) => p.clone(),
-          _ => crate::syntax::expr_to_string(arg),
+          _ => expr_to_string(arg),
         };
         if !crate::is_quiet_print() {
           use std::io::Write as _;
@@ -4132,14 +4122,14 @@ fn csv_cell(expr: &Expr, quote_strings: bool) -> String {
     // Machine numbers are written bare; a bigger integer is quoted, like
     // every other non-machine value.
     Expr::Integer(n) if i64::try_from(*n).is_ok() => n.to_string(),
-    Expr::Real(_) => crate::syntax::expr_to_string(expr),
+    Expr::Real(_) => expr_to_string(expr),
     // The booleans are lower-cased and left unquoted.
     Expr::Identifier(name) if name == "True" || name == "False" => {
       name.to_lowercase()
     }
     // A list is written out; any other compound expression has no CSV
     // representation and becomes the placeholder `-Head-`.
-    Expr::List(_) => quoted(crate::syntax::expr_to_string(expr)),
+    Expr::List(_) => quoted(expr_to_string(expr)),
     Expr::FunctionCall { .. }
     | Expr::BinaryOp { .. }
     | Expr::UnaryOp { .. }
@@ -4149,14 +4139,11 @@ fn csv_cell(expr: &Expr, quote_strings: bool) -> String {
     {
       let head =
         crate::functions::predicate_ast::head_ast(std::slice::from_ref(expr))
-          .map_or_else(
-            |_| "Expression".to_string(),
-            |h| crate::syntax::expr_to_string(&h),
-          );
+          .map_or_else(|_| "Expression".to_string(), |h| expr_to_string(&h));
       quoted(format!("-{head}-"))
     }
     // Symbols, rationals and the other atoms keep their text, quoted.
-    _ => quoted(crate::syntax::expr_to_string(expr)),
+    _ => quoted(expr_to_string(expr)),
   }
 }
 
@@ -4298,7 +4285,7 @@ fn url_build_from_parts(entries: &[(Expr, Expr)]) -> String {
   };
   let text = |e: &Expr| match e {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_string(other),
+    other => expr_to_string(other),
   };
 
   let scheme = lookup("Scheme").map(&text);
@@ -4431,7 +4418,7 @@ fn flatten_file_patterns(pattern: &Expr, out: &mut Vec<Expr>) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left,
       right,
     } => {

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -337,7 +337,7 @@ pub fn dispatch_linear_algebra_functions(
       let call = unevaluated("IdentityMatrix", args);
       crate::emit_message(&format!(
         "IdentityMatrix::targ: Argument {} at position 2 should be a list or sparse array.",
-        crate::syntax::expr_to_string(&args[1])
+        expr_to_string(&args[1])
       ));
       return Some(Ok(call));
     }
@@ -364,7 +364,7 @@ pub fn dispatch_linear_algebra_functions(
           crate::emit_message(&format!(
             "UnitVector::intpm: Positive machine-sized integer expected at position {} in {}.",
             args.len(),
-            crate::syntax::expr_to_string(&call)
+            expr_to_string(&call)
           ));
         } else {
           crate::emit_message(&format!(
@@ -582,8 +582,7 @@ pub fn dispatch_linear_algebra_functions(
                 Expr::Integer(n as i128),
               ]);
             if let Ok(id) = identity {
-              let result = crate::syntax::expr_to_string(&evaluated)
-                == crate::syntax::expr_to_string(&id);
+              let result = expr_to_string(&evaluated) == expr_to_string(&id);
               return Some(Ok(bool_expr(result)));
             }
           }
@@ -971,7 +970,7 @@ pub fn dispatch_linear_algebra_functions(
         crate::emit_message(&format!(
           "MatrixMinimalPolynomial::matsq: Argument {} at position 1 is not \
            a nonempty square matrix.",
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Some(Ok(unevaluated("MatrixMinimalPolynomial", args)));
       }
@@ -2852,7 +2851,7 @@ pub fn dispatch_linear_algebra_functions(
       }
       crate::emit_message(&format!(
         "CrossMatrix::notre: The first argument {} must be a non-complex number or a list of non-complex numbers.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Some(Ok(unevaluated("CrossMatrix", args)));
     }
@@ -3692,11 +3691,7 @@ fn kronecker_product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Binary dissimilarity functions for binary (0/1) vectors.
-fn binary_dissimilarity_ast(
-  name: &str,
-  a: &Expr,
-  b: &Expr,
-) -> crate::syntax::Expr {
+fn binary_dissimilarity_ast(name: &str, a: &Expr, b: &Expr) -> Expr {
   let (list_a, list_b) = match (a, b) {
     (Expr::List(la), Expr::List(lb)) if la.len() == lb.len() => (la, lb),
     _ => {
@@ -4196,7 +4191,7 @@ fn roll_pitch_yaw_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => {
       crate::emit_message(&format!(
         "RollPitchYawMatrix::ang: {} should be a list of three real-valued quantities.",
-        crate::syntax::expr_to_output(other)
+        expr_to_output(other)
       ));
       return Ok(unevaluated("RollPitchYawMatrix", args));
     }
@@ -4536,7 +4531,7 @@ fn lyapunov_solve_common(
     crate::emit_message(&format!(
       "{}::matsq: Argument {} at position 1 is not a nonempty square matrix.",
       name,
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   }
@@ -4549,7 +4544,7 @@ fn lyapunov_solve_common(
       crate::emit_message(&format!(
         "{}::matsq: Argument {} at position 2 is not a nonempty square matrix.",
         name,
-        crate::syntax::expr_to_output(&args[1])
+        expr_to_output(&args[1])
       ));
       return unevaluated();
     }
@@ -4571,8 +4566,8 @@ fn lyapunov_solve_common(
     crate::emit_message(&format!(
       "{}::ndims: The arguments {} and {} have incorrect dimensions.",
       name,
-      crate::syntax::expr_to_output(&args[0]),
-      crate::syntax::expr_to_output(c_expr)
+      expr_to_output(&args[0]),
+      expr_to_output(c_expr)
     ));
     return unevaluated();
   }

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -235,7 +235,7 @@ fn emit_nopar1(name: &str, serial: &str, args: &[Expr]) {
   crate::emit_message_to_stdout(&format!(
     "{name}::nopar1: {} cannot be parallelized; proceeding with \
      sequential evaluation.",
-    crate::syntax::expr_to_string(&unevaluated(serial, args))
+    expr_to_string(&unevaluated(serial, args))
   ));
 }
 
@@ -852,7 +852,7 @@ fn longest_ordered_sequence(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "LongestOrderedSequence::list: List expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&symbolic())
+        expr_to_string(&symbolic())
       ));
       return Ok(symbolic());
     }
@@ -1869,8 +1869,8 @@ pub fn dispatch_list_operations(
       let iseqs = || {
         crate::emit_message(&format!(
           "TakeList::iseqs: Cannot take list {} of sequence specifications at level 1 of {}.",
-          crate::syntax::expr_to_string(&args[1]),
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[1]),
+          expr_to_string(&args[0])
         ));
       };
       // Walk a (start, end) window over `items`, consuming front or back
@@ -1934,7 +1934,7 @@ pub fn dispatch_list_operations(
             crate::emit_message(&format!(
               "TakeList::seqs: Sequence specification (+n, -n, {{+n}}, {{-n}}, {{m, n}} or {{m, n, s}}) expected at position {} in {}.",
               idx + 1,
-              crate::syntax::expr_to_string(&args[1])
+              expr_to_string(&args[1])
             ));
             return Some(Ok(unevaluated));
           }
@@ -2952,7 +2952,7 @@ pub fn dispatch_list_operations(
       if is_atom {
         crate::emit_message(&format!(
           "Signature::normal: Nonatomic expression expected at position 1 in Signature[{}].",
-          crate::syntax::expr_to_output(&args[0])
+          expr_to_output(&args[0])
         ));
       }
       return Some(Ok(unevaluated("Signature", args)));
@@ -3264,9 +3264,7 @@ pub fn dispatch_list_operations(
       // Only re-evaluate when densification actually changed the expression,
       // to avoid disturbing the plain `Normal[expr]` (no Association/
       // SparseArray) pass-through.
-      if crate::syntax::expr_to_string(&converted)
-        == crate::syntax::expr_to_string(&args[0])
-      {
+      if expr_to_string(&converted) == expr_to_string(&args[0]) {
         return Some(Ok(converted));
       }
       return Some(Ok(evaluate_expr_to_expr(&converted).unwrap_or(converted)));
@@ -3707,10 +3705,7 @@ pub fn dispatch_list_operations(
           _ => {
             crate::emit_message(&format!(
               "FixedPointList::intnm: Non-negative machine-sized integer expected at position 3 in {}.",
-              crate::syntax::expr_to_string(&unevaluated(
-                "FixedPointList",
-                args
-              ))
+              expr_to_string(&unevaluated("FixedPointList", args))
             ));
             return Some(Ok(unevaluated("FixedPointList", args)));
           }
@@ -3736,7 +3731,7 @@ pub fn dispatch_list_operations(
         {
           crate::emit_message(&format!(
             "Transpose::nmtx: The first two levels of {} cannot be transposed.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           Ok(unevaluated("Transpose", args))
         }
@@ -3756,7 +3751,7 @@ pub fn dispatch_list_operations(
         } else {
           crate::emit_message(&format!(
             "TensorTranspose::symmperm: Invalid permutation or symmetry generator {}.",
-            crate::syntax::expr_to_string(&args[1])
+            expr_to_string(&args[1])
           ));
           return Some(Ok(unevaluated("TensorTranspose", args)));
         }
@@ -3769,7 +3764,7 @@ pub fn dispatch_list_operations(
         TensorTransposeResult::Ok(e) => e,
         TensorTransposeResult::RankError { rank } => {
           let perm_str = match perm {
-            Some(p) => crate::syntax::expr_to_string(&Expr::List(p.into())),
+            Some(p) => expr_to_string(&Expr::List(p.into())),
             None => "{2, 1}".to_string(),
           };
           crate::emit_message(&format!(
@@ -3779,7 +3774,7 @@ pub fn dispatch_list_operations(
         }
         TensorTransposeResult::SymmPerm => {
           let perm_str = match perm {
-            Some(p) => crate::syntax::expr_to_string(&Expr::List(p.into())),
+            Some(p) => expr_to_string(&Expr::List(p.into())),
             None => "{2, 1}".to_string(),
           };
           crate::emit_message(&format!(
@@ -3907,14 +3902,14 @@ pub fn dispatch_list_operations(
                 format!(
                   "Join::normal1: Expression {} at position 1 is expected to \
                    have nonatomic subexpression at level {}.",
-                  crate::syntax::expr_to_string(a),
+                  expr_to_string(a),
                   level
                 )
               } else {
                 format!(
                   "Join::headsd: Expression {} at position {} is expected to \
                    have head List for all expressions at level {}.",
-                  crate::syntax::expr_to_string(a),
+                  expr_to_string(a),
                   i + 1,
                   level
                 )
@@ -4079,7 +4074,7 @@ pub fn dispatch_list_operations(
         {
           crate::emit_message(&format!(
             "Thread::tdlen: Objects of unequal length in {} cannot be combined.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           Ok(args[0].clone())
         }
@@ -4098,7 +4093,7 @@ pub fn dispatch_list_operations(
         {
           crate::emit_message(&format!(
             "Thread::tdlen: Objects of unequal length in {} cannot be combined.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           Ok(args[0].clone())
         }
@@ -4146,7 +4141,7 @@ pub fn dispatch_list_operations(
           "Thread::tpos: Cannot thread over positions {} through {} in {}.",
           lo,
           hi,
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Some(unevaluated());
       }
@@ -4161,7 +4156,7 @@ pub fn dispatch_list_operations(
           {
             crate::emit_message(&format!(
               "Thread::tdlen: Objects of unequal length in {} cannot be combined.",
-              crate::syntax::expr_to_string(&args[0])
+              expr_to_string(&args[0])
             ));
             Ok(args[0].clone())
           }
@@ -4239,7 +4234,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "{name}::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(name, args)),
+        expr_to_string(&unevaluated(name, args)),
       ));
       return Some(Ok(unevaluated(name, args)));
     }
@@ -4261,7 +4256,7 @@ pub fn dispatch_list_operations(
       ) {
         crate::emit_message(&format!(
           "ExpressionTree::struct: {} is not a valid expression structure. Valid structures include \"HeadTrees\", \"Heads\", \"Subexpressions\" and \"Atoms\".",
-          crate::syntax::expr_to_output(&args[1])
+          expr_to_output(&args[1])
         ));
         return Some(Ok(unevaluated("ExpressionTree", args)));
       }
@@ -4288,7 +4283,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "RootTree::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4325,7 +4320,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "{name}::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(name, args)),
+        expr_to_string(&unevaluated(name, args)),
       ));
       return Some(Ok(unevaluated(name, args)));
     }
@@ -4346,7 +4341,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeReplacePart::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4387,7 +4382,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeInsert::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4402,8 +4397,8 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "TreeInsert::ins: Cannot insert at position {} in {}.",
-        crate::syntax::expr_to_string(&args[2]),
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[2]),
+        expr_to_string(&args[0])
       ));
       return Some(Ok(unevaluated()));
     }
@@ -4414,7 +4409,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeDelete::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4436,7 +4431,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeLevel::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4461,7 +4456,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeSelect::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4485,7 +4480,7 @@ pub fn dispatch_list_operations(
           rest[0] = Expr::Identifier(tree_str);
           crate::emit_message(&format!(
             "TreeSelect::innf: Non-negative integer or Infinity expected at position -1 in {}.",
-            crate::syntax::expr_to_string(&call("TreeSelect", rest))
+            expr_to_string(&call("TreeSelect", rest))
           ));
           return Some(Ok(unevaluated()));
         }
@@ -4531,7 +4526,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "TreePosition::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated())
+        expr_to_string(&unevaluated())
       ));
       return Some(Ok(unevaluated()));
     }
@@ -4545,7 +4540,7 @@ pub fn dispatch_list_operations(
       if tree_node(&args[0]).is_none() {
         crate::emit_message(&format!(
           "TreeExtract::tree: Tree expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4553,8 +4548,8 @@ pub fn dispatch_list_operations(
       let psl1 = || {
         crate::emit_message(&format!(
           "TreeExtract::psl1: Position specification {} in TreeExtract[-Tree-, {}] is not applicable.",
-          crate::syntax::expr_to_string(&args[1]),
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[1]),
+          expr_to_string(&args[1])
         ));
         unevaluated()
       };
@@ -4597,7 +4592,7 @@ pub fn dispatch_list_operations(
       Ok(None) => {
         crate::emit_message(&format!(
           "TreeMap::tree: Tree expected at position 2 in {}.",
-          crate::syntax::expr_to_string(&unevaluated("TreeMap", args)),
+          expr_to_string(&unevaluated("TreeMap", args)),
         ));
         return Some(Ok(unevaluated("TreeMap", args)));
       }
@@ -4613,7 +4608,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "TreeLeaves::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated("TreeLeaves", args))
+        expr_to_string(&unevaluated("TreeLeaves", args))
       ));
       return Some(Ok(unevaluated("TreeLeaves", args)));
     }
@@ -4633,7 +4628,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "TreeCases::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated())
+        expr_to_string(&unevaluated())
       ));
       return Some(Ok(unevaluated()));
     }
@@ -4643,7 +4638,7 @@ pub fn dispatch_list_operations(
       Ok(None) => {
         crate::emit_message(&format!(
           "TreeScan::tree: Tree expected at position 2 in {}.",
-          crate::syntax::expr_to_string(&unevaluated("TreeScan", args))
+          expr_to_string(&unevaluated("TreeScan", args))
         ));
         return Some(Ok(unevaluated("TreeScan", args)));
       }
@@ -4664,7 +4659,7 @@ pub fn dispatch_list_operations(
       }
       crate::emit_message(&format!(
         "TreeCount::tree: Tree expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated())
+        expr_to_string(&unevaluated())
       ));
       return Some(Ok(unevaluated()));
     }
@@ -4687,7 +4682,7 @@ pub fn dispatch_list_operations(
     }
     "Through" if args.len() == 2 => {
       // Through[expr, h] - only apply if head of expr matches h
-      let head_filter = crate::syntax::expr_to_string(&args[1]);
+      let head_filter = expr_to_string(&args[1]);
       return Some(list_helpers_ast::through_ast(&args[0], Some(&head_filter)));
     }
     "Comap" if args.len() == 1 => {
@@ -4728,7 +4723,7 @@ pub fn dispatch_list_operations(
             args: vec![expr.clone()].into(),
           })
           .map(|_| Expr::FunctionCall {
-            name: crate::syntax::expr_to_string(p),
+            name: expr_to_string(p),
             args: vec![expr.clone()].into(),
           }),
         );
@@ -5144,7 +5139,7 @@ pub fn dispatch_list_operations(
           crate::emit_message(&format!(
             "Indexed::partw: Part {} of {} does not exist.",
             n,
-            crate::syntax::expr_to_string(&current)
+            expr_to_string(&current)
           ));
           return Some(Ok(unevaluated("Indexed", args)));
         }
@@ -5566,10 +5561,9 @@ pub fn dispatch_list_operations(
         for elem in elems {
           let key = crate::evaluator::apply_function_to_arg(f, elem)
             .unwrap_or_else(|_| elem.clone());
-          let key_str = crate::syntax::expr_to_string(&key);
-          if let Some(pos) = keys
-            .iter()
-            .position(|k| crate::syntax::expr_to_string(k) == key_str)
+          let key_str = expr_to_string(&key);
+          if let Some(pos) =
+            keys.iter().position(|k| expr_to_string(k) == key_str)
           {
             counts[pos] += 1;
           } else {
@@ -5752,7 +5746,7 @@ pub fn dispatch_list_operations(
     // JoinAcross[list1, list2, key] — join associations on a common key
     "JoinAcross" if args.len() == 3 => {
       if let (Expr::List(l1), Expr::List(l2)) = (&args[0], &args[1]) {
-        let key_str = crate::syntax::expr_to_string(&args[2]);
+        let key_str = expr_to_string(&args[2]);
         let mut results = Vec::new();
         for a1 in l1 {
           let key_val = get_assoc_value(a1, &key_str);
@@ -5760,8 +5754,7 @@ pub fn dispatch_list_operations(
             for a2 in l2 {
               let key_val2 = get_assoc_value(a2, &key_str);
               if let Some(ref kv2) = key_val2
-                && crate::syntax::expr_to_string(kv)
-                  == crate::syntax::expr_to_string(kv2)
+                && expr_to_string(kv) == expr_to_string(kv2)
               {
                 // Merge the two associations
                 let merged = merge_associations(a1, a2);
@@ -5824,8 +5817,8 @@ pub fn dispatch_list_operations(
       if !matches!(&args[0], Expr::List(_)) {
         crate::emit_message(&format!(
           "SequencePosition::list: List expected at position 1 in SequencePosition[{}, {}].",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[0]),
+          expr_to_string(&args[1])
         ));
         return Some(Ok(unevaluated("SequencePosition", args)));
       }
@@ -5951,8 +5944,8 @@ pub fn dispatch_list_operations(
       if !matches!(&args[0], Expr::List(_)) {
         crate::emit_message(&format!(
           "SequenceCases::list: List expected at position 1 in SequenceCases[{}, {}].",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[0]),
+          expr_to_string(&args[1])
         ));
         return Some(Ok(unevaluated("SequenceCases", args)));
       }
@@ -6105,8 +6098,8 @@ pub fn dispatch_list_operations(
       if !matches!(&args[0], Expr::List(_)) {
         crate::emit_message(&format!(
           "SequenceSplit::list: List expected at position 1 in SequenceSplit[{}, {}].",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[0]),
+          expr_to_string(&args[1])
         ));
         return Some(Ok(unevaluated("SequenceSplit", args)));
       }
@@ -6119,7 +6112,7 @@ pub fn dispatch_list_operations(
           let call = unevaluated("SequenceSplit", args);
           crate::emit_message(&format!(
             "SequenceSplit::ipnf: Positive integer or Infinity expected at position 3 in {}.",
-            crate::syntax::expr_to_string(&call)
+            expr_to_string(&call)
           ));
           return Some(Ok(call));
         }
@@ -6261,8 +6254,8 @@ pub fn dispatch_list_operations(
         let call = unevaluated("SequenceCount", args);
         crate::emit_message(&format!(
           "SequenceCount::nonopt: Options expected (instead of {}) beyond position 2 in {}. An option must be a rule or a list of rules.",
-          crate::syntax::expr_to_string(opt),
-          crate::syntax::expr_to_string(&call)
+          expr_to_string(opt),
+          expr_to_string(&call)
         ));
         return Some(Ok(call));
       }
@@ -6382,7 +6375,7 @@ pub fn dispatch_list_operations(
       if !matches!(&args[0], Expr::List(_)) {
         crate::emit_message(&format!(
           "SequenceReplace::list: List expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated("SequenceReplace", args)),
+          expr_to_string(&unevaluated("SequenceReplace", args)),
         ));
         return Some(Ok(unevaluated("SequenceReplace", args)));
       }
@@ -6522,7 +6515,7 @@ pub fn dispatch_list_operations(
       let Expr::List(list) = &args[0] else {
         crate::emit_message(&format!(
           "SubsetReplace::list: List expected at position 1 in {}.",
-          crate::syntax::expr_to_string(&unevaluated())
+          expr_to_string(&unevaluated())
         ));
         return Some(Ok(unevaluated()));
       };
@@ -8203,7 +8196,7 @@ fn normal_convert_associations(expr: &Expr) -> Expr {
 /// Combines a matrix of sub-matrices (blocks) into a single matrix.
 /// Scalar entries (e.g. 0) are expanded to zero/constant matrices
 /// of the appropriate dimensions inferred from neighboring blocks.
-fn array_flatten_ast(arg: &Expr) -> crate::syntax::Expr {
+fn array_flatten_ast(arg: &Expr) -> Expr {
   // arg should be a list of rows, where each row is a list of blocks (sub-matrices)
   let Expr::List(block_rows) = arg else {
     return call1("ArrayFlatten", arg.clone());
@@ -8494,7 +8487,7 @@ fn nearest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "Nearest::near1: {} is neither a list of real points nor a valid list \
        of rules.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return Ok(unevaluated("Nearest", args));
   }
@@ -8937,7 +8930,7 @@ fn compose_transformation_functions(parts: &[Expr]) -> Option<Expr> {
     .then(|| call1("TransformationFunction", product))
 }
 
-fn position_index_ast(expr: &Expr) -> crate::syntax::Expr {
+fn position_index_ast(expr: &Expr) -> Expr {
   // `PositionIndex[list]` indexes values by their integer positions;
   // `PositionIndex[assoc]` indexes the association's values by their keys.
   let pairs: Vec<(Expr, Expr)> = match expr {
@@ -8962,10 +8955,9 @@ fn position_index_ast(expr: &Expr) -> crate::syntax::Expr {
   // value's first appearance.
   let mut map: Vec<(Expr, Vec<Expr>)> = Vec::new();
   for (pos, item) in pairs {
-    let item_str = crate::syntax::expr_to_string(&item);
-    if let Some(entry) = map
-      .iter_mut()
-      .find(|(k, _)| crate::syntax::expr_to_string(k) == item_str)
+    let item_str = expr_to_string(&item);
+    if let Some(entry) =
+      map.iter_mut().find(|(k, _)| expr_to_string(k) == item_str)
     {
       entry.1.push(pos);
     } else {
@@ -9739,7 +9731,7 @@ fn build_inner_sparse(
 ) -> Expr {
   let func_name = match func {
     Expr::Identifier(s) => s.clone(),
-    _ => crate::syntax::expr_to_string(func),
+    _ => expr_to_string(func),
   };
   let make_call = |trailing: Expr| {
     let mut call_args = Vec::with_capacity(outer_vals.len() + 1);

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1832,7 +1832,7 @@ pub fn dispatch_math_functions(
           crate::emit_message(&format!(
             "StieltjesGamma::intnm: Non-negative machine-sized integer \
              expected at position 1 in StieltjesGamma[{}].",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           unevaluated
         }
@@ -1866,7 +1866,7 @@ pub fn dispatch_math_functions(
           crate::emit_message(&format!(
             "StieltjesGamma::intnm: Non-negative machine-sized integer \
              expected at position 1 in StieltjesGamma[{}].",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           unevaluated
         }
@@ -2825,8 +2825,8 @@ pub fn dispatch_math_functions(
           // A negative (or otherwise invalid) integer: message + unevaluated.
           crate::emit_message(&format!(
             "CardinalBSplineBasis::intnm: Non-negative machine-sized integer expected at position 1 in CardinalBSplineBasis[{}, {}].",
-            crate::syntax::expr_to_string(&args[0]),
-            crate::syntax::expr_to_string(&args[1]),
+            expr_to_string(&args[0]),
+            expr_to_string(&args[1]),
           ));
           return Some(Ok(unevaluated()));
         }
@@ -2928,9 +2928,9 @@ pub fn dispatch_math_functions(
       if n < 0 {
         crate::emit_message(&format!(
           "BernsteinBasis::intnm: Non-negative machine-sized integer expected at position 2 in BernsteinBasis[{}, {}, {}].",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&args[1]),
-          crate::syntax::expr_to_string(&args[2]),
+          expr_to_string(&args[0]),
+          expr_to_string(&args[1]),
+          expr_to_string(&args[2]),
         ));
         return Some(Ok(unevaluated()));
       }
@@ -4320,8 +4320,8 @@ pub fn dispatch_math_functions(
         if is_zero {
           crate::emit_message(&format!(
             "ShearingMatrix::proj: The projection of {} onto the plane defined by {} has zero magnitude.",
-            crate::syntax::expr_to_string(&args[1]),
-            crate::syntax::expr_to_string(&args[2]),
+            expr_to_string(&args[1]),
+            expr_to_string(&args[2]),
           ));
           return Some(Ok(unevaluated("ShearingMatrix", args)));
         }
@@ -4531,8 +4531,8 @@ pub fn dispatch_math_functions(
     }
     // BinaryDistance[u, v] — 0 if u == v, 1 otherwise
     "BinaryDistance" if args.len() == 2 => {
-      let s1 = crate::syntax::expr_to_string(&args[0]);
-      let s2 = crate::syntax::expr_to_string(&args[1]);
+      let s1 = expr_to_string(&args[0]);
+      let s2 = expr_to_string(&args[1]);
       return Some(Ok(Expr::Integer(i128::from(s1 != s2))));
     }
     // SquaresR[k, n] — number of representations of n as sum of k squares
@@ -4660,7 +4660,7 @@ pub fn dispatch_math_functions(
         let new_operands: Vec<Expr> = operands
           .iter()
           .map(|op| Expr::FunctionCall {
-            name: crate::syntax::expr_to_string(&args[0]),
+            name: expr_to_string(&args[0]),
             args: vec![op.clone()].into(),
           })
           .collect();
@@ -4966,7 +4966,7 @@ pub fn dispatch_math_functions(
         {
           crate::emit_message(&format!(
             "ChampernowneNumber::ibase: Base {} is not an integer greater than 1.",
-            crate::syntax::expr_to_output(first)
+            expr_to_output(first)
           ));
         }
       }
@@ -5056,7 +5056,7 @@ fn qgamma_ast(z_expr: &Expr, q_expr: &Expr) -> Result<Expr, InterpreterError> {
 /// Algorithm: Express x in base 3. If a digit 1 appears, replace it
 /// and all subsequent digits with a single "1" in base 2.
 /// Replace all 2s with 1s. Read the result in base 2.
-fn cantor_staircase_ast(arg: &Expr) -> crate::syntax::Expr {
+fn cantor_staircase_ast(arg: &Expr) -> Expr {
   use crate::functions::math_ast::{expr_to_i128, try_eval_to_f64};
 
   // Handle exact integers
@@ -5271,7 +5271,7 @@ fn qfactorial_ast(
 
 /// Find minimum linear recurrence coefficients {c1, c2, ..., cd} such that
 /// a[n] = c1*a[n-1] + c2*a[n-2] + ... + cd*a[n-d] for all valid n.
-fn find_linear_recurrence_impl(seq: &[Expr]) -> crate::syntax::Expr {
+fn find_linear_recurrence_impl(seq: &[Expr]) -> Expr {
   // Convert sequence to rationals
   let mut rats: Vec<(i128, i128)> = Vec::new();
   for e in seq {
@@ -5483,7 +5483,7 @@ fn substitute_complex_vars(expr: &Expr, vars: &[String]) -> Expr {
 
 /// ComplexExpand[expr] — expand complex-valued functions assuming all
 /// variables are real. E.g. Sin[x + I*y] → Sin[x]*Cosh[y] + I*Cos[x]*Sinh[y].
-fn complex_expand_ast(expr: &Expr) -> crate::syntax::Expr {
+fn complex_expand_ast(expr: &Expr) -> Expr {
   // Re-evaluate so arithmetic left by the generic Plus/Times recursion folds
   // (e.g. the `-0` from Re[a + b I] = -Im[b] + Re[a] → -0 + a).
   let folded = ce_simplify(complex_expand_recursive(expr));
@@ -5500,7 +5500,7 @@ fn complex_expand_ast(expr: &Expr) -> crate::syntax::Expr {
 /// Like `complex_expand_ast` but additionally distributes products via
 /// Expand, used by the 2-arg form `ComplexExpand[expr, vars]` so the
 /// polynomial result is a single distributed Plus chain.
-fn complex_expand_with_expand(expr: &Expr) -> crate::syntax::Expr {
+fn complex_expand_with_expand(expr: &Expr) -> Expr {
   let expanded = complex_expand_recursive(expr);
   let distributed = crate::evaluator::evaluate_function_call_ast(
     "Expand",

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -249,7 +249,7 @@ pub fn dispatch_plotting(
         {
           crate::emit_message(&format!(
             "ListLinePlot::lpn: {} is not a list of numbers or pairs of numbers.",
-            crate::syntax::expr_to_string(&evaluated)
+            expr_to_string(&evaluated)
           ));
           Some(Ok(unevaluated("ListLinePlot", args)))
         }
@@ -579,10 +579,8 @@ pub fn dispatch_plotting(
         crate::capture_stdout("");
         return Some(Ok(Expr::Identifier("Null".to_string())));
       }
-      let display_str: String = args
-        .iter()
-        .map(crate::syntax::expr_to_output)
-        .collect::<String>();
+      let display_str: String =
+        args.iter().map(expr_to_output).collect::<String>();
       if !crate::is_quiet_print() {
         println!("{display_str}");
       }

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -843,7 +843,7 @@ fn modulus_equation_system(expr: &Expr) -> Option<Vec<(Expr, Expr)>> {
       Some(all)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::And,
+      op: BinaryOperator::And,
       left,
       right,
     } => {

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -540,7 +540,7 @@ pub fn dispatch_predicate_functions(
         Some(_) => {
           crate::emit_message(&format!(
             "CreateUUID::string: String expected at position 1 in {}.",
-            crate::syntax::expr_to_string(&unevaluated("CreateUUID", args))
+            expr_to_string(&unevaluated("CreateUUID", args))
           ));
           return Some(Ok(unevaluated("CreateUUID", args)));
         }
@@ -612,7 +612,7 @@ pub fn dispatch_predicate_functions(
         _ => {
           crate::emit_message(&format!(
             "Unique::usym: {} is not a symbol or a valid symbol name.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Some(Ok(unevaluated("Unique", args)));
         }
@@ -1360,7 +1360,7 @@ pub fn dispatch_predicate_functions(
           crate::emit_message_to_stdout(&format!(
             "Context::ssle: Symbol or string expected at position 1 in \
              Context[{}].",
-            crate::syntax::expr_to_output(other)
+            expr_to_output(other)
           ));
           return Some(Ok(unevaluated("Context", args)));
         }
@@ -1666,7 +1666,7 @@ pub fn dispatch_predicate_functions(
           let v = evaluate_expr_to_expr(&v)?;
           Ok(match &wrapper {
             Some(h) => Expr::FunctionCall {
-              name: crate::syntax::expr_to_string(h),
+              name: expr_to_string(h),
               args: vec![v].into(),
             },
             None => v,

--- a/src/evaluator/dispatch/string_functions.rs
+++ b/src/evaluator/dispatch/string_functions.rs
@@ -236,7 +236,7 @@ pub fn dispatch_string_functions(
       if !is_valid_codepoint_arg(&args[0]) {
         crate::emit_message(&format!(
           "FromCharacterCode::intnm: Non-negative machine-sized integer expected at position 1 in FromCharacterCode[{}].",
-          crate::syntax::expr_to_string(&args[0]),
+          expr_to_string(&args[0]),
         ));
         return Some(Ok(unevaluated("FromCharacterCode", args)));
       }
@@ -481,8 +481,7 @@ pub fn dispatch_string_functions(
           }
           match (num_val(a), num_val(b)) {
             (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(Ordering::Equal),
-            _ => crate::syntax::expr_to_string(a)
-              .cmp(&crate::syntax::expr_to_string(b)),
+            _ => expr_to_string(a).cmp(&expr_to_string(b)),
           }
         }
         let mut items: Vec<Expr> = elems.to_vec();

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -643,8 +643,8 @@ pub fn apply_function_to_arg(
           "Function::fpct: Too many parameters in {{{}}} to be filled from Function[{{{}}}, {}][{}].",
           params.join(", "),
           params.join(", "),
-          crate::syntax::expr_to_string(body),
-          crate::syntax::expr_to_string(arg),
+          expr_to_string(body),
+          expr_to_string(arg),
         ));
         return Ok(Expr::CurriedCall {
           func: Box::new(func.clone()),
@@ -974,7 +974,7 @@ fn operator_form_accepts_subject(name: &str, subject: &Expr) -> bool {
   if !accepted {
     crate::emit_message(&format!(
       "Merge::list1: The argument {} is not a valid list of Associations or rules or lists of rules.",
-      crate::syntax::expr_to_output(subject)
+      expr_to_output(subject)
     ));
   }
   accepted
@@ -1162,13 +1162,12 @@ pub fn apply_curried_call(
       // Named-parameter function: substitute each param with corresponding arg
       if params.len() > args.len() {
         // Too many parameters for the given arguments — return unevaluated
-        let args_str: Vec<String> =
-          args.iter().map(crate::syntax::expr_to_string).collect();
+        let args_str: Vec<String> = args.iter().map(expr_to_string).collect();
         crate::emit_message(&format!(
           "Function::fpct: Too many parameters in {{{}}} to be filled from Function[{{{}}}, {}][{}].",
           params.join(", "),
           params.join(", "),
-          crate::syntax::expr_to_string(body),
+          expr_to_string(body),
           args_str.join(", "),
         ));
         return Ok(Expr::CurriedCall {
@@ -1291,11 +1290,11 @@ pub fn apply_curried_call(
       let line = if func_args.len() == 2 {
         format!(
           ">> {} {}",
-          crate::syntax::expr_to_output(&func_args[0]),
-          crate::syntax::expr_to_output(&display)
+          expr_to_output(&func_args[0]),
+          expr_to_output(&display)
         )
       } else {
-        format!(">> {}", crate::syntax::expr_to_output(&display))
+        format!(">> {}", expr_to_output(&display))
       };
       println!("{line}");
       crate::capture_stdout(&line);
@@ -1309,8 +1308,8 @@ pub fn apply_curried_call(
     } if name == "EchoLabel" && func_args.len() == 1 && args.len() == 1 => {
       let line = format!(
         ">> {} {}",
-        crate::syntax::expr_to_output(&func_args[0]),
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&func_args[0]),
+        expr_to_output(&args[0])
       );
       println!("{line}");
       crate::capture_stdout(&line);
@@ -2566,10 +2565,7 @@ pub fn apply_curried_call(
 }
 
 /// Evaluate BezierFunction[{control_points}][t] using de Casteljau's algorithm.
-fn evaluate_bezier_function(
-  func_args: &[Expr],
-  args: &[Expr],
-) -> crate::syntax::Expr {
+fn evaluate_bezier_function(func_args: &[Expr], args: &[Expr]) -> Expr {
   if args.len() != 1 {
     return unevaluated("BezierFunction", func_args);
   }
@@ -2712,10 +2708,7 @@ fn bspline_point_coords(e: &Expr) -> Option<Vec<f64>> {
 /// parameters (one per spline dimension). Curves take a single parameter and
 /// surfaces take two; the control points are evaluated via (tensor-product)
 /// de Boor. Non-numeric parameters leave the application unevaluated.
-fn evaluate_bspline_function(
-  func_args: &[Expr],
-  args: &[Expr],
-) -> crate::syntax::Expr {
+fn evaluate_bspline_function(func_args: &[Expr], args: &[Expr]) -> Expr {
   // When the spline can't be sampled (symbolic parameters, malformed form),
   // echo the object applied to its parameters: `BSplineFunction[...][params]`.
   let unevaluated = || Expr::CurriedCall {

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -3,7 +3,8 @@ use crate::helpers::{
   times2, unevaluated,
 };
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
+  expr_to_string,
 };
 use crate::{ENV, InterpreterError, PART_DEPTH, StoredValue, interpret};
 use num_bigint::{BigInt, Sign};

--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -62,7 +62,7 @@ pub fn flatten_alternatives_binop(expr: &Expr) -> Option<Expr> {
 }
 
 fn part_take_warn(expr: &Expr, start: i64, end: i64) {
-  let expr_str = crate::syntax::expr_to_string(expr);
+  let expr_str = expr_to_string(expr);
   crate::emit_message_to_stdout(&format!(
     "Part::take: Cannot take positions {start} through {end} in {expr_str}."
   ));
@@ -816,7 +816,7 @@ fn extract_part_ast_rest(
         Ok(items[actual_idx as usize].clone())
       } else {
         // Print warning to stderr and return unevaluated Part expression
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -842,7 +842,7 @@ fn extract_part_ast_rest(
           if actual_idx >= 0 && actual_idx < len {
             return Ok(Expr::Integer(bytes[actual_idx as usize] as i128));
           }
-          let expr_str = crate::syntax::expr_to_string(expr);
+          let expr_str = expr_to_string(expr);
           crate::emit_message_to_stdout(&format!(
             "Part::partw: Part {idx} of {expr_str} does not exist."
           ));
@@ -854,7 +854,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(args[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -884,7 +884,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(parts[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -933,7 +933,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(parts[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -955,7 +955,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(parts[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -980,7 +980,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(children[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));
@@ -1003,7 +1003,7 @@ fn extract_part_ast_rest(
       if actual_idx >= 0 && actual_idx < len {
         Ok(parts[actual_idx as usize].clone())
       } else {
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let expr_str = expr_to_string(expr);
         crate::emit_message_to_stdout(&format!(
           "Part::partw: Part {idx} of {expr_str} does not exist."
         ));

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -704,8 +704,8 @@ fn lookup_user_default(
     if let Ok(result) = crate::evaluator::evaluate_expr_to_expr(&call) {
       // If evaluation produced something other than the unevaluated form,
       // a user-defined Default fired.
-      let call_str = crate::syntax::expr_to_string(&call);
-      let result_str = crate::syntax::expr_to_string(&result);
+      let call_str = expr_to_string(&call);
+      let result_str = expr_to_string(&result);
       if result_str != call_str {
         return Some(result);
       }
@@ -716,7 +716,6 @@ fn lookup_user_default(
 
 /// Map a BinaryOperator to the corresponding Wolfram Language function name.
 fn binary_op_to_func_name(op: BinaryOperator) -> &'static str {
-  use BinaryOperator;
   match op {
     BinaryOperator::Plus => "Plus",
     BinaryOperator::Times => "Times",
@@ -1456,7 +1455,7 @@ fn try_align_groups(
       if let Some(test) = &seq_info.test {
         for e in &elements {
           let test_call = Expr::FunctionCall {
-            name: crate::syntax::expr_to_string(test),
+            name: expr_to_string(test),
             args: vec![e.clone()].into(),
           };
           let result =

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -6,7 +6,7 @@ use super::*;
 fn non_list_local_spec(head: &str, args: &[Expr], spec: &Expr) -> Expr {
   crate::emit_message(&format!(
     "{head}::lvlist: Local variable specification {} is not a List.",
-    crate::syntax::expr_to_string(spec)
+    expr_to_string(spec)
   ));
   unevaluated_with_spec(head, args, spec)
 }
@@ -414,8 +414,8 @@ pub fn block_random_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "BlockRandom::nonopt: Options expected (instead of {}) beyond \
            position 1 in {}. An option must be a rule or a list of rules.",
-          crate::syntax::expr_to_output(opt),
-          crate::syntax::expr_to_output(&unevaluated("BlockRandom", args))
+          expr_to_output(opt),
+          expr_to_output(&unevaluated("BlockRandom", args))
         ));
         return Ok(unevaluated("BlockRandom", args));
       }
@@ -424,7 +424,7 @@ pub fn block_random_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some((name, _)) = options.iter().find(|(n, _)| n != "RandomSeeding") {
     crate::emit_message(&format!(
       "BlockRandom::optx: Unknown option {name} in {}.",
-      crate::syntax::expr_to_output(&unevaluated("BlockRandom", args))
+      expr_to_output(&unevaluated("BlockRandom", args))
     ));
     return Ok(unevaluated("BlockRandom", args));
   }
@@ -451,7 +451,7 @@ pub fn block_random_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
          not Automatic, Inherited, an integer, string or valid \
          RandomGeneratorState expression. Using the default seeding for \
          BlockRandom instead.",
-        crate::syntax::expr_to_output(spec)
+        expr_to_output(spec)
       ));
     }
   }

--- a/src/evaluator/symbol_values.rs
+++ b/src/evaluator/symbol_values.rs
@@ -11,7 +11,6 @@
 //! [`restore_symbol_values`].
 
 use super::*;
-use crate::syntax::Expr;
 
 /// One `FUNC_DEFS` entry: `(params, conditions, defaults, head_constraints,
 /// blank_types, body)`.
@@ -131,15 +130,14 @@ pub(crate) fn take_symbol_values(sym: &str) -> SymbolValues {
   saved.up = crate::UPVALUES.with(|m| m.borrow_mut().remove(sym));
   if let Some(up_defs) = &saved.up {
     for (outer_func, params, _, _, _, body, _, _) in up_defs {
-      let body_str = crate::syntax::expr_to_string(body);
+      let body_str = expr_to_string(body);
       let pulled = crate::FUNC_DEFS.with(|m| {
         let mut map = m.borrow_mut();
         let Some(entries) = map.get_mut(outer_func) else {
           return Vec::new();
         };
-        let matches = |d: &FuncDef| {
-          &d.0 == params && crate::syntax::expr_to_string(&d.5) == body_str
-        };
+        let matches =
+          |d: &FuncDef| &d.0 == params && expr_to_string(&d.5) == body_str;
         if !entries.iter().any(matches) {
           return Vec::new();
         }

--- a/src/functions/association_ast.rs
+++ b/src/functions/association_ast.rs
@@ -287,7 +287,7 @@ pub fn key_drop_from_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "KeyDropFrom expects exactly 2 arguments".into(),
     ));
   }
-  let key_str = crate::syntax::expr_to_string(&args[1]);
+  let key_str = expr_to_string(&args[1]);
   // Compare keys structurally: a string key ("a") must NOT match a symbol
   // key (a), matching wolframscript (and Woxi's part-access path).
   let key_cmp = key_str.as_str();
@@ -297,7 +297,7 @@ pub fn key_drop_from_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let filtered: Vec<(Expr, Expr)> = items
         .iter()
         .filter(|(k, _)| {
-          let k_str = crate::syntax::expr_to_string(k);
+          let k_str = expr_to_string(k);
           let k_cmp = k_str.as_str();
           k_cmp != key_cmp
         })
@@ -328,7 +328,7 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "KeyExistsQ expects exactly 2 arguments".into(),
     ));
   }
-  let key_str = crate::syntax::expr_to_string(&args[1]);
+  let key_str = expr_to_string(&args[1]);
   // Compare keys structurally: a string key ("a") must NOT match a symbol
   // key (a), matching wolframscript (and Woxi's part-access path).
   let key_cmp = key_str.as_str();
@@ -336,7 +336,7 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Association(items) => {
       for (k, _) in items {
-        let k_str = crate::syntax::expr_to_string(k);
+        let k_str = expr_to_string(k);
         let k_cmp = k_str.as_str();
         if k_cmp == key_cmp {
           return Ok(bool_expr(true));
@@ -350,7 +350,7 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       for item in items {
         if let Some(k) = extract_rule_key(item) {
-          let k_str = crate::syntax::expr_to_string(&k);
+          let k_str = expr_to_string(&k);
           if k_str.as_str() == key_cmp {
             return Ok(bool_expr(true));
           }
@@ -397,7 +397,7 @@ pub fn lookup_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::List(results?.into()));
   }
 
-  let key_str = crate::syntax::expr_to_string(&args[1]);
+  let key_str = expr_to_string(&args[1]);
   // Compare keys structurally: a string key ("a") must NOT match a symbol
   // key (a), matching wolframscript (and Woxi's part-access path).
   let key_cmp = key_str.as_str();
@@ -405,7 +405,7 @@ pub fn lookup_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Association(items) => {
       for (k, v) in items {
-        let k_str = crate::syntax::expr_to_string(k);
+        let k_str = expr_to_string(k);
         let k_cmp = k_str.as_str();
         if k_cmp == key_cmp {
           return Ok(assoc_entry_value(k, v));
@@ -461,8 +461,8 @@ pub fn key_sort_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           crate::functions::list_helpers_ast::comparator_cmp(p, &a.0, &b.0)
         }),
         None => sorted.sort_by(|a, b| {
-          let ka = crate::syntax::expr_to_string(&a.0);
-          let kb = crate::syntax::expr_to_string(&b.0);
+          let ka = expr_to_string(&a.0);
+          let kb = expr_to_string(&b.0);
           if let (Ok(na), Ok(nb)) = (ka.parse::<f64>(), kb.parse::<f64>()) {
             na.partial_cmp(&nb).unwrap_or(std::cmp::Ordering::Equal)
           } else {
@@ -650,7 +650,7 @@ pub fn merge_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let push_pair = |key_values: &mut Vec<(String, Expr, Vec<Expr>)>,
                    k: &Expr,
                    v: &Expr| {
-    let k_str = crate::syntax::expr_to_string(k);
+    let k_str = expr_to_string(k);
     if let Some(entry) = key_values.iter_mut().find(|(ks, _, _)| *ks == k_str) {
       entry.2.push(v.clone());
     } else {
@@ -785,10 +785,8 @@ pub fn key_take_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Keys compare structurally (a string key "a" must not match a symbol a).
   let keep_keys: Vec<String> = match &args[1] {
-    Expr::List(items) => {
-      items.iter().map(crate::syntax::expr_to_string).collect()
-    }
-    other => vec![crate::syntax::expr_to_string(other)],
+    Expr::List(items) => items.iter().map(expr_to_string).collect(),
+    other => vec![expr_to_string(other)],
   };
 
   match &args[0] {
@@ -796,7 +794,7 @@ pub fn key_take_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut result = Vec::new();
       for desired_key in &keep_keys {
         for (k, v) in items {
-          let k_str = crate::syntax::expr_to_string(k);
+          let k_str = expr_to_string(k);
           let k_cmp = k_str.as_str();
           if k_cmp == desired_key {
             result.push((k.clone(), v.clone()));
@@ -826,10 +824,8 @@ pub fn key_drop_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Keys compare structurally (a string key "a" must not match a symbol a).
   let drop_keys: Vec<String> = match &args[1] {
-    Expr::List(items) => {
-      items.iter().map(crate::syntax::expr_to_string).collect()
-    }
-    other => vec![crate::syntax::expr_to_string(other)],
+    Expr::List(items) => items.iter().map(expr_to_string).collect(),
+    other => vec![expr_to_string(other)],
   };
 
   match &args[0] {
@@ -837,7 +833,7 @@ pub fn key_drop_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let result: Vec<(Expr, Expr)> = items
         .iter()
         .filter(|(k, _)| {
-          let k_str = crate::syntax::expr_to_string(k);
+          let k_str = expr_to_string(k);
           let k_cmp = k_str.as_str();
           !drop_keys.iter().any(|dk| dk == k_cmp)
         })
@@ -971,7 +967,7 @@ pub fn key_union_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut seen_keys: Vec<String> = Vec::new();
   for assoc in &all_assocs {
     for (key, _) in assoc {
-      let key_str = crate::syntax::expr_to_string(key);
+      let key_str = expr_to_string(key);
       if !seen_keys.contains(&key_str) {
         seen_keys.push(key_str);
         all_keys.push(key.clone());
@@ -984,10 +980,10 @@ pub fn key_union_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for assoc in &all_assocs {
     let mut new_items: Vec<(Expr, Expr)> = Vec::new();
     for key in &all_keys {
-      let key_str = crate::syntax::expr_to_string(key);
+      let key_str = expr_to_string(key);
       let value = assoc
         .iter()
-        .find(|(k, _)| crate::syntax::expr_to_string(k) == key_str)
+        .find(|(k, _)| expr_to_string(k) == key_str)
         .map(|(_, v)| v.clone());
       if let Some(v) = value {
         new_items.push((key.clone(), v));
@@ -995,7 +991,7 @@ pub fn key_union_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let missing = match default_fn {
           Some(func) => {
             let call = Expr::FunctionCall {
-              name: crate::syntax::expr_to_string(func),
+              name: expr_to_string(func),
               args: vec![key.clone()].into(),
             };
             crate::evaluator::evaluate_expr_to_expr(&call)?
@@ -1070,11 +1066,10 @@ pub fn key_intersection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .iter()
     .map(|(k, _)| k.clone())
     .filter(|k| {
-      let ks = crate::syntax::expr_to_string(k);
-      all_assocs[1..].iter().all(|a| {
-        a.iter()
-          .any(|(k2, _)| crate::syntax::expr_to_string(k2) == ks)
-      })
+      let ks = expr_to_string(k);
+      all_assocs[1..]
+        .iter()
+        .all(|a| a.iter().any(|(k2, _)| expr_to_string(k2) == ks))
     })
     .collect();
 
@@ -1084,10 +1079,10 @@ pub fn key_intersection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let items: Vec<(Expr, Expr)> = common_keys
         .iter()
         .map(|k| {
-          let ks = crate::syntax::expr_to_string(k);
+          let ks = expr_to_string(k);
           let v = assoc
             .iter()
-            .find(|(k2, _)| crate::syntax::expr_to_string(k2) == ks)
+            .find(|(k2, _)| expr_to_string(k2) == ks)
             .map(|(_, v)| v.clone())
             .unwrap();
           (k.clone(), v)
@@ -1119,12 +1114,12 @@ pub fn key_complement_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let other_keys: Vec<String> = all_assocs[1..]
     .iter()
-    .flat_map(|a| a.iter().map(|(k, _)| crate::syntax::expr_to_string(k)))
+    .flat_map(|a| a.iter().map(|(k, _)| expr_to_string(k)))
     .collect();
 
   let items: Vec<(Expr, Expr)> = all_assocs[0]
     .iter()
-    .filter(|(k, _)| !other_keys.contains(&crate::syntax::expr_to_string(k)))
+    .filter(|(k, _)| !other_keys.contains(&expr_to_string(k)))
     .cloned()
     .collect();
 

--- a/src/functions/astronomy_ast.rs
+++ b/src/functions/astronomy_ast.rs
@@ -992,7 +992,7 @@ fn expr_to_f64(e: &Expr) -> Option<f64> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => expr_to_f64(operand).map(|v| -v),
     _ => None,
@@ -1193,11 +1193,7 @@ pub fn full_moon_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(next_phase_function("FullMoon", Phase::Full, args))
 }
 
-fn next_phase_function(
-  name: &str,
-  phase: Phase,
-  args: &[Expr],
-) -> crate::syntax::Expr {
+fn next_phase_function(name: &str, phase: Phase, args: &[Expr]) -> Expr {
   let jd = match args {
     [] => now_jd(),
     [date] => match parse_date_arg(date) {
@@ -1307,7 +1303,7 @@ fn body_position_ast(
   name: &str,
   ra_dec_dist: fn(f64) -> (f64, f64, f64),
   args: &[Expr],
-) -> crate::syntax::Expr {
+) -> Expr {
   let (positional, system) = split_celestial_options(args);
   let Some(((lat, lon), jd)) = parse_location_date(&positional) else {
     return unevaluated(name, args);
@@ -1406,7 +1402,7 @@ pub fn sidereal_time_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 // ─── Sunrise / Sunset / DaylightQ ───────────────────────────────────
 
-fn sun_event_ast(name: &str, rise: bool, args: &[Expr]) -> crate::syntax::Expr {
+fn sun_event_ast(name: &str, rise: bool, args: &[Expr]) -> Expr {
   let Some(((lat, lon), jd)) = parse_location_date(args) else {
     return unevaluated(name, args);
   };

--- a/src/functions/audio_ast/data.rs
+++ b/src/functions/audio_ast/data.rs
@@ -357,7 +357,7 @@ pub fn duration_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let durinv = |e: &Expr| {
     crate::emit_message(&format!(
       "Duration::durinv: Expecting an audio, sound, video, time series or date interval object instead of {}.",
-      crate::syntax::expr_to_string(e)
+      expr_to_string(e)
     ));
   };
 
@@ -492,10 +492,7 @@ fn audio_argument(name: &str, args: &[Expr]) -> Option<AudioData> {
   if audio.is_none() {
     crate::emit_message(&format!(
       "{name}::audio: Expecting an audio object instead of {}.",
-      args
-        .first()
-        .map(crate::syntax::expr_to_string)
-        .unwrap_or_default()
+      args.first().map(expr_to_string).unwrap_or_default()
     ));
   }
   audio
@@ -602,7 +599,7 @@ pub fn audio_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "AudioData::audiodtype: The specified data type {} should be \
          \"SignedInteger8\", \"SignedInteger16\", \"SignedInteger32\", \
          \"Real32\", \"Real64\" or Automatic.",
-        crate::syntax::expr_to_string(other)
+        expr_to_string(other)
       ));
       return echo();
     }

--- a/src/functions/audio_ast/edit.rs
+++ b/src/functions/audio_ast/edit.rs
@@ -271,10 +271,7 @@ fn require_audio(
   if audio.is_none() {
     crate::emit_message(&format!(
       "{name}::audio: Expecting an audio object instead of {}.",
-      args
-        .first()
-        .map(crate::syntax::expr_to_string)
-        .unwrap_or_default()
+      args.first().map(expr_to_string).unwrap_or_default()
     ));
   }
   audio

--- a/src/functions/audio_ast/mod.rs
+++ b/src/functions/audio_ast/mod.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::helpers::{bool_expr, call, call1, unevaluated};
-use crate::syntax::Expr;
+use crate::syntax::{Expr, expr_to_string};
 
 pub mod data;
 pub mod edit;

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -169,10 +169,9 @@ fn reduce_xor_operands(
         // Two syntactically-identical operands cancel: a ⊻ a = False.
         // Remove the existing partner instead of keeping the duplicate so
         // an even multiplicity vanishes and an odd one keeps a single copy.
-        let ev_str = crate::syntax::expr_to_string(&evaluated);
-        if let Some(pos) = remaining
-          .iter()
-          .position(|e| crate::syntax::expr_to_string(e) == ev_str)
+        let ev_str = expr_to_string(&evaluated);
+        if let Some(pos) =
+          remaining.iter().position(|e| expr_to_string(e) == ev_str)
         {
           remaining.remove(pos);
         } else {
@@ -253,7 +252,7 @@ pub fn same_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // arguments (e.g. comparing the steps of NestWhileList[f, x, UnsameQ, 2]),
   // turns each comparison into a costly re-traversal.
   let first = &args[0];
-  let first_str = crate::syntax::expr_to_string(first);
+  let first_str = expr_to_string(first);
 
   for arg in args.iter().skip(1) {
     // `expr_to_string` reports every `Image[…]` as the same `-Image-`
@@ -267,7 +266,7 @@ pub fn same_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       continue;
     }
-    let val_str = crate::syntax::expr_to_string(arg);
+    let val_str = expr_to_string(arg);
     if val_str != first_str && !same_q_real_bigfloat(first, arg) {
       return Ok(bool_expr(false));
     }
@@ -378,8 +377,7 @@ pub fn unsame_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // placeholder, so that string fast path would treat any two images as
   // identical regardless of their pixel data — compare those pairs
   // structurally instead.
-  let strs: Vec<String> =
-    args.iter().map(crate::syntax::expr_to_string).collect();
+  let strs: Vec<String> = args.iter().map(expr_to_string).collect();
 
   // UnsameQ is True only if ALL pairs are different
   for i in 0..strs.len() {
@@ -556,7 +554,7 @@ pub fn all_components_equal(a: &Expr, b: &Expr) -> bool {
       if let (Some(va), Some(vb)) = (try_eval_to_f64(a), try_eval_to_f64(b)) {
         va == vb
       } else {
-        crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+        expr_to_string(a) == expr_to_string(b)
       }
     }
   }
@@ -597,7 +595,7 @@ pub fn infinity_equal_verdict(a: &Expr, b: &Expr) -> Option<Option<bool>> {
       Expr::FunctionCall { name, args } if name == "DirectedInfinity" => {
         match args.len() {
           0 => Some(None),
-          1 => Some(Some(crate::syntax::expr_to_string(&args[0]))),
+          1 => Some(Some(expr_to_string(&args[0]))),
           _ => None,
         }
       }
@@ -675,7 +673,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   use crate::functions::math_ast::try_eval_to_f64;
 
-  let first_str = crate::syntax::expr_to_string(&args[0]);
+  let first_str = expr_to_string(&args[0]);
   let mut all_identical = true;
 
   for arg in args.iter().skip(1) {
@@ -692,7 +690,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       continue;
     }
-    let val_str = crate::syntax::expr_to_string(arg);
+    let val_str = expr_to_string(arg);
     if val_str != first_str {
       all_identical = false;
       break;
@@ -850,8 +848,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   use crate::functions::math_ast::try_eval_to_f64;
 
-  let strs: Vec<String> =
-    args.iter().map(crate::syntax::expr_to_string).collect();
+  let strs: Vec<String> = args.iter().map(expr_to_string).collect();
   let has_free = args.iter().any(crate::evaluator::has_free_symbols);
 
   // For symbolic chains, Wolfram only collapses Unequal to False when an
@@ -983,9 +980,7 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(false) => not_ast(&[a]),
         None => {
           // Implies[a, a] → True.
-          if crate::syntax::expr_to_string(&a)
-            == crate::syntax::expr_to_string(&b)
-          {
+          if expr_to_string(&a) == expr_to_string(&b) {
             Ok(bool_expr(true))
           } else {
             Ok(call("Implies", vec![a, b]))
@@ -1081,7 +1076,7 @@ pub fn equivalent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Duplicate operands are redundant (Equivalent[a, b, a] == Equivalent[a, b]),
   // matching wolframscript. Keep first-occurrence order.
   let mut seen = std::collections::HashSet::new();
-  remaining.retain(|e| seen.insert(crate::syntax::expr_to_string(e)));
+  remaining.retain(|e| seen.insert(expr_to_string(e)));
 
   // If we have both True and False, it's False
   if has_true && has_false {
@@ -1271,17 +1266,11 @@ fn dnf_literal(e: &Expr) -> (String, bool, Expr) {
     Expr::UnaryOp {
       op: UnaryOperator::Not,
       operand,
-    } => (
-      crate::syntax::expr_to_string(operand),
-      false,
-      (**operand).clone(),
-    ),
-    Expr::FunctionCall { name, args } if name == "Not" && args.len() == 1 => (
-      crate::syntax::expr_to_string(&args[0]),
-      false,
-      args[0].clone(),
-    ),
-    _ => (crate::syntax::expr_to_string(e), true, e.clone()),
+    } => (expr_to_string(operand), false, (**operand).clone()),
+    Expr::FunctionCall { name, args } if name == "Not" && args.len() == 1 => {
+      (expr_to_string(&args[0]), false, args[0].clone())
+    }
+    _ => (expr_to_string(e), true, e.clone()),
   }
 }
 
@@ -1825,7 +1814,7 @@ fn is_tautological_clause(clause: &Expr) -> bool {
 
 /// Simple structural equality check for expressions
 fn expr_eq(a: &Expr, b: &Expr) -> bool {
-  crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+  expr_to_string(a) == expr_to_string(b)
 }
 
 /// Distribute Or over And to achieve CNF (AND of ORs).
@@ -2202,13 +2191,13 @@ pub fn boolean_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Expr::FunctionCall { name, args }
           if name == "Not" && args.len() == 1 =>
         {
-          (vec![crate::syntax::expr_to_string(&args[0])], vec![0])
+          (vec![expr_to_string(&args[0])], vec![0])
         }
         Expr::UnaryOp {
           op: UnaryOperator::Not,
           operand,
-        } => (vec![crate::syntax::expr_to_string(operand)], vec![0]),
-        _ => (vec![crate::syntax::expr_to_string(e)], vec![1]),
+        } => (vec![expr_to_string(operand)], vec![0]),
+        _ => (vec![expr_to_string(e)], vec![1]),
       }
     }
     match expr {
@@ -2317,12 +2306,12 @@ fn reduce_cnf_clauses(expr: &Expr) -> Expr {
         Expr::FunctionCall { name, args }
           if name == "Not" && args.len() == 1 =>
         {
-          (true, crate::syntax::expr_to_string(&args[0]))
+          (true, expr_to_string(&args[0]))
         }
         Expr::UnaryOp {
           op: UnaryOperator::Not,
           operand,
-        } => (true, crate::syntax::expr_to_string(operand)),
+        } => (true, expr_to_string(operand)),
         Expr::Identifier(name) => (false, name.clone()),
         _ => return None,
       };
@@ -3016,10 +3005,7 @@ fn greedy_cover(primes: &[Implicant], minterms: &[u64]) -> Vec<Implicant> {
 /// The variables are given as expressions rather than names because
 /// `BooleanFunction[k, n, vars]` accepts any expression per position (a
 /// Demonstration typically passes styled labels), not just symbols.
-fn implicants_to_expr(
-  implicants: &[Implicant],
-  vars: &[Expr],
-) -> crate::syntax::Expr {
+fn implicants_to_expr(implicants: &[Implicant], vars: &[Expr]) -> Expr {
   if implicants.is_empty() {
     return bool_expr(false);
   }
@@ -3125,10 +3111,7 @@ pub fn boolean_counting_function_ast(
     crate::emit_message(&format!(
       "BooleanCountingFunction::bspec: {} is not a valid \
        BooleanCountingFunction specification.",
-      crate::syntax::expr_to_output(&unevaluated(
-        "BooleanCountingFunction",
-        args
-      ))
+      expr_to_output(&unevaluated("BooleanCountingFunction", args))
     ));
     return Ok(unevaluated("BooleanCountingFunction", args));
   }
@@ -3452,11 +3435,7 @@ pub fn vector_less_equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(vector_compare_ast(args, "VectorLessEqual", true))
 }
 
-fn vector_compare_ast(
-  args: &[Expr],
-  name: &str,
-  allow_equal: bool,
-) -> crate::syntax::Expr {
+fn vector_compare_ast(args: &[Expr], name: &str, allow_equal: bool) -> Expr {
   // VectorLess/VectorLessEqual takes exactly 1 argument: a list of vectors/scalars
   if args.len() != 1 {
     return unevaluated(name, args);
@@ -3628,7 +3607,7 @@ pub fn boolean_variables_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Resolve the variable list for the 1- or 2-argument satisfiability forms.
-fn satisfiability_vars(args: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
+fn satisfiability_vars(args: &[Expr]) -> std::vec::Vec<Expr> {
   if args.len() == 2 {
     match &args[1] {
       Expr::List(items) => items.iter().cloned().collect(),
@@ -3999,7 +3978,7 @@ pub fn unate_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return unevaluated();
   }
   // Which variable positions to test for positive unateness.
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let checked: Vec<usize> = match args.get(1) {
     None => (0..n).collect(),
     Some(Expr::List(sel)) => sel

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -68,7 +68,7 @@ pub fn d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           crate::emit_message(&format!(
             "D::optx: Unknown option {} in {}.",
             opt,
-            crate::syntax::expr_to_output(&unevaluated())
+            expr_to_output(&unevaluated())
           ));
           return Ok(unevaluated());
         }
@@ -10632,7 +10632,7 @@ fn bounded_trig_extremum(
   // 1/Abs[Sin[g]] — the reciprocal of something that gets arbitrarily close
   // to 0 while never exceeding 1.
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = expr
@@ -18829,7 +18829,7 @@ fn limit_resolved(e: &Expr) -> bool {
 /// division is put through the evaluator before the limit is taken.
 fn ratio(f: &Expr, g: &Expr) -> Expr {
   let quotient = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(f.clone()),
     right: Box::new(g.clone()),
   };
@@ -18937,7 +18937,7 @@ pub fn asymptotic_comparison_ast(
     crate::emit_message(&format!(
       "{}::lim: Limit specification {} is not of the form x -> x0.",
       name,
-      crate::syntax::expr_to_output(rule)
+      expr_to_output(rule)
     ));
     return Ok(original());
   };

--- a/src/functions/cellular_automaton_ast.rs
+++ b/src/functions/cellular_automaton_ast.rs
@@ -70,7 +70,7 @@ pub fn cellular_automaton_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Some(rule) = parse_rule(&args[0]) else {
     crate::emit_message(&format!(
       "CellularAutomaton::nspecnl: Rule specification {} should be an Integer, a List, a pure Boolean function, a String or an Association.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return unevaluated();
   };

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -498,7 +498,7 @@ pub(crate) fn expr_to_label(e: &Expr) -> Option<String> {
     Expr::String(s) => Some(s.clone()),
     Expr::Identifier(s) => Some(s.clone()),
     Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_) => {
-      Some(crate::syntax::expr_to_string(e))
+      Some(expr_to_string(e))
     }
     // A styled label reads as its content — a Demonstration writes its
     // frame labels as `Style["force (kN)", 12]`. The same holds for the
@@ -3812,7 +3812,7 @@ pub fn word_cloud_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let ev = evaluate_expr_to_expr(item).unwrap_or(item.clone());
     match &ev {
       Expr::String(s) => words.push(s.clone()),
-      _ => words.push(crate::syntax::expr_to_string(&ev)),
+      _ => words.push(expr_to_string(&ev)),
     }
   }
 

--- a/src/functions/code_parser.rs
+++ b/src/functions/code_parser.rs
@@ -18,7 +18,7 @@
 //! `ErrorNode` the abstract tree is expected to carry, positioned where the
 //! reader gave up.
 
-use crate::syntax::Expr;
+use super::*;
 
 /// How a node reports the piece of source it came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/functions/confirm_ast.rs
+++ b/src/functions/confirm_ast.rs
@@ -113,7 +113,7 @@ pub fn is_confirmation_throw(tag: &Option<Box<Expr>>) -> bool {
 pub fn confirm_failure(value: &Expr, information: Expr) -> Expr {
   let has_info = !matches!(&information, Expr::Identifier(s) if s == "Null");
   let (template, parameters) = if has_info {
-    (crate::syntax::expr_to_output(&information), Vec::new())
+    (expr_to_output(&information), Vec::new())
   } else {
     ("`` encountered.".to_string(), vec![value.clone()])
   };
@@ -246,7 +246,7 @@ fn fill_template(template: &str, parameters: &[Expr]) -> String {
   while let Some(at) = rest.find("``") {
     out.push_str(&rest[..at]);
     match next.next() {
-      Some(p) => out.push_str(&crate::syntax::expr_to_output(p)),
+      Some(p) => out.push_str(&expr_to_output(p)),
       None => out.push_str("``"),
     }
     rest = &rest[at + 2..];
@@ -343,7 +343,7 @@ fn untagged_exception(spec: &Expr) -> Expr {
     "Exception::untagged: The construction of the untagged exception from \
      general expression {} is not supported. Please provide some exception \
      tag.",
-    crate::syntax::expr_to_output(spec)
+    expr_to_output(spec)
   ));
   let pairs: Vec<(Expr, Expr)> = vec![
     (string("ErrorType"), string("UnttaggedExceptionPayload")),
@@ -414,10 +414,9 @@ pub fn exception_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let Expr::List(tags) = &eargs[0] else {
       unreachable!("checked by is_canonical_exception")
     };
-    ok = tags.iter().any(|t| {
-      crate::syntax::expr_to_string(t)
-        == crate::syntax::expr_to_string(&args[1])
-    });
+    ok = tags
+      .iter()
+      .any(|t| expr_to_string(t) == expr_to_string(&args[1]));
   }
   Ok(Expr::Identifier(
     if ok { "True" } else { "False" }.to_string(),

--- a/src/functions/control_flow_ast.rs
+++ b/src/functions/control_flow_ast.rs
@@ -25,7 +25,7 @@ pub fn switch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Evaluate the test expression
   let test = evaluate_expr_to_expr(&args[0])?;
-  let test_str = crate::syntax::expr_to_string(&test);
+  let test_str = expr_to_string(&test);
 
   // Iterate pattern-value pairs (the argument list is odd, so `rest` is even
   // and every pattern has a value — there is no leftover default argument).
@@ -404,11 +404,7 @@ fn do_trace(
       // Each step is printed wrapped in HoldCompleteForm, the same way
       // TraceScan's steps reach the scanning function wrapped in HoldForm.
       let wrapped = call1("HoldCompleteForm", expr.clone());
-      let line = format!(
-        "{}{}",
-        " ".repeat(depth),
-        crate::syntax::expr_to_output(&wrapped)
-      );
+      let line = format!("{}{}", " ".repeat(depth), expr_to_output(&wrapped));
       if !crate::is_quiet_print() {
         println!("{line}");
       }

--- a/src/functions/convex_hull.rs
+++ b/src/functions/convex_hull.rs
@@ -36,7 +36,7 @@ pub fn convex_hull_mesh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(convex_hull_mesh_2d(pts, args))
 }
 
-fn convex_hull_mesh_2d(pts: &[Expr], args: &[Expr]) -> crate::syntax::Expr {
+fn convex_hull_mesh_2d(pts: &[Expr], args: &[Expr]) -> Expr {
   // Parse points, keeping the original coordinate expressions (to preserve
   // exact display) and tracking whether every coordinate is exact.
   let mut coords: Vec<(f64, f64)> = Vec::new();

--- a/src/functions/datetime_ast.rs
+++ b/src/functions/datetime_ast.rs
@@ -1302,14 +1302,14 @@ pub fn time_zone_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "TimeZoneConvert::nodobj: First argument {} in TimeZoneConvert is not a DateObject.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   };
   if dname != "DateObject" || dargs.is_empty() {
     crate::emit_message(&format!(
       "TimeZoneConvert::nodobj: First argument {} in TimeZoneConvert is not a DateObject.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   }
@@ -1364,7 +1364,7 @@ pub fn time_zone_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Some(target_display) = tz_display(&target_tz) else {
     crate::emit_message(&format!(
       "DateObject::zone: Time zone specification {} should be a real number, integer or time zone string.",
-      crate::syntax::expr_to_output(&target_tz)
+      expr_to_output(&target_tz)
     ));
     return unevaluated();
   };
@@ -1414,7 +1414,7 @@ pub fn time_zone_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Some(target_offset) = zone_offset_hours(&target_tz, &utc, false) else {
     crate::emit_message(&format!(
       "DateObject::zone: Time zone specification {} should be a real number, integer or time zone string.",
-      crate::syntax::expr_to_output(&target_tz)
+      expr_to_output(&target_tz)
     ));
     return unevaluated();
   };
@@ -1771,7 +1771,7 @@ fn quantity_increment_text(magnitude: &Expr, unit: &str) -> String {
   } else {
     format!("{unit_lower}s")
   };
-  format!("{} {}", crate::syntax::expr_to_string(magnitude), word)
+  format!("{} {}", expr_to_string(magnitude), word)
 }
 
 fn make_date_result(
@@ -2044,11 +2044,7 @@ pub fn date_difference_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   ))
 }
 
-fn date_difference_multi_unit(
-  c1: &[f64],
-  c2: &[f64],
-  units: &Expr,
-) -> crate::syntax::Expr {
+fn date_difference_multi_unit(c1: &[f64], c2: &[f64], units: &Expr) -> Expr {
   // Multi-unit decomposition like {"Week", "Day"} → MixedMagnitude[{9, 6}].
   // Walk the unit list largest-to-smallest, taking the integer part of each
   // bucket and passing the remainder down. Returns the unevaluated form for
@@ -2498,8 +2494,8 @@ pub fn day_name_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let call = unevaluated("DayName", args);
     crate::emit_message(&format!(
       "DayName::nonopt: Options expected (instead of {}) beyond position 1 in {}. An option must be a rule or a list of rules.",
-      crate::syntax::expr_to_string(bad),
-      crate::syntax::expr_to_string(&call)
+      expr_to_string(bad),
+      expr_to_string(&call)
     ));
     return Ok(call);
   }
@@ -4270,7 +4266,7 @@ pub fn date_within_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let arg_error = |e: &Expr| {
     crate::emit_message(&format!(
       "DateWithinQ::arg: Argument {} is not a valid date object expression.",
-      crate::syntax::expr_to_output(e)
+      expr_to_output(e)
     ));
   };
   let Some((s1, e1)) = span(&args[0]) else {
@@ -4492,7 +4488,7 @@ pub fn date_overlaps_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let arg_error = |e: &Expr| {
     crate::emit_message(&format!(
       "DateOverlapsQ::arg: Argument {} is not a valid date object expression.",
-      crate::syntax::expr_to_output(e)
+      expr_to_output(e)
     ));
   };
   let (Some(a), Some(b)) = (spans(&args[0]), spans(&args[1])) else {
@@ -4554,7 +4550,7 @@ pub fn from_julian_date_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "FromJulianDate::arg: Argument {} cannot be interpreted as a Julian date input.",
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       ));
       return unevaluated();
     }

--- a/src/functions/dendrogram.rs
+++ b/src/functions/dendrogram.rs
@@ -240,7 +240,7 @@ fn parse_data(arg: &Expr) -> Option<(Vec<Expr>, Vec<String>)> {
 fn expr_to_label(expr: &Expr) -> String {
   match expr {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_output(other),
+    other => expr_to_output(other),
   }
 }
 

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -33,7 +33,7 @@ pub fn dirichlet_character_ast(
   if j <= 0 {
     crate::emit_message(&format!(
       "DirichletCharacter::intp: Positive integer expected at position 2 in {}.",
-      crate::syntax::expr_to_string(&unevaluated(args))
+      expr_to_string(&unevaluated(args))
     ));
     return Ok(unevaluated(args));
   }
@@ -42,7 +42,7 @@ pub fn dirichlet_character_ast(
     crate::emit_message(&format!(
       "DirichletCharacter::invl: Argument {} at position 2 in {} should be a positive integer less than or equal to {}.",
       j,
-      crate::syntax::expr_to_string(&unevaluated(args)),
+      expr_to_string(&unevaluated(args)),
       phi
     ));
     return Ok(unevaluated(args));
@@ -357,7 +357,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if j <= 0 {
     crate::emit_message(&format!(
       "DirichletL::intp: Positive integer expected at position 2 in {}.",
-      crate::syntax::expr_to_string(&unevaluated(args))
+      expr_to_string(&unevaluated(args))
     ));
     return Ok(unevaluated(args));
   }
@@ -366,7 +366,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "DirichletL::invl: Argument {} at position 2 in {} should be a positive integer less than or equal to {}.",
       j,
-      crate::syntax::expr_to_string(&unevaluated(args)),
+      expr_to_string(&unevaluated(args)),
       phi
     ));
     return Ok(unevaluated(args));

--- a/src/functions/entity_ast.rs
+++ b/src/functions/entity_ast.rs
@@ -633,7 +633,7 @@ pub fn entity_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-fn entity_list_for_type(type_name: &str) -> crate::syntax::Expr {
+fn entity_list_for_type(type_name: &str) -> Expr {
   if !is_type_registered(type_name) {
     if type_name == "Country" {
       return Expr::List(
@@ -680,10 +680,7 @@ fn entity_list_for_type(type_name: &str) -> crate::syntax::Expr {
   Expr::List(entities.into())
 }
 
-fn entity_list_for_class(
-  type_name: &str,
-  class_name: &str,
-) -> crate::syntax::Expr {
+fn entity_list_for_class(type_name: &str, class_name: &str) -> Expr {
   if !is_type_registered(type_name) {
     return Expr::FunctionCall {
       name: "Missing".to_string(),
@@ -724,7 +721,7 @@ fn entity_list_for_class(
   Expr::List(entities.into())
 }
 
-fn entity_count_for_type(type_name: &str) -> crate::syntax::Expr {
+fn entity_count_for_type(type_name: &str) -> Expr {
   if !is_type_registered(type_name) {
     if type_name == "Country" {
       return Expr::Integer(
@@ -825,7 +822,7 @@ pub fn entity_properties_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-fn entity_properties_for_type(type_name: &str) -> crate::syntax::Expr {
+fn entity_properties_for_type(type_name: &str) -> Expr {
   if !is_type_registered(type_name) {
     return Expr::FunctionCall {
       name: "Missing".to_string(),

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1,6 +1,5 @@
 use plotters::prelude::{Color, *};
 
-#[allow(unused_imports)]
 use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::graphics::{Color as GfxColor, parse_color};
@@ -1375,7 +1374,7 @@ pub(crate) fn equation_zero_body(e: &Expr) -> Option<Expr> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       (&operands[0], &operands[1])
     }
@@ -1385,7 +1384,7 @@ pub(crate) fn equation_zero_body(e: &Expr) -> Option<Expr> {
     _ => return None,
   };
   Some(Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(lhs.clone()),
     right: Box::new(rhs.clone()),
   })

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -115,7 +115,7 @@ fn magnitude_in_unit(expr: &Expr, target_unit: &str) -> Option<f64> {
   // may be stored as a String (`"AngularDegrees"`) or a symbol.
   let unit_name = match &args[1] {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_string(other),
+    other => expr_to_string(other),
   };
   if unit_name == target_unit {
     return crate::functions::graphics::expr_to_f64(&args[0]);
@@ -498,7 +498,7 @@ pub fn dms_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(_) => {
       crate::emit_message(&format!(
         "DMSString::num: {} cannot be interpreted as a numerical angle specification.",
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       ));
       return unevaluated();
     }
@@ -536,7 +536,7 @@ pub fn dms_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         _ => {
           crate::emit_message(&format!(
             "DMSString::dms: {} cannot be interpreted as a degree-minute-second list specification.",
-            crate::syntax::expr_to_output(&args[0])
+            expr_to_output(&args[0])
           ));
           unevaluated()
         }
@@ -554,7 +554,7 @@ pub fn dms_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       crate::emit_message(&format!(
         "DMSString::ang: {} cannot be interpreted as a degree-minute-second angle specification.",
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       ));
       unevaluated()
     }
@@ -564,7 +564,7 @@ pub fn dms_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } else {
         crate::emit_message(&format!(
           "DMSString::ang: {} cannot be interpreted as a degree-minute-second angle specification.",
-          crate::syntax::expr_to_output(other)
+          expr_to_output(other)
         ));
         unevaluated()
       }
@@ -614,8 +614,7 @@ mod tests {
     let list = |a: i128, b: i128| {
       Expr::List(vec![Expr::Integer(a), Expr::Integer(b)].into())
     };
-    let render =
-      |e: Expr| crate::syntax::expr_to_string(&geo_antipode_ast(&[e]).unwrap());
+    let render = |e: Expr| expr_to_string(&geo_antipode_ast(&[e]).unwrap());
     // Western longitude shifts east, exact integers preserved.
     assert_eq!(render(list(40, -100)), "{-40, 80}");
     // Longitude 0 maps to 180 (the boundary stays positive).

--- a/src/functions/geographics.rs
+++ b/src/functions/geographics.rs
@@ -1606,7 +1606,7 @@ fn geographics_impl(
   content: &Expr,
   opt_args: &[Expr],
   legend: Option<Legend>,
-) -> crate::syntax::Expr {
+) -> Expr {
   // Options: ImageSize (width), GeoRange, GeoProjection, GeoGridLines.
   let mut width = 360.0_f64;
   let mut range = GeoRange::Auto;

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -1831,10 +1831,7 @@ pub fn graph_reciprocity(edges: &[Expr]) -> Option<Expr> {
     return None; // mixed graph
   }
   let key = |u: &Expr, v: &Expr, directed: bool| -> (String, String) {
-    let (ku, kv) = (
-      crate::syntax::expr_to_string(u),
-      crate::syntax::expr_to_string(v),
-    );
+    let (ku, kv) = (expr_to_string(u), expr_to_string(v));
     if directed || ku <= kv {
       (ku, kv)
     } else {
@@ -1853,10 +1850,7 @@ pub fn graph_reciprocity(edges: &[Expr]) -> Option<Expr> {
   let reciprocated = parsed
     .iter()
     .filter(|(u, v, _)| {
-      let (ku, kv) = (
-        crate::syntax::expr_to_string(u),
-        crate::syntax::expr_to_string(v),
-      );
+      let (ku, kv) = (expr_to_string(u), expr_to_string(v));
       ku == kv || dir_set.contains(&(kv, ku))
     })
     .count();
@@ -1879,15 +1873,15 @@ pub fn graph_disjoint_union(graphs: &[(&[Expr], &[Expr])]) -> Expr {
     let mut label: HashMap<String, i128> = HashMap::new();
     for (j, v) in verts.iter().enumerate() {
       let new_id = (offset + j + 1) as i128;
-      label.insert(crate::syntax::expr_to_string(v), new_id);
+      label.insert(expr_to_string(v), new_id);
       new_vertices.push(Expr::Integer(new_id));
     }
     for e in *edges {
       match edge_endpoints(e) {
         Some((u, v, directed)) => {
           match (
-            label.get(&crate::syntax::expr_to_string(&u)),
-            label.get(&crate::syntax::expr_to_string(&v)),
+            label.get(&expr_to_string(&u)),
+            label.get(&expr_to_string(&v)),
           ) {
             (Some(&nu), Some(&nv)) => {
               // Undirected endpoints are stored canonically as (min, max).
@@ -2517,7 +2511,7 @@ pub fn undirected_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let not_a_graph = || {
     crate::emit_message(&format!(
       "UndirectedGraph::graph: A graph object is expected at position 1 in {}.",
-      crate::syntax::expr_to_string(&unevaluated())
+      expr_to_string(&unevaluated())
     ));
     Ok(unevaluated())
   };
@@ -3547,7 +3541,7 @@ pub fn transitive_closure_graph_ast(
     _ => return Ok(unevaluated(args)),
   };
 
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -3649,7 +3643,7 @@ pub fn transitive_reduction_graph_ast(
     _ => return Ok(unevaluated(args)),
   };
 
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -3733,7 +3727,7 @@ pub fn reverse_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let not_a_graph = || {
     crate::emit_message(&format!(
       "ReverseGraph::graph: A graph object is expected at position 1 in {}.",
-      crate::syntax::expr_to_string(&unevaluated())
+      expr_to_string(&unevaluated())
     ));
     Ok(unevaluated())
   };
@@ -3754,7 +3748,7 @@ pub fn reverse_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return not_a_graph(),
   };
 
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -3813,7 +3807,7 @@ pub fn directed_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let not_a_graph = || {
     crate::emit_message(&format!(
       "DirectedGraph::graph: A graph object is expected at position 1 in {}.",
-      crate::syntax::expr_to_string(&unevaluated())
+      expr_to_string(&unevaluated())
     ));
     Ok(unevaluated())
   };
@@ -3834,7 +3828,7 @@ pub fn directed_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return not_a_graph(),
   };
 
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -3922,7 +3916,7 @@ pub fn find_independent_vertex_set_ast(
   if n == 0 || n > 64 {
     return Ok(unevaluated(args));
   }
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -4008,7 +4002,7 @@ pub fn vertex_component_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => return Ok(unevaluated(args)),
   };
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -4050,7 +4044,7 @@ pub fn vertex_component_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "VertexComponent::inv: The argument {} in {} is not a valid vertex.",
         key(seed),
-        crate::syntax::expr_to_string(&call(
+        expr_to_string(&call(
           "VertexComponent",
           vec![graph.clone(), args[1].clone()]
         ))
@@ -4122,7 +4116,7 @@ pub fn vertex_reach_component_ast(
     _ => return Ok(unevaluated()),
   };
 
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let index: std::collections::HashMap<String, usize> = vertices
     .iter()
     .enumerate()
@@ -4168,10 +4162,7 @@ pub fn vertex_reach_component_ast(
         "{}::inv: The argument {} in {} is not a valid vertex.",
         name,
         key(seed),
-        crate::syntax::expr_to_string(&call(
-          name,
-          vec![graph.clone(), args[1].clone()]
-        ))
+        expr_to_string(&call(name, vec![graph.clone(), args[1].clone()]))
       ));
       return Ok(unevaluated());
     }
@@ -4234,7 +4225,7 @@ pub fn weighted_adjacency_graph_ast(
     None => (1..=n as i128).map(Expr::Integer).collect(),
   };
   let is_edge = |e: &Expr| !matches!(e, Expr::Identifier(s) if s == "Infinity");
-  let key = |e: &Expr| crate::syntax::expr_to_string(e);
+  let key = |e: &Expr| expr_to_string(e);
   let symmetric =
     (0..n).all(|i| (0..n).all(|j| key(&rows[i][j]) == key(&rows[j][i])));
 
@@ -4515,7 +4506,7 @@ pub fn nearest_neighbor_graph_ast(
     _ => {
       crate::emit_message(&format!(
         "NearestNeighborGraph::list: List expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(args))
+        expr_to_string(&unevaluated(args))
       ));
       return Ok(unevaluated(args));
     }
@@ -5491,7 +5482,7 @@ pub fn kirchhoff_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let not_square = || {
     crate::emit_message(&format!(
       "KirchhoffGraph::matsq: Argument {} at position {} is not a nonempty square matrix.",
-      crate::syntax::expr_to_output(matrix_expr),
+      expr_to_output(matrix_expr),
       matrix_pos
     ));
     Ok(unevaluated())
@@ -5499,11 +5490,8 @@ pub fn kirchhoff_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let invalid = || {
     crate::emit_message(&format!(
       "KirchhoffGraph::inv: The argument {} in {} is not a valid Kirchhoff matrix.",
-      crate::syntax::expr_to_output(matrix_expr),
-      crate::syntax::expr_to_string(&call(
-        "KirchhoffGraph",
-        vec![matrix_expr.clone()]
-      ))
+      expr_to_output(matrix_expr),
+      expr_to_string(&call("KirchhoffGraph", vec![matrix_expr.clone()]))
     ));
     Ok(unevaluated())
   };
@@ -5593,7 +5581,7 @@ pub fn incidence_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let not_a_matrix = || {
     crate::emit_message(&format!(
       "IncidenceGraph::matrix: Argument {} at position {} is not a nonempty rectangular matrix.",
-      crate::syntax::expr_to_output(matrix_expr),
+      expr_to_output(matrix_expr),
       matrix_pos
     ));
     Ok(unevaluated())
@@ -5601,8 +5589,8 @@ pub fn incidence_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let invalid = || {
     crate::emit_message(&format!(
       "IncidenceGraph::inv: The argument {} in {} is not a valid incidence matrix.",
-      crate::syntax::expr_to_output(matrix_expr),
-      crate::syntax::expr_to_string(&unevaluated())
+      expr_to_output(matrix_expr),
+      expr_to_string(&unevaluated())
     ));
     Ok(unevaluated())
   };
@@ -7249,9 +7237,7 @@ fn same_edge(a: &Expr, b: &Expr) -> bool {
   let Some((b1, b2, b_directed)) = edge_endpoints(b) else {
     return false;
   };
-  let eq = |x: &Expr, y: &Expr| {
-    crate::syntax::expr_to_string(x) == crate::syntax::expr_to_string(y)
-  };
+  let eq = |x: &Expr, y: &Expr| expr_to_string(x) == expr_to_string(y);
   (eq(&a1, &b1) && eq(&a2, &b2))
     || (!a_directed && !b_directed && eq(&a1, &b2) && eq(&a2, &b1))
 }
@@ -7288,19 +7274,19 @@ pub fn vertex_replace_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return Ok(original()),
   };
   let rename = |v: &Expr| -> Expr {
-    let key = crate::syntax::expr_to_string(v);
+    let key = expr_to_string(v);
     rules
       .iter()
-      .find(|(from, _)| crate::syntax::expr_to_string(from) == key)
+      .find(|(from, _)| expr_to_string(from) == key)
       .map_or_else(|| v.clone(), |(_, to)| to.clone())
   };
   let mut new_vertices: Vec<Expr> = Vec::with_capacity(vertices.len());
   for v in &vertices {
     let renamed = rename(v);
-    let key = crate::syntax::expr_to_string(&renamed);
+    let key = expr_to_string(&renamed);
     if !new_vertices
       .iter()
-      .any(|existing| crate::syntax::expr_to_string(existing) == key)
+      .any(|existing| expr_to_string(existing) == key)
     {
       new_vertices.push(renamed);
     }
@@ -7462,9 +7448,7 @@ fn value_fallback(value: &Expr) -> Option<Expr> {
 /// Whether `item` is the vertex or edge the rule on the left names.
 fn names_item(lhs: &Expr, item: &Expr, scope: Scope) -> bool {
   match scope {
-    Scope::Vertex => {
-      crate::syntax::expr_to_string(lhs) == crate::syntax::expr_to_string(item)
-    }
+    Scope::Vertex => expr_to_string(lhs) == expr_to_string(item),
     Scope::Edge => same_edge(lhs, item),
   }
 }
@@ -7476,9 +7460,10 @@ fn item_position(
   edges: &[Expr],
   item: &Expr,
 ) -> Option<(Scope, usize)> {
-  if let Some(i) = vertices.iter().position(|v| {
-    crate::syntax::expr_to_string(v) == crate::syntax::expr_to_string(item)
-  }) {
+  if let Some(i) = vertices
+    .iter()
+    .position(|v| expr_to_string(v) == expr_to_string(item))
+  {
     return Some((Scope::Vertex, i));
   }
   edges
@@ -7680,7 +7665,7 @@ pub fn graph_annotation_keys_ast(
   let Some((vertices, edges, options)) = graph_parts(graph) else {
     crate::emit_message(&format!(
       "AnnotationKeys::pvobj: {} is not an object with annotations.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(original());
   };
@@ -7768,7 +7753,7 @@ pub fn graph_annotation_delete_ast(
   let Some((vertices, edges, options)) = graph_parts(graph) else {
     crate::emit_message(&format!(
       "AnnotationDelete::pvobj: {} is not an object with annotations.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(original());
   };
@@ -7878,9 +7863,9 @@ pub fn graph_set_property_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .collect();
   if let Some(item) = item {
     let index = if property.starts_with("Vertex") {
-      vertices.iter().position(|v| {
-        crate::syntax::expr_to_string(v) == crate::syntax::expr_to_string(item)
-      })
+      vertices
+        .iter()
+        .position(|v| expr_to_string(v) == expr_to_string(item))
     } else {
       edges.iter().position(|e| same_edge(e, item))
     };
@@ -7917,9 +7902,9 @@ pub fn graph_options_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let name_of = |o: &Expr| match o {
     Expr::Rule { pattern, .. } => match pattern.as_ref() {
       Expr::Identifier(s) => s.clone(),
-      other => crate::syntax::expr_to_string(other),
+      other => expr_to_string(other),
     },
-    other => crate::syntax::expr_to_string(other),
+    other => expr_to_string(other),
   };
   options.sort_by(|a, b| {
     crate::functions::list_helpers_ast::sorting::wolfram_string_order(
@@ -8081,10 +8066,10 @@ pub fn edge_tagged_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(original());
     };
     for v in [&a, &b] {
-      let key = crate::syntax::expr_to_string(v);
+      let key = expr_to_string(v);
       if !vertices
         .iter()
-        .any(|existing| crate::syntax::expr_to_string(existing) == key)
+        .any(|existing| expr_to_string(existing) == key)
       {
         vertices.push((*v).clone());
       }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{DEFAULT_HEIGHT, DEFAULT_WIDTH, parse_image_size};
-use crate::syntax::expr_to_output;
 
 /// Dash length for the "Small" named size in Dashing directives.
 /// This is the default dash segment length used by Dashed, Dotted, etc.
@@ -3054,14 +3053,14 @@ fn graphics_text_content(expr: &Expr) -> String {
       if (name == "Subscript" || name == "Superscript") && args.len() >= 2 =>
     {
       crate::functions::chart::expr_to_label(expr)
-        .unwrap_or_else(|| crate::syntax::expr_to_string(expr))
+        .unwrap_or_else(|| expr_to_string(expr))
     }
     _ => {
       let text = match crate::functions::string_ast::to_string_ast(
         std::slice::from_ref(expr),
       ) {
         Ok(Expr::String(ref s)) => s.clone(),
-        _ => crate::syntax::expr_to_string(expr),
+        _ => expr_to_string(expr),
       };
       typeset_constants_in_text(&text)
     }
@@ -8816,13 +8815,13 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
             elements,
           };
         }
-        let text = crate::syntax::expr_to_output(expr);
+        let text = expr_to_output(expr);
         BoxLayout::text(&text, font_size)
       }
 
       // Unknown function: render as text
       _ => {
-        let text = crate::syntax::expr_to_output(expr);
+        let text = expr_to_output(expr);
         BoxLayout::text(&text, font_size)
       }
     },
@@ -8852,7 +8851,7 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
     }
 
     _ => {
-      let text = crate::syntax::expr_to_output(expr);
+      let text = expr_to_output(expr);
       BoxLayout::text(&text, font_size)
     }
   }
@@ -10614,7 +10613,7 @@ pub fn boxes_to_svg(expr: &Expr) -> String {
     }
 
     // Fallback: use expr_to_output for anything else
-    _ => svg_escape(&crate::syntax::expr_to_output(expr)),
+    _ => svg_escape(&expr_to_output(expr)),
   }
 }
 
@@ -10991,7 +10990,7 @@ pub fn estimate_box_display_width(expr: &Expr) -> f64 {
 
     Expr::List(items) => items.iter().map(estimate_box_display_width).sum(),
 
-    _ => crate::syntax::expr_to_output(expr).len() as f64,
+    _ => expr_to_output(expr).len() as f64,
   }
 }
 
@@ -11079,7 +11078,7 @@ fn merge_option(opts: &mut Vec<Expr>, opt: &Expr) {
 }
 
 /// Merge two PlotRange values by taking the union (min of mins, max of maxes).
-fn merge_plot_ranges(a: &Expr, b: &Expr) -> crate::syntax::Expr {
+fn merge_plot_ranges(a: &Expr, b: &Expr) -> Expr {
   let (ax, ay) = parse_plot_range(a);
   let (bx, by) = parse_plot_range(b);
 
@@ -17351,7 +17350,7 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // wolframscript's behavior.
         crate::emit_message(&format!(
           "Manipulate::vsform: Manipulate argument {} does not have the correct form for a variable specification.",
-          crate::syntax::expr_to_string(spec)
+          expr_to_string(spec)
         ));
         out_args.push(spec.clone());
       }
@@ -20936,7 +20935,7 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       _ => output_run(italic),
     },
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => script_runs(
@@ -20997,14 +20996,14 @@ fn directed_infinity_glyph(expr: &Expr) -> Option<&'static str> {
       matches!(args.first(), Some(Expr::Integer(n)) if *n < 0)
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     Expr::FunctionCall { name, args } if name == "Times" => {
       args.iter().any(|a| matches!(a, Expr::Integer(-1)))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -21031,7 +21030,7 @@ fn radical_radicand(expr: &Expr) -> Option<&Expr> {
         )
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left,
         right,
       } => {
@@ -21051,7 +21050,7 @@ fn radical_radicand(expr: &Expr) -> Option<&Expr> {
       args.first()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if is_one_half(right) => Some(left),
@@ -21066,7 +21065,7 @@ fn reciprocal_base(expr: &Expr) -> Option<&Expr> {
   // unevaluated expression, as a negated `1`.
   let is_minus_one = |e: &Expr| {
     matches!(e, Expr::Integer(-1))
-      || matches!(e, Expr::UnaryOp { op: crate::syntax::UnaryOperator::Minus, operand }
+      || matches!(e, Expr::UnaryOp { op: UnaryOperator::Minus, operand }
         if matches!(operand.as_ref(), Expr::Integer(1)))
   };
   match expr {
@@ -21076,7 +21075,7 @@ fn reciprocal_base(expr: &Expr) -> Option<&Expr> {
       args.first()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if is_minus_one(right) => Some(left),
@@ -21171,9 +21170,9 @@ fn contains_presentation_head(expr: &Expr) -> bool {
 /// are compound. The spellings match the OutputForm renderer this falls
 /// back to, so a label reads the same whichever path builds it.
 fn arithmetic_label_operator(
-  op: crate::syntax::BinaryOperator,
+  op: BinaryOperator,
 ) -> Option<(&'static str, bool)> {
-  use crate::syntax::BinaryOperator as Op;
+  use BinaryOperator as Op;
   Some(match op {
     Op::Plus => (" + ", false),
     Op::Minus => (" - ", false),
@@ -24314,7 +24313,7 @@ fn curve_order(name: &str, args: &[Expr], max_n: i128) -> Option<i128> {
         "{}::intpm: Positive machine-sized integer expected at position 1 in {}[{}].",
         name,
         name,
-        crate::syntax::expr_to_output(other)
+        expr_to_output(other)
       ));
       None
     }

--- a/src/functions/http_ast.rs
+++ b/src/functions/http_ast.rs
@@ -126,7 +126,7 @@ pub fn http_request_extract(func_args: &[Expr], arg: &Expr) -> Option<Expr> {
 fn emit_notprop(spec: &Expr, arg_count: usize) {
   let name = match spec {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_string(other),
+    other => expr_to_string(other),
   };
   crate::emit_message_to_stdout(&format!(
     "HTTPRequest::notprop: {name} is not a known property for \
@@ -527,7 +527,7 @@ fn apply_assoc_overrides(parts: &mut UrlParts, pairs: &[(Expr, Expr)]) {
 fn rule_side_to_string(expr: &Expr) -> String {
   match expr {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_string(other),
+    other => expr_to_string(other),
   }
 }
 
@@ -628,7 +628,7 @@ pub fn url_read_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
   for (name, value) in request_headers(assoc) {
     let value = match &value {
       Expr::String(s) => s.clone(),
-      other => crate::syntax::expr_to_string(other),
+      other => expr_to_string(other),
     };
     cmd.arg("-H").arg(format!("{name}: {value}"));
   }
@@ -898,7 +898,7 @@ pub fn url_parse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => {
       crate::emit_message(&format!(
         "URLParse::invuri: The URI {} is invalid.",
-        crate::syntax::expr_to_output(other)
+        expr_to_output(other)
       ));
       return unevaluated();
     }
@@ -1017,7 +1017,7 @@ pub fn url_parse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let invcomp = || {
     crate::emit_message(&format!(
       "URLParse::invcomp: The component specification {} is invalid.",
-      crate::syntax::expr_to_output(spec)
+      expr_to_output(spec)
     ));
   };
   match spec {

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -220,7 +220,7 @@ pub fn image_constructor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       let shown = match second {
         Expr::String(s) => s.clone(),
-        e => crate::syntax::expr_to_string(e),
+        e => expr_to_string(e),
       };
       crate::emit_message(&format!(
         "Image::imgdtype: The specified data type {shown} should be \"Bit\", \"Byte\", \"Bit16\", \"Real32\" or \"Real64\"."
@@ -236,7 +236,7 @@ pub fn image_constructor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if !matches!(opt, Expr::Rule { .. } | Expr::RuleDelayed { .. }) {
       return Err(InterpreterError::EvaluationError(format!(
         "Image: extra argument is not a Rule option: {}",
-        crate::syntax::expr_to_string(opt)
+        expr_to_string(opt)
       )));
     }
   }
@@ -336,7 +336,7 @@ pub fn image_constructor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let invalid = || {
     crate::emit_message(&format!(
       "Image::imgarray: The specified argument {} should be an array of rank 2 or 3 with machine-sized numbers.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   };
   let parsed = parse_image_array(raw_arg);
@@ -471,7 +471,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
   crate::functions::math_ast::try_eval_to_f64(expr).ok_or_else(|| {
     InterpreterError::EvaluationError(format!(
       "Image: expected a number, got {}",
-      crate::syntax::expr_to_string(expr)
+      expr_to_string(expr)
     ))
   })
 }
@@ -567,7 +567,7 @@ pub fn image_dimensions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // returning the unevaluated call.
   crate::emit_message(&format!(
     "ImageDimensions::imginv: Expecting an image or graphics instead of {}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ImageDimensions", args))
 }
@@ -645,7 +645,7 @@ pub fn image_aspect_ratio_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   crate::emit_message(&format!(
     "ImageAspectRatio::imginv: Expecting an image or graphics instead of {}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ImageAspectRatio", args))
 }
@@ -666,7 +666,7 @@ pub fn image_channels_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   crate::emit_message(&format!(
     "ImageChannels::imginv: Expecting an image or graphics instead of {}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ImageChannels", args))
 }
@@ -725,7 +725,7 @@ pub fn image_type_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   crate::emit_message(&format!(
     "ImageType::imginv: Expecting an image or graphics instead of {}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ImageType", args))
 }
@@ -867,7 +867,7 @@ pub fn image_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     crate::emit_message(&format!(
       "ImageData::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(unevaluated("ImageData", args))
   }
@@ -903,7 +903,7 @@ pub fn pixel_value_positions_ast(
   else {
     crate::emit_message(&format!(
       "PixelValuePositions::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("PixelValuePositions", args));
   };
@@ -996,7 +996,7 @@ pub fn image_color_space_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // unevaluated instead of erroring out.
   crate::emit_message(&format!(
     "ImageColorSpace::imginv: Expecting an image or graphics instead of {}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ImageColorSpace", args))
 }
@@ -1154,7 +1154,7 @@ pub fn color_negate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // list of such objects.` on `ColorNegate[$Failed]`.
       crate::emit_message(&format!(
         "ColorNegate::imginv: {} should be a valid image, a color directive or a list of such objects.",
-        crate::syntax::expr_to_string(other)
+        expr_to_string(other)
       ));
       Ok(unevaluated("ColorNegate", args))
     }
@@ -1175,7 +1175,7 @@ pub fn binarize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "Binarize::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("Binarize", args));
   }
@@ -1350,7 +1350,7 @@ pub fn image_effect_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImageEffect::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ImageEffect", args));
   };
@@ -1442,7 +1442,7 @@ fn blur_radius_pair(head: &str, args: &[Expr]) -> Option<(f64, f64)> {
     crate::emit_message(&format!(
       "{}::imginv: Expecting an image or graphics instead of {}.",
       head,
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return None;
   }
@@ -1519,7 +1519,7 @@ pub fn thumbnail_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "Thumbnail::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("Thumbnail", args));
   }
@@ -1564,7 +1564,7 @@ pub fn image_adjust_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImageAdjust::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ImageAdjust", args));
   };
@@ -1594,7 +1594,7 @@ pub fn image_adjust_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // A list of any other length isn't a spec ImageAdjust knows.
     crate::emit_message(&format!(
       "ImageAdjust::arg2: Invalid correction parameters {}.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated("ImageAdjust", args));
   } else {
@@ -1698,7 +1698,7 @@ pub fn histogram_transform_ast(
   else {
     crate::emit_message(&format!(
       "HistogramTransform::imginv: {} should be an image, a dataset or a list of datasets.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("HistogramTransform", args));
   };
@@ -1810,7 +1810,7 @@ pub fn image_histogram_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImageHistogram::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ImageHistogram", args));
   };
@@ -2002,7 +2002,7 @@ pub fn image_reflect_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     crate::emit_message(&format!(
       "ImageReflect::imgvinv: Expecting an image, graphics or video instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(unevaluated("ImageReflect", args))
   }
@@ -2021,7 +2021,7 @@ pub fn image_rotate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "ImageRotate::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ImageRotate", args));
   }
@@ -2160,7 +2160,7 @@ pub fn image_resize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "ImageResize::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ImageResize", args));
   }
@@ -2536,7 +2536,7 @@ fn as_int(e: &Expr) -> Option<i64> {
   match e {
     Expr::Integer(n) => Some(*n as i64),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => as_int(operand).map(|n| -n),
     _ => None,
@@ -2979,7 +2979,7 @@ pub fn dominant_colors_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "DominantColors::imginv: Expecting an image or graphics instead of {{{}}}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("DominantColors", args));
   }
@@ -3197,7 +3197,7 @@ pub fn image_apply_ast(
     let call = match func {
       Expr::Function { body } => crate::syntax::substitute_slots(body, &[arg]),
       _ => Expr::FunctionCall {
-        name: crate::syntax::expr_to_string(func),
+        name: expr_to_string(func),
         args: vec![arg].into(),
       },
     };
@@ -3893,7 +3893,7 @@ fn pointwise_image_op(
   crate::emit_message(&format!(
     "{}::imginv: Expecting an image or graphics instead of {}.",
     name,
-    crate::syntax::expr_to_string(bad)
+    expr_to_string(bad)
   ));
   Ok(unevaluated(name, args))
 }
@@ -3973,7 +3973,7 @@ pub fn random_image_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let range = Expr::List(vec![bound(0, min_val), bound(1, max_val)].into());
     crate::emit_message(&format!(
       "RandomImage::bddist: The specified random distribution UniformDistribution[{}] should generate a real number or a list of real numbers.",
-      crate::syntax::expr_to_string(&range)
+      expr_to_string(&range)
     ));
     return Ok(unevaluated("RandomImage", args));
   }
@@ -4037,7 +4037,7 @@ pub fn pixel_value_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "PixelValue::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("PixelValue", args));
   };
@@ -4101,7 +4101,7 @@ pub fn text_recognize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) && !is_valid_image3d(&args[0]) {
     crate::emit_message(&format!(
       "TextRecognize::imgvinv: Expecting an image, graphics or video instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("TextRecognize", args));
   }
@@ -4330,7 +4330,7 @@ pub fn median_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// The body of `median_filter_ast`, reached with a range already
 /// resolved for list data.
-fn median_filter_body(args: &[Expr]) -> crate::syntax::Expr {
+fn median_filter_body(args: &[Expr]) -> Expr {
   let r = crate::functions::math_ast::try_eval_to_f64(&args[1])
     .filter(|v| *v >= 0.0)
     .map(|v| v as usize);
@@ -4460,7 +4460,7 @@ fn median_filter_body(args: &[Expr]) -> crate::syntax::Expr {
     // wolframscript prints MedianFilter::arg1 to stdout for a non-array arg.
     crate::emit_message_to_stdout(&format!(
       "MedianFilter::arg1: The first argument {} should be a rectangular array, image or video.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   }
   unevaluated("MedianFilter", args)
@@ -4667,7 +4667,7 @@ pub fn image_difference_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if parts(arg).is_none() {
       crate::emit_message(&format!(
         "ImageDifference::imginv: Expecting an image or graphics instead of {}.",
-        crate::syntax::expr_to_string(arg)
+        expr_to_string(arg)
       ));
       return echo();
     }
@@ -4764,7 +4764,7 @@ pub fn neighborhood_radius(
     if report {
       crate::emit_message(&format!(
         "{head}::bdrad: {} is not a valid neighborhood range specification.",
-        crate::syntax::expr_to_string(spec)
+        expr_to_string(spec)
       ));
     }
     None
@@ -4789,7 +4789,7 @@ fn aggregating_filter_ast(
   agg: &str,
   filter_name: &str,
   range: NeighborhoodRange,
-) -> crate::syntax::Expr {
+) -> Expr {
   let r = neighborhood_radius(filter_name, &args[1], range, false);
 
   if let (Expr::List(elems), Some(r)) = (&args[0], r) {
@@ -4863,7 +4863,7 @@ fn aggregating_filter_ast(
   } else if !matches!(&args[0], Expr::Image { .. } | Expr::List(_)) {
     crate::emit_message(&format!(
       "{filter_name}::arg1: The first argument {} should be a rectangular array, image or video.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   }
   unevaluated(filter_name, args)
@@ -4956,7 +4956,7 @@ fn spatial_filter_ast(
   else {
     crate::emit_message(&format!(
       "{head}::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated(head, args));
   };
@@ -5033,7 +5033,7 @@ pub fn gaussian_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if !valid && !args.is_empty() {
       crate::emit_message(&format!(
         "GaussianFilter::arg1: The first argument {} should be a rectangular array, image or video.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
     }
     return Ok(unevaluated("GaussianFilter", args));
@@ -5110,7 +5110,7 @@ pub fn gaussian_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   crate::emit_message(&format!(
     "GaussianFilter::arg1: The first argument {} should be a rectangular array, image or video.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("GaussianFilter", args))
 }
@@ -5316,7 +5316,7 @@ fn expr_to_f64_opt(e: &Expr) -> Option<f64> {
   }
 }
 
-fn symbolic_gaussian_matrix(args: &[Expr]) -> crate::syntax::Expr {
+fn symbolic_gaussian_matrix(args: &[Expr]) -> Expr {
   unevaluated("GaussianMatrix", args)
 }
 
@@ -5378,7 +5378,7 @@ pub fn colorize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !is_image {
     crate::emit_message(&format!(
       "Colorize::invinput: Expecting an integer matrix or an image instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   }
   Ok(unevaluated("Colorize", args))
@@ -5535,7 +5535,7 @@ pub fn pruning_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "Pruning::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -5673,7 +5673,7 @@ pub fn morphological_binarize_ast(
   else {
     crate::emit_message(&format!(
       "MorphologicalBinarize::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -5687,7 +5687,7 @@ pub fn morphological_binarize_ast(
   let Some((t1, t2)) = thresholds else {
     crate::emit_message(&format!(
       "MorphologicalBinarize::bdarg2: Invalid threshold specification {}.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated());
   };
@@ -5757,7 +5757,7 @@ pub fn image_value_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImageValue::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -5795,7 +5795,7 @@ pub fn image_value_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Some(spec) = spec else {
     crate::emit_message(&format!(
       "ImageValue::imgrng: The specified argument {} should be an image, a graphics object or a list of coordinates.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated());
   };
@@ -6220,7 +6220,7 @@ pub fn filling_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "FillingTransform::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -6272,14 +6272,14 @@ pub fn filling_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(_) => {
           crate::emit_message(&format!(
             "FillingTransform::invh: The height specification {} must be positive.",
-            crate::syntax::expr_to_string(e)
+            expr_to_string(e)
           ));
           return Ok(unevaluated());
         }
         None => {
           crate::emit_message(&format!(
             "FillingTransform::arg2: Expecting either a marker or depth specification as the second argument instead of {}.",
-            crate::syntax::expr_to_string(e)
+            expr_to_string(e)
           ));
           return Ok(unevaluated());
         }
@@ -6460,7 +6460,7 @@ pub fn distance_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "DistanceTransform::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -6470,7 +6470,7 @@ pub fn distance_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       crate::emit_message(&format!(
         "DistanceTransform::rthres: The specified threshold value {} should represent a real number.",
-        crate::syntax::expr_to_string(&args[1])
+        expr_to_string(&args[1])
       ));
       return Ok(unevaluated());
     }
@@ -6572,7 +6572,7 @@ pub fn color_combine_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       let shown = match &args[1] {
         Expr::String(s) => s.clone(),
-        e => crate::syntax::expr_to_string(e),
+        e => expr_to_string(e),
       };
       crate::emit_message(&format!(
         "ColorCombine::imgcstype: {shown} is an invalid color space specification."
@@ -6586,7 +6586,7 @@ pub fn color_combine_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let invalid_list = || {
     crate::emit_message(&format!(
       "ColorCombine::ccbinput: {} should be a list of images with the same image dimensions.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   };
   let Expr::List(items) = &args[0] else {
@@ -6686,7 +6686,7 @@ pub fn color_separate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ColorSeparate::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("ColorSeparate", args));
   };
@@ -6714,7 +6714,7 @@ pub fn color_quantize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "ColorQuantize::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
   }
   Ok(unevaluated("ColorQuantize", args))
@@ -6735,7 +6735,7 @@ pub fn threshold_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !is_array_like {
     crate::emit_message(&format!(
       "Threshold::wlist: Argument {} should be one of rectangular array of any depth, image, sound or sampled sound list.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   }
@@ -6846,7 +6846,7 @@ pub fn threshold_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     crate::emit_message(&format!(
       "Threshold::nlist: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   }
@@ -6855,7 +6855,7 @@ pub fn threshold_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     crate::emit_message(&format!(
       "Threshold::nlist: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(unevaluated())
   }
@@ -7206,7 +7206,7 @@ pub fn image_partition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImagePartition::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -7216,7 +7216,7 @@ pub fn image_partition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ImagePartition::arg2: {} is not a valid size specification for image partitions.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated());
   };
@@ -7242,19 +7242,19 @@ pub fn image_partition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let (Some(a), Some(b)) = (step_of(&items[0]), step_of(&items[1])) {
           (a, b)
         } else {
-          invalid(&crate::syntax::expr_to_string(&args[2]));
+          invalid(&expr_to_string(&args[2]));
           return Ok(unevaluated());
         }
       }
       Expr::List(_) => {
-        invalid(&crate::syntax::expr_to_string(&args[2]));
+        invalid(&expr_to_string(&args[2]));
         return Ok(unevaluated());
       }
       e => {
         if let Some(d) = step_of(e) {
           (d, d)
         } else {
-          let shown = crate::syntax::expr_to_string(e);
+          let shown = expr_to_string(e);
           invalid(&format!("{{{shown}, {shown}}}"));
           return Ok(unevaluated());
         }
@@ -7358,7 +7358,7 @@ pub fn image_take_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     crate::emit_message(&format!(
       "ImageTake::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(unevaluated("ImageTake", args))
   }
@@ -8726,7 +8726,7 @@ fn resolve_color_value(
     }
     _ => Err(InterpreterError::EvaluationError(format!(
       "ConstantImage: unsupported value {}",
-      crate::syntax::expr_to_string(expr)
+      expr_to_string(expr)
     ))),
   }
 }
@@ -8916,7 +8916,7 @@ pub fn color_balance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   else {
     crate::emit_message(&format!(
       "ColorBalance::imginv: Expecting an image or graphics instead of {}.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated());
   };
@@ -9065,13 +9065,13 @@ pub fn color_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let lab1 = color_to_lab(&args[0]).ok_or_else(|| {
     InterpreterError::EvaluationError(format!(
       "ColorDistance: unsupported color {}",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ))
   })?;
   let lab2 = color_to_lab(&args[1]).ok_or_else(|| {
     InterpreterError::EvaluationError(format!(
       "ColorDistance: unsupported color {}",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ))
   })?;
 

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -4111,7 +4111,7 @@ fn integer_eigenvectors(
   matrix: &[Vec<Expr>],
   int_matrix: &[Vec<i128>],
   n: usize,
-) -> crate::syntax::Expr {
+) -> Expr {
   let coeffs = char_poly_coefficients(int_matrix);
   let mut eigenvalues = find_polynomial_roots(&coeffs);
   sort_eigenvalues(&mut eigenvalues);
@@ -4449,7 +4449,7 @@ fn normalize_symbolic_eigenvector(v: Vec<Expr>) -> Vec<Expr> {
 }
 
 /// Compute eigenvectors for a numeric (f64) matrix.
-fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> crate::syntax::Expr {
+fn numeric_eigenvectors(matrix: &[Vec<Expr>], n: usize) -> Expr {
   // Convert to f64 matrix
   let f_matrix: Vec<Vec<f64>> = matrix
     .iter()
@@ -5377,7 +5377,7 @@ fn linear_solve_rectangular(
   b: &[Expr],
   ncols: usize,
   args: &[Expr],
-) -> crate::syntax::Expr {
+) -> Expr {
   // Augment [A | b] and reduce.
   let aug: Vec<Vec<Expr>> = matrix
     .iter()
@@ -6695,7 +6695,7 @@ pub fn lower_triangularize_ast(
   Ok(triangularize_ast(args, false))
 }
 
-fn triangularize_ast(args: &[Expr], upper: bool) -> crate::syntax::Expr {
+fn triangularize_ast(args: &[Expr], upper: bool) -> Expr {
   let name = if upper {
     "UpperTriangularize"
   } else {
@@ -11623,7 +11623,7 @@ pub fn schur_decomposition_ast(
       crate::emit_message(&format!(
         "SchurDecomposition::matsq: Argument {} at position 1 is not a \
          nonempty square matrix.",
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       ));
       return Ok(original());
     }
@@ -11676,7 +11676,7 @@ pub fn schur_decomposition_ast(
     crate::emit_message(&format!(
       "SchurDecomposition::matsq: Argument {} at position 1 is not a nonempty \
        square matrix.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return Ok(original());
   }

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -178,7 +178,7 @@ pub fn group_by_ast(
     let mut order: Vec<String> = Vec::new();
     for (k, v) in assoc_pairs {
       let key = apply_func_ast(key_func, v)?;
-      let key_str = crate::syntax::expr_to_string(&key);
+      let key_str = expr_to_string(&key);
       let stored = match val_func {
         Some(g) => apply_func_ast(g, v)?,
         None => v.clone(),
@@ -232,7 +232,7 @@ pub fn group_by_ast(
 
   for item in items {
     let key = apply_func_ast(key_func, item)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     let value = match val_func {
       Some(g) => apply_func_ast(g, item)?,
       None => item.clone(),
@@ -274,7 +274,7 @@ fn group_by_nested(
   let mut order: Vec<String> = Vec::new();
   for item in items {
     let key = apply_func_ast(&funcs[0], item)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     if let Some(group) = groups.get_mut(&key_str) {
       group.push(item.clone());
     } else {
@@ -315,7 +315,7 @@ fn group_by_nested_assoc(
   let mut order: Vec<String> = Vec::new();
   for (k, v) in entries {
     let key = apply_func_ast(&funcs[0], v)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     if let Some(group) = groups.get_mut(&key_str) {
       group.push((k.clone(), v.clone()));
     } else {
@@ -774,7 +774,7 @@ pub fn median_ast(list: &Expr) -> Result<Expr, InterpreterError> {
   if items.iter().all(is_quantity) {
     let unit_key = |e: &Expr| -> Option<String> {
       if let Expr::FunctionCall { args, .. } = e {
-        Some(crate::syntax::expr_to_string(&args[1]))
+        Some(expr_to_string(&args[1]))
       } else {
         None
       }
@@ -1193,10 +1193,9 @@ pub fn gather_ast(list: &Expr) -> Result<Expr, InterpreterError> {
   };
   let mut groups: Vec<Vec<Expr>> = Vec::new();
   for item in items {
-    let found = groups.iter_mut().find(|g| {
-      crate::syntax::expr_to_string(&g[0])
-        == crate::syntax::expr_to_string(item)
-    });
+    let found = groups
+      .iter_mut()
+      .find(|g| expr_to_string(&g[0]) == expr_to_string(item));
     if let Some(group) = found {
       group.push(item.clone());
     } else {
@@ -1267,7 +1266,7 @@ pub fn gather_by_ast(
   let mut groups: Vec<(String, Vec<Expr>)> = Vec::new();
   for item in items {
     let key = apply_func_ast(func, item)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     let found = groups.iter_mut().find(|(k, _)| *k == key_str);
     if let Some((_, group)) = found {
       group.push(item.clone());
@@ -1296,7 +1295,7 @@ fn gather_by_nested(
   let mut groups: Vec<(String, Vec<Expr>)> = Vec::new();
   for item in items {
     let key = apply_func_ast(func, item)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     let found = groups.iter_mut().find(|(k, _)| *k == key_str);
     if let Some((_, group)) = found {
       group.push(item.clone());
@@ -1363,9 +1362,7 @@ pub fn split_ast(list: &Expr) -> Result<Expr, InterpreterError> {
   let mut groups: Vec<Vec<Expr>> = vec![vec![items[0].clone()]];
   for item in items.iter().skip(1) {
     let last_group = groups.last().unwrap();
-    if crate::syntax::expr_to_string(&last_group[0])
-      == crate::syntax::expr_to_string(item)
-    {
+    if expr_to_string(&last_group[0]) == expr_to_string(item) {
       groups.last_mut().unwrap().push(item.clone());
     } else {
       groups.push(vec![item.clone()]);
@@ -1458,9 +1455,7 @@ pub fn split_by_ast(
   let mut groups: Vec<Vec<Expr>> = vec![vec![items[0].clone()]];
   for item in items.iter().skip(1) {
     let key = apply_func_ast(func, item)?;
-    if crate::syntax::expr_to_string(&key)
-      == crate::syntax::expr_to_string(&prev_key)
-    {
+    if expr_to_string(&key) == expr_to_string(&prev_key) {
       groups.last_mut().unwrap().push(item.clone());
     } else {
       groups.push(vec![item.clone()]);
@@ -2188,7 +2183,7 @@ pub fn histogram_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Expr::List(data) = &args[0] else {
     crate::emit_message(&format!(
       "HistogramList::ldata: {} is not a valid dataset or list of datasets.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated("HistogramList", args));
   };
@@ -2228,7 +2223,7 @@ pub fn histogram_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::Integer(_) | Expr::Real(_) => {
         crate::emit_message(&format!(
           "HistogramList::hbins: The bin specification {} cannot be used to determine either how many or which bins to use.",
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[1])
         ));
         if matches!(&args[1], Expr::Real(v) if *v > 0.0) {
           wl_bin_spec(&values, None)
@@ -2480,10 +2475,10 @@ pub fn all_same_by_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(bool_expr(true));
   }
   let first_val = apply_func_ast(&args[1], &items[0])?;
-  let first_str = crate::syntax::expr_to_string(&first_val);
+  let first_str = expr_to_string(&first_val);
   for item in &items[1..] {
     let val = apply_func_ast(&args[1], item)?;
-    if crate::syntax::expr_to_string(&val) != first_str {
+    if expr_to_string(&val) != first_str {
       return Ok(bool_expr(false));
     }
   }
@@ -2699,7 +2694,7 @@ fn cluster_keys_emit_values(
   keys: &[Expr],
   vals: &[Expr],
   raw_input: &Expr,
-) -> crate::syntax::Expr {
+) -> Expr {
   // Numeric keys only.
   let mut numeric_keys: Vec<f64> = Vec::with_capacity(keys.len());
   for k in keys {
@@ -3049,11 +3044,7 @@ fn edit_distance_str(a: &str, b: &str) -> u32 {
   prev[n]
 }
 
-fn find_clusters_with_k(
-  list: &Expr,
-  k: usize,
-  raw_args: &[Expr],
-) -> crate::syntax::Expr {
+fn find_clusters_with_k(list: &Expr, k: usize, raw_args: &[Expr]) -> Expr {
   let items = match list {
     Expr::List(items) => items.clone(),
     _ => {

--- a/src/functions/list_helpers_ast/combinatorics.rs
+++ b/src/functions/list_helpers_ast/combinatorics.rs
@@ -215,7 +215,7 @@ fn generate_k_permutations(
     if used[i] {
       continue;
     }
-    let key = crate::syntax::expr_to_string(&items[i]);
+    let key = expr_to_string(&items[i]);
     if !seen_at_level.insert(key) {
       continue;
     }

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -133,7 +133,7 @@ pub fn table_iterators_invalid(name: &str, iters: &[Expr]) -> Option<String> {
         return Some(format!(
           "{}::nliter: Nonlist iterator {} at position {} does not evaluate to a real numeric value.",
           name,
-          crate::syntax::expr_to_string(iter),
+          expr_to_string(iter),
           position
         ));
       }
@@ -256,7 +256,7 @@ pub fn table_ast(
           // and returns the call unevaluated rather than raising an error.
           crate::emit_message(&format!(
             "Table::itraw: Raw object {} cannot be used as an iterator.",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           return Ok(call("Table", vec![body.clone(), iter_spec.clone()]));
         }
@@ -981,7 +981,7 @@ pub fn constant_array_ast(
       if crate::functions::predicate_ast::is_numeric_q(d) {
         crate::emit_message(&format!(
           "ConstantArray::ilsmn: Single or list of non-negative machine-sized integers expected at position 2 of {}.",
-          crate::syntax::expr_to_string(&call(
+          expr_to_string(&call(
             "ConstantArray",
             vec![elem.clone(), dims.clone()]
           ))
@@ -1176,7 +1176,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
           // returns the call unevaluated rather than raising an error.
           crate::emit_message(&format!(
             "Do::itraw: Raw object {} cannot be used as an iterator.",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           return Ok(call("Do", vec![body.clone(), iter_spec.clone()]));
         }
@@ -1469,7 +1469,7 @@ pub fn do_multi_ast(
     {
       crate::emit_message(&format!(
         "Do::itraw: Raw object {} cannot be used as an iterator.",
-        crate::syntax::expr_to_string(&items[0])
+        expr_to_string(&items[0])
       ));
       return Ok(Expr::FunctionCall {
         name: "Do".to_string(),
@@ -1852,7 +1852,7 @@ pub fn array_multi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => {
             // Fall back to invoking the function via the standard call form
             // (e.g. Composition, named symbols stored as values, …).
-            let func_str = crate::syntax::expr_to_string(func);
+            let func_str = expr_to_string(func);
             crate::evaluator::evaluate_function_call_ast(&func_str, &index_args)
           }
         }
@@ -2315,7 +2315,7 @@ fn collect_dense_rules(
       }
     }
     _ => {
-      if crate::syntax::expr_to_string(expr) != default_str {
+      if expr_to_string(expr) != default_str {
         rules.push((indices.clone(), expr.clone()));
       }
     }
@@ -2353,7 +2353,7 @@ fn parse_sparse_data(
 
   // Dense nested list: must be rectangular.
   let shape = dense_shape(data)?;
-  let default_str = crate::syntax::expr_to_string(default);
+  let default_str = expr_to_string(default);
   let mut rules = Vec::new();
   let mut indices = Vec::new();
   collect_dense_rules(data, &mut indices, &mut rules, &default_str);
@@ -2440,7 +2440,7 @@ pub fn sparse_array_normalize_ast(
   // matches wolframscript:
   //   Normal[SparseArray[{1 -> 5, 1 -> 9}, 3]] == {5, 0, 0}
   // BTreeMap gives us deterministic lexicographic ordering.
-  let default_str = crate::syntax::expr_to_string(&default);
+  let default_str = expr_to_string(&default);
   let mut dedup: std::collections::BTreeMap<Vec<i128>, Expr> =
     std::collections::BTreeMap::new();
   for (pos, val) in parsed_rules {
@@ -2454,7 +2454,7 @@ pub fn sparse_array_normalize_ast(
     {
       continue;
     }
-    if crate::syntax::expr_to_string(&val) == default_str {
+    if expr_to_string(&val) == default_str {
       continue;
     }
     dedup.entry(pos).or_insert(val);
@@ -2732,7 +2732,7 @@ fn sparse_stored_paths(dense: &Expr, background: &Expr) -> Vec<Vec<usize>> {
       }
       return;
     }
-    if crate::syntax::expr_to_string(e) != crate::syntax::expr_to_string(bg) {
+    if expr_to_string(e) != expr_to_string(bg) {
       out.push(path.clone());
     }
   }
@@ -2815,9 +2815,7 @@ pub fn try_sparse_array_arithmetic(head: &str, args: &[Expr]) -> Option<Expr> {
       });
     }
     let value = apply(operands)?;
-    if crate::syntax::expr_to_string(&value)
-      == crate::syntax::expr_to_string(&background)
-    {
+    if expr_to_string(&value) == expr_to_string(&background) {
       continue;
     }
     rules.push(Expr::Rule {

--- a/src/functions/list_helpers_ast/element_access.rs
+++ b/src/functions/list_helpers_ast/element_access.rs
@@ -802,7 +802,7 @@ fn take_ast(list: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
   if count >= 0 {
     if count > len {
       // Print warning to stderr and return unevaluated
-      let list_str = crate::syntax::expr_to_string(list);
+      let list_str = expr_to_string(list);
       crate::emit_message(&format!(
         "Take::take: Cannot take positions 1 through {count} in {list_str}."
       ));
@@ -812,7 +812,7 @@ fn take_ast(list: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
   } else {
     if -count > len {
       // Print warning to stderr and return unevaluated
-      let list_str = crate::syntax::expr_to_string(list);
+      let list_str = expr_to_string(list);
       crate::emit_message(&format!(
         "Take::take: Cannot take positions {count} through -1 in {list_str}."
       ));
@@ -1211,10 +1211,8 @@ pub fn insert_ast(
         })
       }
       Expr::FunctionCall { name, args } if name == "Key" && args.len() == 1 => {
-        let ks = crate::syntax::expr_to_string(&args[0]);
-        pairs
-          .iter()
-          .position(|(k, _)| crate::syntax::expr_to_string(k) == ks)
+        let ks = expr_to_string(&args[0]);
+        pairs.iter().position(|(k, _)| expr_to_string(k) == ks)
       }
       _ => None,
     };
@@ -1369,11 +1367,8 @@ fn extract_resolve(subject: &Expr, path: &[ExtractComp]) -> ExtractOutcome {
         let Expr::Association(pairs) = &current else {
           return ExtractOutcome::Partd;
         };
-        let key_str = crate::syntax::expr_to_string(key);
-        match pairs
-          .iter()
-          .find(|(k, _)| crate::syntax::expr_to_string(k) == key_str)
-        {
+        let key_str = expr_to_string(key);
+        match pairs.iter().find(|(k, _)| expr_to_string(k) == key_str) {
           Some((_, v)) => {
             let value = v.clone();
             current = value;
@@ -1609,16 +1604,12 @@ fn assoc_position_index(spec: &Expr, pairs: &[(Expr, Expr)]) -> Option<usize> {
       (idx >= 0 && (idx as usize) < pairs.len()).then_some(idx as usize)
     }
     Expr::FunctionCall { name, args } if name == "Key" && args.len() == 1 => {
-      let ks = crate::syntax::expr_to_string(&args[0]);
-      pairs
-        .iter()
-        .position(|(k, _)| crate::syntax::expr_to_string(k) == ks)
+      let ks = expr_to_string(&args[0]);
+      pairs.iter().position(|(k, _)| expr_to_string(k) == ks)
     }
     Expr::String(_) | Expr::Identifier(_) => {
-      let ks = crate::syntax::expr_to_string(spec);
-      pairs
-        .iter()
-        .position(|(k, _)| crate::syntax::expr_to_string(k) == ks)
+      let ks = expr_to_string(spec);
+      pairs.iter().position(|(k, _)| expr_to_string(k) == ks)
     }
     Expr::List(items) if items.len() == 1 => {
       assoc_position_index(&items[0], pairs)
@@ -2035,7 +2026,7 @@ pub fn delete_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "Delete::partw: Part {{{}}} of {} does not exist.",
           pos,
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Ok(unevaluated("Delete", args));
       }
@@ -2195,7 +2186,7 @@ fn delete_at_position_general(
   items: &[Expr],
   pos: i128,
   head_name: Option<&str>,
-) -> crate::syntax::Expr {
+) -> Expr {
   let wrap = |result_items: Vec<Expr>| -> Expr {
     match head_name {
       Some(h) => call(h, result_items),

--- a/src/functions/list_helpers_ast/filtering.rs
+++ b/src/functions/list_helpers_ast/filtering.rs
@@ -446,11 +446,8 @@ fn apply_test_bool(test: &Expr, elem: &Expr) -> bool {
       crate::evaluator::evaluate_expr_to_expr(&substituted).ok()
     }
     _ => {
-      let call_str = format!(
-        "({})[{}]",
-        crate::syntax::expr_to_string(test),
-        crate::syntax::expr_to_string(elem)
-      );
+      let call_str =
+        format!("({})[{}]", expr_to_string(test), expr_to_string(elem));
       crate::interpret(&call_str).ok().map(|r| {
         if r == "True" {
           bool_expr(true)
@@ -569,11 +566,8 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
         }
         _ => {
           // General expression used as function: call (test)[expr]
-          let call_str = format!(
-            "({})[{}]",
-            crate::syntax::expr_to_string(test),
-            crate::syntax::expr_to_string(expr)
-          );
+          let call_str =
+            format!("({})[{}]", expr_to_string(test), expr_to_string(expr));
           crate::interpret(&call_str).ok().map(|r| {
             if r == "True" {
               bool_expr(true)
@@ -613,8 +607,7 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
     Expr::FunctionCall { name, args }
       if name == "Verbatim" && args.len() == 1 =>
     {
-      crate::syntax::expr_to_string(expr)
-        == crate::syntax::expr_to_string(&args[0])
+      expr_to_string(expr) == expr_to_string(&args[0])
     }
     // Except[c] - matches anything that doesn't match c
     // Except[c, pattern] - matches pattern but not c
@@ -681,8 +674,8 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
           .is_some()
       } else if pat_name == "Except" || pat_name == "PatternTest" {
         // Already handled above or not a structural match
-        let pattern_str = crate::syntax::expr_to_string(pattern);
-        let expr_str = crate::syntax::expr_to_string(expr);
+        let pattern_str = expr_to_string(pattern);
+        let expr_str = expr_to_string(expr);
         expr_str == pattern_str
       } else if let Expr::FunctionCall {
         name: expr_name,
@@ -763,8 +756,8 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
     }
     // Literal comparison
     _ => {
-      let pattern_str = crate::syntax::expr_to_string(pattern);
-      let expr_str = crate::syntax::expr_to_string(expr);
+      let pattern_str = expr_to_string(pattern);
+      let expr_str = expr_to_string(expr);
       expr_str == pattern_str
     }
   }
@@ -1802,7 +1795,7 @@ pub fn contains_only_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut found = false;
       for elem in elems {
         let call = Expr::FunctionCall {
-          name: crate::syntax::expr_to_string(&test),
+          name: expr_to_string(&test),
           args: vec![item.clone(), elem.clone()].into(),
         };
         // Try treating `test` as a callable expression (e.g. Equal).
@@ -1827,11 +1820,10 @@ pub fn contains_only_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   use std::collections::HashSet;
-  let allowed: HashSet<String> =
-    elems.iter().map(crate::syntax::expr_to_string).collect();
+  let allowed: HashSet<String> = elems.iter().map(expr_to_string).collect();
 
   for item in list {
-    if !allowed.contains(&crate::syntax::expr_to_string(item)) {
+    if !allowed.contains(&expr_to_string(item)) {
       return Ok(bool_expr(false));
     }
   }
@@ -2355,7 +2347,7 @@ pub fn commonest_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Expr::List(items) = &args[0] else {
     crate::emit_message(&format!(
       "CommonestFilter::arg1: The first argument {} should be a rectangular array, image or video.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(unevaluated(args));
   };
@@ -2376,15 +2368,12 @@ pub fn commonest_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Commonest in `window` with the tie rules; elements compare by
   // their printed form
   let pick = |window: &[&Expr], center: &Expr| -> Expr {
-    let keys: Vec<String> = window
-      .iter()
-      .map(|e| crate::syntax::expr_to_string(e))
-      .collect();
+    let keys: Vec<String> = window.iter().map(|e| expr_to_string(e)).collect();
     let count_of = |key: &str| -> usize {
       keys.iter().filter(|k| k.as_str() == key).count()
     };
     let max_count = keys.iter().map(|k| count_of(k)).max().unwrap_or(0);
-    let center_key = crate::syntax::expr_to_string(center);
+    let center_key = expr_to_string(center);
     if count_of(&center_key) == max_count {
       return center.clone();
     }
@@ -2411,7 +2400,7 @@ pub fn commonest_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if rows.iter().any(|row| row.len() != width) {
       crate::emit_message(&format!(
         "CommonestFilter::arg1: The first argument {} should be a rectangular array, image or video.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Ok(unevaluated(args));
     }

--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -196,7 +196,7 @@ fn fixed_point_converged(
 
 /// FixedPoint/FixedPointList default comparison: SameQ semantics.
 fn same_q_default(a: &Expr, b: &Expr) -> bool {
-  crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+  expr_to_string(a) == expr_to_string(b)
     || crate::functions::boolean_ast::same_q_real_bigfloat(a, b)
 }
 
@@ -1703,9 +1703,9 @@ pub fn inner_ast(
       crate::emit_message(&format!(
         "Inner::incom: Length {} of dimension 1 in {} is incommensurate with length {} of dimension 1 in {}.",
         l1_len,
-        crate::syntax::expr_to_string(list1),
+        expr_to_string(list1),
         l2_len,
-        crate::syntax::expr_to_string(list2),
+        expr_to_string(list2),
       ));
       Ok(call(
         "Inner",
@@ -2020,8 +2020,7 @@ pub fn find_repeat_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if items.is_empty() {
         return Ok(Expr::List(vec![].into()));
       }
-      let strs: Vec<String> =
-        items.iter().map(crate::syntax::expr_to_string).collect();
+      let strs: Vec<String> = items.iter().map(expr_to_string).collect();
       match find_repeat_period(&strs, min_reps) {
         Some(p) => Ok(Expr::List(items[..p].to_vec().into())),
         None => Ok(Expr::List(vec![].into())),
@@ -2043,10 +2042,8 @@ pub fn find_repeat_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if pairs.is_empty() {
         return Ok(Expr::Association(vec![]));
       }
-      let strs: Vec<String> = pairs
-        .iter()
-        .map(|(_, v)| crate::syntax::expr_to_string(v))
-        .collect();
+      let strs: Vec<String> =
+        pairs.iter().map(|(_, v)| expr_to_string(v)).collect();
       match find_repeat_period(&strs, min_reps) {
         Some(p) => Ok(Expr::Association(pairs[..p].to_vec())),
         None => Ok(Expr::Association(vec![])),
@@ -2055,7 +2052,7 @@ pub fn find_repeat_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "FindRepeat::arg1: The first argument {} to FindRepeat is expected to be a list, an association or a string.",
-        crate::syntax::expr_to_string(arg)
+        expr_to_string(arg)
       ));
       Ok(unevaluated("FindRepeat", args))
     }
@@ -2105,7 +2102,7 @@ pub fn find_transient_repeat_ast(
     _ => {
       crate::emit_message(&format!(
         "FindTransientRepeat::intp: Positive integer expected at position 2 in {}.",
-        crate::syntax::expr_to_string(&unevaluated())
+        expr_to_string(&unevaluated())
       ));
       return Ok(unevaluated());
     }
@@ -2113,8 +2110,7 @@ pub fn find_transient_repeat_ast(
 
   match &args[0] {
     Expr::List(items) => {
-      let strs: Vec<String> =
-        items.iter().map(crate::syntax::expr_to_string).collect();
+      let strs: Vec<String> = items.iter().map(expr_to_string).collect();
       let (t, p) = transient_repeat_split(&strs, n);
       Ok(Expr::List(
         vec![
@@ -2138,10 +2134,8 @@ pub fn find_transient_repeat_ast(
       ))
     }
     Expr::Association(pairs) => {
-      let strs: Vec<String> = pairs
-        .iter()
-        .map(|(_, v)| crate::syntax::expr_to_string(v))
-        .collect();
+      let strs: Vec<String> =
+        pairs.iter().map(|(_, v)| expr_to_string(v)).collect();
       let (t, p) = transient_repeat_split(&strs, n);
       Ok(Expr::List(
         vec![

--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -565,10 +565,9 @@ fn map_at_rebuilt(
     && let Some(key) = extract_assoc_key(pos_spec)
     && !selects_positions(key)
   {
-    let key_str = crate::syntax::expr_to_string(key);
-    if let Some(idx) = pairs
-      .iter()
-      .position(|(k, _)| crate::syntax::expr_to_string(k) == key_str)
+    let key_str = expr_to_string(key);
+    if let Some(idx) =
+      pairs.iter().position(|(k, _)| expr_to_string(k) == key_str)
     {
       let mut new_pairs = pairs.clone();
       new_pairs[idx].1 = apply_func_ast(func, &new_pairs[idx].1)?;
@@ -696,10 +695,10 @@ fn map_at_rebuilt(
           return Some(vec![n]);
         }
         let key = extract_assoc_key(entry)?;
-        let key_str = crate::syntax::expr_to_string(key);
+        let key_str = expr_to_string(key);
         pairs
           .iter()
-          .position(|(k, _)| crate::syntax::expr_to_string(k) == key_str)
+          .position(|(k, _)| expr_to_string(k) == key_str)
           .map(|i| vec![i as i128 + 1])
       }
       other => expr_to_i128(other).map(|n| vec![n]),

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -8,7 +8,10 @@ use crate::helpers::{
   bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2, times2,
   unevaluated,
 };
-use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
+  expr_to_string,
+};
 use num_bigint::{BigInt, Sign};
 
 mod aggregation;

--- a/src/functions/list_helpers_ast/properties.rs
+++ b/src/functions/list_helpers_ast/properties.rs
@@ -107,10 +107,7 @@ pub fn array_components_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut rule_map: std::collections::HashMap<String, Expr> =
     std::collections::HashMap::new();
   // Default rule: integer 0 -> 0.
-  rule_map.insert(
-    crate::syntax::expr_to_string(&Expr::Integer(0)),
-    Expr::Integer(0),
-  );
+  rule_map.insert(expr_to_string(&Expr::Integer(0)), Expr::Integer(0));
   if args.len() >= 3 {
     let rule_list: Vec<Expr> = match &args[2] {
       Expr::List(rs) => rs.to_vec(),
@@ -123,7 +120,7 @@ pub fn array_components_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } = r
       {
         rule_map.insert(
-          crate::syntax::expr_to_string(pattern.as_ref()),
+          expr_to_string(pattern.as_ref()),
           replacement.as_ref().clone(),
         );
       }
@@ -165,7 +162,7 @@ pub fn array_components_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     next_index: &mut i128,
     claimed: &std::collections::HashSet<i128>,
   ) -> Expr {
-    let key = crate::syntax::expr_to_string(expr);
+    let key = expr_to_string(expr);
     if let Some(existing) = label_for_key.get(&key) {
       return existing.clone();
     }
@@ -794,8 +791,8 @@ pub fn symmetric_matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
       // Check symmetry: m[i][j] == m[j][i]
       for i in 0..n {
         for j in (i + 1)..n {
-          let a = crate::syntax::expr_to_string(&grid[i][j]);
-          let b = crate::syntax::expr_to_string(&grid[j][i]);
+          let a = expr_to_string(&grid[i][j]);
+          let b = expr_to_string(&grid[j][i]);
           if a != b {
             return Ok(bool_expr(false));
           }
@@ -858,8 +855,8 @@ pub fn to_packed_array_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "Developer`ToPackedArray::nonopt: Options expected (instead of {}) \
          beyond position 2 in {}. An option must be a rule or a list of \
          rules.",
-        crate::syntax::expr_to_output(offender),
-        crate::syntax::expr_to_output(&unevaluated_call())
+        expr_to_output(offender),
+        expr_to_output(&unevaluated_call())
       ));
       return Ok(unevaluated_call());
     }
@@ -867,7 +864,7 @@ pub fn to_packed_array_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "Developer`ToPackedArray::optx: Unknown option {} in {}.",
         name,
-        crate::syntax::expr_to_output(&unevaluated_call())
+        expr_to_output(&unevaluated_call())
       ));
       return Ok(unevaluated_call());
     }
@@ -930,12 +927,12 @@ fn is_option_like(expr: &Expr) -> bool {
 fn first_option_name(expr: &Expr) -> Option<String> {
   match expr {
     Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. } => {
-      Some(crate::syntax::expr_to_output(pattern))
+      Some(expr_to_output(pattern))
     }
     Expr::FunctionCall { name, args }
       if (name == "Rule" || name == "RuleDelayed") && args.len() == 2 =>
     {
-      Some(crate::syntax::expr_to_output(&args[0]))
+      Some(expr_to_output(&args[0]))
     }
     Expr::List(items) => items.iter().find_map(first_option_name),
     _ => None,

--- a/src/functions/list_helpers_ast/restructuring.rs
+++ b/src/functions/list_helpers_ast/restructuring.rs
@@ -289,11 +289,7 @@ pub fn partition_multi_dim_ast(
 }
 
 /// Flatten[expr, n, head] - flatten expressions with a specific head
-fn flatten_head_ast(
-  list: &Expr,
-  depth: i128,
-  head: &str,
-) -> crate::syntax::Expr {
+fn flatten_head_ast(list: &Expr, depth: i128, head: &str) -> Expr {
   fn flatten_with_head(
     expr: &Expr,
     depth: i128,
@@ -395,11 +391,7 @@ fn flatten_together_depth(expr: &Expr, head: &str) -> usize {
   }
 }
 
-fn flatten_dims_ast(
-  list: &Expr,
-  dim_spec: &[Vec<usize>],
-  head: &str,
-) -> crate::syntax::Expr {
+fn flatten_dims_ast(list: &Expr, dim_spec: &[Vec<usize>], head: &str) -> Expr {
   // Access element at given multi-index, returns None if out of bounds
   fn access(expr: &Expr, indices: &[usize], head: &str) -> Option<Expr> {
     if indices.is_empty() {
@@ -964,7 +956,7 @@ pub fn transpose_perm_ast(
 
   // The literal call, used for messages and the unevaluated return value.
   let perm_list = Expr::List(perm.to_vec().into());
-  let perm_str = crate::syntax::expr_to_string(&perm_list);
+  let perm_str = expr_to_string(&perm_list);
   let unevaluated =
     || Ok(call("Transpose", vec![list.clone(), perm_list.clone()]));
 
@@ -978,7 +970,7 @@ pub fn transpose_perm_ast(
       _ => {
         crate::emit_message(&format!(
           "Transpose::perm1: Entry {} in permutation {} is not a positive machine integer.",
-          crate::syntax::expr_to_string(p),
+          expr_to_string(p),
           perm_str
         ));
         return unevaluated();
@@ -1012,7 +1004,7 @@ pub fn transpose_perm_ast(
     crate::emit_message(&format!(
       "Transpose::tperm: Permutation {} is longer than the dimensions {} of the expression.",
       perm_str,
-      crate::syntax::expr_to_string(&dims_list)
+      expr_to_string(&dims_list)
     ));
     return unevaluated();
   }
@@ -1973,10 +1965,10 @@ pub fn join_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Expr::Association(pairs) = list {
         for (k, v) in pairs {
           // Later values override earlier ones for the same key
-          let key_str = crate::syntax::expr_to_string(k);
+          let key_str = expr_to_string(k);
           if let Some(pos) = result
             .iter()
-            .position(|(ek, _)| crate::syntax::expr_to_string(ek) == key_str)
+            .position(|(ek, _)| expr_to_string(ek) == key_str)
           {
             result[pos] = (k.clone(), v.clone());
           } else {
@@ -2087,10 +2079,10 @@ pub fn append_ast(list: &Expr, elem: &Expr) -> Result<Expr, InterpreterError> {
       // Append a rule to an association
       // If the key already exists, remove the old entry (new one goes to end)
       if let Some((k, v)) = extract_rule_pair(elem) {
-        let key_str = crate::syntax::expr_to_string(&k);
+        let key_str = expr_to_string(&k);
         let mut result: Vec<(Expr, Expr)> = pairs
           .iter()
-          .filter(|(ek, _)| crate::syntax::expr_to_string(ek) != key_str)
+          .filter(|(ek, _)| expr_to_string(ek) != key_str)
           .cloned()
           .collect();
         result.push((k, v));
@@ -2123,12 +2115,12 @@ pub fn prepend_ast(list: &Expr, elem: &Expr) -> Result<Expr, InterpreterError> {
       // Prepend a rule to an association
       // If the key already exists, remove the old entry (new one goes to front)
       if let Some((k, v)) = extract_rule_pair(elem) {
-        let key_str = crate::syntax::expr_to_string(&k);
+        let key_str = expr_to_string(&k);
         let mut result = vec![(k, v)];
         result.extend(
           pairs
             .iter()
-            .filter(|(ek, _)| crate::syntax::expr_to_string(ek) != key_str)
+            .filter(|(ek, _)| expr_to_string(ek) != key_str)
             .cloned(),
         );
         Ok(Expr::Association(result))

--- a/src/functions/list_helpers_ast/set_operations.rs
+++ b/src/functions/list_helpers_ast/set_operations.rs
@@ -25,7 +25,7 @@ pub fn tally_ast(list: &Expr) -> Result<Expr, InterpreterError> {
   let mut order: Vec<String> = Vec::new();
 
   for item in items {
-    let key_str = crate::syntax::expr_to_string(item);
+    let key_str = expr_to_string(item);
     if let Some((_, count)) = counts.get_mut(&key_str) {
       *count += 1;
     } else {
@@ -111,7 +111,7 @@ pub fn counts_ast(list: &Expr) -> Result<Expr, InterpreterError> {
   let mut order: Vec<String> = Vec::new();
 
   for item in items {
-    let key_str = crate::syntax::expr_to_string(item);
+    let key_str = expr_to_string(item);
     if let Some((_, count)) = counts.get_mut(&key_str) {
       *count += 1;
     } else {
@@ -159,7 +159,7 @@ pub fn delete_duplicates_ast(
     let mut seen: HashSet<String> = HashSet::new();
     let mut result: Vec<(Expr, Expr)> = Vec::new();
     for (k, v) in pairs {
-      if seen.insert(crate::syntax::expr_to_string(v)) {
+      if seen.insert(expr_to_string(v)) {
         result.push((k.clone(), v.clone()));
       }
     }
@@ -203,7 +203,7 @@ pub fn delete_duplicates_ast(
     let mut seen: HashSet<String> = HashSet::new();
     let mut result = Vec::new();
     for item in items {
-      if seen.insert(crate::syntax::expr_to_string(item)) {
+      if seen.insert(expr_to_string(item)) {
         result.push(item.clone());
       }
     }
@@ -326,14 +326,10 @@ fn all_association_pairs(lists: &[Expr]) -> Option<Vec<&[(Expr, Expr)]>> {
 
 /// True if `pairs` contains a key->value pair structurally equal to (k, v).
 fn pairs_contain(pairs: &[(Expr, Expr)], k: &Expr, v: &Expr) -> bool {
-  let (ks, vs) = (
-    crate::syntax::expr_to_string(k),
-    crate::syntax::expr_to_string(v),
-  );
-  pairs.iter().any(|(k2, v2)| {
-    crate::syntax::expr_to_string(k2) == ks
-      && crate::syntax::expr_to_string(v2) == vs
-  })
+  let (ks, vs) = (expr_to_string(k), expr_to_string(v));
+  pairs
+    .iter()
+    .any(|(k2, v2)| expr_to_string(k2) == ks && expr_to_string(v2) == vs)
 }
 
 pub fn union_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -347,7 +343,7 @@ pub fn union_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut map: HashMap<String, (Expr, Expr)> = HashMap::new();
     for pairs in &assocs {
       for (k, v) in *pairs {
-        let ks = crate::syntax::expr_to_string(k);
+        let ks = expr_to_string(k);
         if !map.contains_key(&ks) {
           order.push(ks.clone());
         }
@@ -376,7 +372,7 @@ pub fn union_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut seen: HashSet<String> = HashSet::new();
     for items in &slices {
       for item in *items {
-        let key_str = crate::syntax::expr_to_string(item);
+        let key_str = expr_to_string(item);
         if seen.insert(key_str) {
           result.push(item.clone());
         }
@@ -479,28 +475,23 @@ pub fn intersection_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(wrap(Vec::new()));
   };
 
-  let mut common: HashSet<String> = first_items
-    .iter()
-    .map(crate::syntax::expr_to_string)
-    .collect();
+  let mut common: HashSet<String> =
+    first_items.iter().map(expr_to_string).collect();
 
   // Intersect with each subsequent list
   for items in slices.iter().skip(1) {
-    let list_set: HashSet<String> =
-      items.iter().map(crate::syntax::expr_to_string).collect();
+    let list_set: HashSet<String> = items.iter().map(expr_to_string).collect();
     common = common.intersection(&list_set).cloned().collect();
   }
 
   // Collect matching elements and sort canonically (like Mathematica)
   let mut result: Vec<Expr> = first_items
     .iter()
-    .filter(|item| common.contains(&crate::syntax::expr_to_string(item)))
+    .filter(|item| common.contains(&expr_to_string(item)))
     .cloned()
     .collect();
   sort_canonical(&mut result);
-  result.dedup_by(|a, b| {
-    crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
-  });
+  result.dedup_by(|a, b| expr_to_string(a) == expr_to_string(b));
 
   Ok(wrap(result))
 }
@@ -512,7 +503,7 @@ pub fn intersection_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
 fn intersection_with_same_test(
   slices: &[&[Expr]],
   test: &Expr,
-) -> std::vec::Vec<crate::syntax::Expr> {
+) -> std::vec::Vec<Expr> {
   let first_items: Vec<Expr> = match slices.first() {
     Some(items) => items.to_vec(),
     None => return Vec::new(),
@@ -605,7 +596,7 @@ pub fn complement_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut exclude: HashSet<String> = HashSet::new();
   for items in slices.iter().skip(1) {
     for item in *items {
-      exclude.insert(crate::syntax::expr_to_string(item));
+      exclude.insert(expr_to_string(item));
     }
   }
 
@@ -617,7 +608,7 @@ pub fn complement_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut result: Vec<Expr> = first_items
     .iter()
     .filter(|item| {
-      let s = crate::syntax::expr_to_string(item);
+      let s = expr_to_string(item);
       !exclude.contains(&s) && seen.insert(s)
     })
     .cloned()
@@ -701,7 +692,7 @@ pub fn delete_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Expr::List(elems) = elems_expr else {
     crate::emit_message(&format!(
       "DeleteElements::invl: The argument {} is not a list.",
-      crate::syntax::expr_to_string(elems_expr)
+      expr_to_string(elems_expr)
     ));
     let rhs = match mult_expr {
       Some(m) => m.clone(),
@@ -732,7 +723,7 @@ pub fn delete_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let ilsmp = |bad: &Expr| {
     crate::emit_message(&format!(
       "DeleteElements::ilsmp: Single or list of positive machine-sized integers expected at position 1 of {}.",
-      crate::syntax::expr_to_string(bad)
+      expr_to_string(bad)
     ));
   };
 
@@ -768,7 +759,7 @@ pub fn delete_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Map each element (by SameQ string key) to its remaining removal budget.
   let mut remaining: HashMap<String, usize> = HashMap::new();
   for (e, b) in elems.iter().zip(budgets.iter()) {
-    let key = crate::syntax::expr_to_string(e);
+    let key = expr_to_string(e);
     let slot = remaining.entry(key).or_insert(0);
     *slot = slot.saturating_add(*b);
   }
@@ -776,7 +767,7 @@ pub fn delete_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let result: Vec<Expr> = items
     .iter()
     .filter(|item| {
-      let key = crate::syntax::expr_to_string(item);
+      let key = expr_to_string(item);
       if let Some(b) = remaining.get_mut(&key)
         && *b > 0
       {
@@ -809,7 +800,7 @@ pub fn delete_duplicates_by_ast(
 
   for item in items {
     let key = apply_func_ast(func, item)?;
-    let key_str = crate::syntax::expr_to_string(&key);
+    let key_str = expr_to_string(&key);
     if seen.insert(key_str) {
       result.push(item.clone());
     }
@@ -836,9 +827,7 @@ pub fn delete_adjacent_duplicates_ast(
   // True when `b` continues the run `a` starts.
   let same = |a: &Expr, b: &Expr| -> Result<bool, InterpreterError> {
     match test {
-      None => {
-        Ok(crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b))
-      }
+      None => Ok(expr_to_string(a) == expr_to_string(b)),
       Some(t) => {
         let r = apply_func_to_two_args(t, a, b)?;
         Ok(matches!(&r, Expr::Identifier(s) if s == "True"))
@@ -929,7 +918,7 @@ pub fn commonest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // counts: Vec<(key, item, count, first_appearance)>
   let mut counts: Vec<(String, &Expr, usize, usize)> = Vec::new();
   for (idx, item) in items.iter().enumerate() {
-    let key = crate::syntax::expr_to_string(item);
+    let key = expr_to_string(item);
     if let Some(entry) = counts.iter_mut().find(|(k, _, _, _)| k == &key) {
       entry.2 += 1;
     } else {
@@ -1014,9 +1003,7 @@ pub fn unique_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Precompute the set of keys present in each list.
       let key_sets: Vec<HashSet<String>> = slices
         .iter()
-        .map(|(items, _)| {
-          items.iter().map(crate::syntax::expr_to_string).collect()
-        })
+        .map(|(items, _)| items.iter().map(expr_to_string).collect())
         .collect();
 
       let mut result = Vec::with_capacity(slices.len());
@@ -1024,7 +1011,7 @@ pub fn unique_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let mut seen: HashSet<String> = HashSet::new();
         let mut unique = Vec::new();
         for item in *items {
-          let key = crate::syntax::expr_to_string(item);
+          let key = expr_to_string(item);
           let in_other = key_sets
             .iter()
             .enumerate()
@@ -1101,7 +1088,7 @@ pub fn symmetric_difference_ast(
     // Deduplicate within this list
     let mut seen_in_list = std::collections::HashSet::new();
     for item in items {
-      let key = crate::syntax::expr_to_string(item);
+      let key = expr_to_string(item);
       if seen_in_list.insert(key.clone()) {
         membership_count
           .entry(key)
@@ -1119,9 +1106,7 @@ pub fn symmetric_difference_ast(
     .collect();
 
   // Sort canonically (matching Complement/Union behavior)
-  result.sort_by(|a, b| {
-    crate::syntax::expr_to_string(a).cmp(&crate::syntax::expr_to_string(b))
-  });
+  result.sort_by_key(expr_to_string);
 
   Ok(Expr::List(result.into()))
 }

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -15,7 +15,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
     return Some((v, 0.0));
   }
   // Check if expression contains I (complex unit)
-  let s = crate::syntax::expr_to_string(e);
+  let s = expr_to_string(e);
   if !s.contains('I') {
     return None;
   }
@@ -124,7 +124,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
 /// Check if an expression is Infinity or -Infinity (DirectedInfinity).
 /// In Wolfram's canonical ordering, these sort after all finite numbers.
 fn is_infinity_expr(e: &Expr) -> Option<i8> {
-  let s = crate::syntax::expr_to_string(e);
+  let s = expr_to_string(e);
   if s == "Infinity" {
     Some(1)
   } else if s == "-Infinity" {
@@ -340,9 +340,9 @@ pub fn canonical_cmp(a: &Expr, b: &Expr) -> std::cmp::Ordering {
         let base_exp = |e: &Expr| -> Option<(String, f64)> {
           if let Some((base, exp)) = power_parts(e) {
             let v = crate::functions::math_ast::try_eval_to_f64(&exp)?;
-            Some((crate::syntax::expr_to_string(&base), v))
+            Some((expr_to_string(&base), v))
           } else {
-            Some((crate::syntax::expr_to_string(e), 1.0))
+            Some((expr_to_string(e), 1.0))
           }
         };
         let a_is_pow = power_parts(a).is_some();
@@ -498,8 +498,8 @@ pub fn canonical_cmp(a: &Expr, b: &Expr) -> std::cmp::Ordering {
       }
 
       // Atomic non-numeric: string/symbol comparison
-      let sa = crate::syntax::expr_to_string(a);
-      let sb = crate::syntax::expr_to_string(b);
+      let sa = expr_to_string(a);
+      let sb = expr_to_string(b);
       wolfram_string_cmp(&sa, &sb)
     }
   }
@@ -796,7 +796,7 @@ fn limit_ordering(
     };
     crate::emit_message(&format!(
       "Take::take: Cannot take positions {from} through {to} in {}.",
-      crate::syntax::expr_to_output(&Expr::List(ordering.into()))
+      expr_to_output(&Expr::List(ordering.into()))
     ));
     return None;
   }
@@ -1016,8 +1016,8 @@ fn by_key_cmp(a: &Expr, b: &Expr) -> std::cmp::Ordering {
   if let Some(ord) = exact_real_cmp(a, b) {
     return ord;
   }
-  let ka = crate::syntax::expr_to_string(a);
-  let kb = crate::syntax::expr_to_string(b);
+  let ka = expr_to_string(a);
+  let kb = expr_to_string(b);
   if let (Ok(na), Ok(nb)) = (ka.parse::<f64>(), kb.parse::<f64>()) {
     na.partial_cmp(&nb).unwrap_or(std::cmp::Ordering::Equal)
   } else {
@@ -1077,10 +1077,10 @@ fn minimal_maximal_by_assoc(
       .cloned();
     let result: Vec<(Expr, Expr)> = match extreme {
       Some(ex) => {
-        let ex_str = crate::syntax::expr_to_string(&ex);
+        let ex_str = expr_to_string(&ex);
         keyed
           .into_iter()
-          .filter(|(_, c)| crate::syntax::expr_to_string(c) == ex_str)
+          .filter(|(_, c)| expr_to_string(c) == ex_str)
           .map(|(kv, _)| kv)
           .collect()
       }
@@ -1139,10 +1139,10 @@ pub fn minimal_by_ast(
       .cloned();
 
     if let Some(min_k) = min_key {
-      let min_str = crate::syntax::expr_to_string(&min_k);
+      let min_str = expr_to_string(&min_k);
       let result: Vec<Expr> = keyed
         .into_iter()
-        .filter(|(_, k)| crate::syntax::expr_to_string(k) == min_str)
+        .filter(|(_, k)| expr_to_string(k) == min_str)
         .map(|(item, _)| item)
         .collect();
       Ok(Expr::List(result.into()))
@@ -1203,10 +1203,10 @@ pub fn maximal_by_ast(
       .cloned();
 
     if let Some(max_k) = max_key {
-      let max_str = crate::syntax::expr_to_string(&max_k);
+      let max_str = expr_to_string(&max_k);
       let result: Vec<Expr> = keyed
         .into_iter()
-        .filter(|(_, k)| crate::syntax::expr_to_string(k) == max_str)
+        .filter(|(_, k)| expr_to_string(k) == max_str)
         .map(|(item, _)| item)
         .collect();
       Ok(Expr::List(result.into()))
@@ -1556,7 +1556,7 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
   // -1/9*t^2 (degree ascending; wolframscript-verified). The string
   // comparison below would order "E^(-1/9*t^2)" first on '1' < '2'.
   if let (Some((ba, ea)), Some((bb, eb))) = (power_parts(a), power_parts(b))
-    && crate::syntax::expr_to_string(&ba) == crate::syntax::expr_to_string(&bb)
+    && expr_to_string(&ba) == expr_to_string(&bb)
   {
     let ord = compare_exprs(&ea, &eb);
     if ord != 0 {
@@ -1594,8 +1594,8 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
     match (a_is_atom, b_is_atom) {
       (true, true) => {
         // Both atoms: alphabetical comparison
-        let a_str = crate::syntax::expr_to_string(a);
-        let b_str = crate::syntax::expr_to_string(b);
+        let a_str = expr_to_string(a);
+        let b_str = expr_to_string(b);
         wolfram_string_order(&a_str, &b_str)
       }
       (true, false) => {
@@ -1612,7 +1612,7 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
           return -1;
         }
         let b_key = expr_sort_key(b);
-        let a_str = crate::syntax::expr_to_string(a);
+        let a_str = expr_to_string(a);
         let cmp = wolfram_string_order(&a_str, &b_key);
         if cmp == 0 {
           1 // atom comes before compound with same key
@@ -1629,7 +1629,7 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
           return 1;
         }
         let a_key = expr_sort_key(a);
-        let b_str = crate::syntax::expr_to_string(b);
+        let b_str = expr_to_string(b);
         let cmp = wolfram_string_order(&a_key, &b_str);
         if cmp == 0 {
           -1 // compound comes after atom with same key
@@ -1671,8 +1671,8 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
         if cmp != 0 {
           return cmp;
         }
-        let a_str = crate::syntax::expr_to_string(a);
-        let b_str = crate::syntax::expr_to_string(b);
+        let a_str = expr_to_string(a);
+        let b_str = expr_to_string(b);
         wolfram_string_order(&a_str, &b_str)
       }
     }
@@ -1693,7 +1693,7 @@ fn int_base_power(e: &Expr) -> Option<((i128, i128), f64)> {
       (args[0].clone(), args[1].clone())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => ((**left).clone(), (**right).clone()),
@@ -1765,7 +1765,7 @@ fn power_parts(e: &Expr) -> Option<(Expr, Expr)> {
       Some((args[0].clone(), args[1].clone()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),
@@ -2040,10 +2040,7 @@ fn sum_highest_term_negates(sum: &Expr, atom: &Expr) -> bool {
     _ => None,
   };
   match negated_inner {
-    Some(inner) => {
-      crate::syntax::expr_to_string(&inner)
-        == crate::syntax::expr_to_string(atom)
-    }
+    Some(inner) => expr_to_string(&inner) == expr_to_string(atom),
     None => false,
   }
 }
@@ -2093,20 +2090,20 @@ pub fn expr_sort_key(e: &Expr) -> String {
         && let Some(last) = args.last()
       {
         if is_atom_expr(last) {
-          return crate::syntax::expr_to_string(last);
+          return expr_to_string(last);
         }
         return expr_sort_key(last);
       }
       // For Power/Sqrt: sort key is the base (same as BinaryOp::Power)
       if name == "Power" && args.len() == 2 {
         if is_atom_expr(&args[0]) {
-          return crate::syntax::expr_to_string(&args[0]);
+          return expr_to_string(&args[0]);
         }
         return expr_sort_key(&args[0]);
       }
       if let Some(sqrt_arg) = crate::functions::math_ast::is_sqrt(e) {
         if is_atom_expr(sqrt_arg) {
-          return crate::syntax::expr_to_string(sqrt_arg);
+          return expr_to_string(sqrt_arg);
         }
         return expr_sort_key(sqrt_arg);
       }
@@ -2123,32 +2120,32 @@ pub fn expr_sort_key(e: &Expr) -> String {
       if let Expr::FunctionCall { name, .. } = func.as_ref() {
         return name.clone();
       }
-      crate::syntax::expr_to_string(e)
+      expr_to_string(e)
     }
     Expr::BinaryOp { op, left, right } => {
       match op {
         BinaryOperator::Power => {
           // Power: sort key is the base (recurse for compound bases)
           if is_atom_expr(left) {
-            crate::syntax::expr_to_string(left)
+            expr_to_string(left)
           } else {
             expr_sort_key(left)
           }
         }
         BinaryOperator::Plus | BinaryOperator::Times => {
           // For binary plus/times: use the "larger" operand
-          let l = crate::syntax::expr_to_string(left);
-          let r = crate::syntax::expr_to_string(right);
+          let l = expr_to_string(left);
+          let r = expr_to_string(right);
           if wolfram_string_order(&l, &r) >= 0 {
             r
           } else {
             l
           }
         }
-        _ => crate::syntax::expr_to_string(e),
+        _ => expr_to_string(e),
       }
     }
-    _ => crate::syntax::expr_to_string(e),
+    _ => expr_to_string(e),
   }
 }
 

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -1910,7 +1910,7 @@ fn regularized_infinite_sum(
   // search on the printed form would trip over a name like `Sin` containing `n`.
   let mentions_var = |e: &Expr| {
     let probe = crate::syntax::substitute_variable(e, var, &Expr::Integer(0));
-    crate::syntax::expr_to_string(&probe) != crate::syntax::expr_to_string(e)
+    expr_to_string(&probe) != expr_to_string(e)
   };
   if coefficients.iter().any(mentions_var) {
     return Ok(None);
@@ -1943,7 +1943,7 @@ fn regularized_infinite_sum(
   // A pole (`Zeta[1]`, from a `1/n` term) leaves `ComplexInfinity` or an
   // unevaluated `Zeta` behind instead of a value; either means the summand is
   // outside the scheme's reach.
-  let rendered = crate::syntax::expr_to_string(&canonical);
+  let rendered = expr_to_string(&canonical);
   if rendered.contains("ComplexInfinity")
     || rendered.contains("Indeterminate")
     || rendered.contains("Zeta")
@@ -2784,9 +2784,7 @@ fn try_binomial_theorem_sum(
     return None;
   }
   // The upper limit must be exactly the Binomial's first argument.
-  if crate::syntax::expr_to_string(&n)
-    != crate::syntax::expr_to_string(max_expr)
-  {
+  if expr_to_string(&n) != expr_to_string(max_expr) {
     return None;
   }
 
@@ -2928,8 +2926,7 @@ fn try_symbolic_sum(
     && name == "Binomial"
     && args.len() == 2
     && matches!(&args[1], Expr::Identifier(v) if v == var_name)
-    && crate::syntax::expr_to_string(&args[0])
-      == crate::syntax::expr_to_string(max_expr)
+    && expr_to_string(&args[0]) == expr_to_string(max_expr)
   {
     let two_n = times2(Expr::Integer(2), max_expr.clone());
     let result = call("Binomial", vec![two_n, max_expr.clone()]);
@@ -3981,7 +3978,7 @@ fn try_telescoping_rational_sum(
   body: &Expr,
   var_name: &str,
   min: i128,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   // Trim trailing zero coefficients to get true degrees.
   let trim = |mut v: Vec<(i128, i128)>| {
     while v.len() > 1 && v.last() == Some(&(0, 1)) {
@@ -4133,7 +4130,7 @@ fn try_rational_pole_telescoping_sum(
   body: &Expr,
   var_name: &str,
   min: i128,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   use std::collections::{HashMap, HashSet};
   let trim = |mut v: Vec<(i128, i128)>| {
     while v.len() > 1 && v.last() == Some(&(0, 1)) {
@@ -5368,7 +5365,7 @@ pub fn angle_path_3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let steps_err = || {
     crate::emit_message(&format!(
       "AnglePath3D::steps: Invalid steps specification {}.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     unevaluated()
   };

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -1,4 +1,3 @@
-#[allow(unused_imports)]
 use super::*;
 
 /// Convert an Expr to a boolean value.
@@ -68,7 +67,7 @@ pub fn apply_func_to_two_args(
       crate::evaluator::evaluate_function_call_ast(name, &new_args)
     }
     _ => {
-      let func_str = crate::syntax::expr_to_string(func);
+      let func_str = expr_to_string(func);
       crate::evaluator::evaluate_function_call_ast(
         &func_str,
         &[arg1.clone(), arg2.clone()],
@@ -109,7 +108,7 @@ pub fn apply_func_to_args(
       crate::evaluator::evaluate_function_call_ast(name, &new_args)
     }
     _ => {
-      let func_str = crate::syntax::expr_to_string(func);
+      let func_str = expr_to_string(func);
       crate::evaluator::evaluate_function_call_ast(&func_str, call_args)
     }
   }
@@ -228,7 +227,7 @@ pub fn apply_func_to_n_args(
       crate::evaluator::evaluate_function_call_ast(name, &new_args)
     }
     _ => {
-      let func_str = crate::syntax::expr_to_string(func);
+      let func_str = expr_to_string(func);
       crate::evaluator::evaluate_function_call_ast(&func_str, args)
     }
   }

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -109,7 +109,7 @@ fn error_extremes(all_series: &[Vec<ErrPoint>]) -> Vec<Vec<(f64, f64)>> {
 fn label_string(e: &Expr) -> String {
   match e {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_output(other),
+    other => expr_to_output(other),
   }
 }
 
@@ -513,7 +513,7 @@ fn unwrap_labeled(expr: &Expr) -> Option<(Expr, String)> {
   {
     let label = match &args[1] {
       Expr::String(s) => s.clone(),
-      other => crate::syntax::expr_to_output(other),
+      other => expr_to_output(other),
     };
     Some((args[0].clone(), label))
   } else {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -6550,7 +6550,7 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
 fn try_series_data_times_var_power(
   series: &Expr,
   power: &Expr,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   // Match a SeriesData head.
   let (var, x0, coeffs, nmin, nmax, denom) = match series {
     Expr::FunctionCall { name, args }
@@ -12353,7 +12353,7 @@ pub fn min_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Sum BigFloat (precision-tagged) numbers with precision tracking.
 /// Handles BigFloat + BigFloat and BigFloat + Integer/Rational.
-fn bigfloat_plus(args: &[Expr]) -> crate::syntax::Expr {
+fn bigfloat_plus(args: &[Expr]) -> Expr {
   // Extract (f64_value, precision) for each argument
   // BigFloat: use stored precision; Integer/Rational: infinite precision
   let mut sum_val: f64 = 0.0;

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -30,7 +30,7 @@ fn exprs_equal_simple(a: &Expr, b: &Expr) -> bool {
     (Expr::Integer(x), Expr::Integer(y)) => x == y,
     (Expr::Real(x), Expr::Real(y)) => x == y,
     (Expr::Identifier(x), Expr::Identifier(y)) => x == y,
-    _ => crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b),
+    _ => expr_to_string(a) == expr_to_string(b),
   }
 }
 

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -638,9 +638,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
     let mut bare: Vec<Expr> = Vec::new();
     for t in &terms {
       let c = conjugate_one(t)?;
-      if crate::syntax::expr_to_string(&c)
-        == crate::syntax::expr_to_string(&conj_wrap(t))
-      {
+      if expr_to_string(&c) == expr_to_string(&conj_wrap(t)) {
         bare.push(t.clone());
       } else {
         simplified.push(c);
@@ -752,8 +750,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
   {
     let num = conjugate_one(left)?;
     let den = conjugate_one(right)?;
-    let clean =
-      |e: &Expr| !crate::syntax::expr_to_string(e).contains("Conjugate[");
+    let clean = |e: &Expr| !expr_to_string(e).contains("Conjugate[");
     if clean(&num) && clean(&den) {
       return crate::evaluator::evaluate_expr_to_expr(&div2(num, den));
     }

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -2697,7 +2697,7 @@ pub fn integer_reverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(_) => {
         crate::emit_message(&format!(
           "IntegerReverse::intpm: Positive machine-sized integer expected at position 3 in {}.",
-          crate::syntax::expr_to_string(&unevaluated("IntegerReverse", args))
+          expr_to_string(&unevaluated("IntegerReverse", args))
         ));
         return uneval();
       }

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -127,8 +127,8 @@ pub(crate) fn reject_bad_distribution_params(dist: &Expr) -> bool {
     crate::emit_message(&format!(
       "{name}::posprm: Parameter {} at position {pos} in {} is expected to \
        be positive.",
-      crate::syntax::expr_to_string(arg),
-      crate::syntax::expr_to_string(dist),
+      expr_to_string(arg),
+      expr_to_string(dist),
     ));
     return true;
   }
@@ -2390,11 +2390,8 @@ fn cdf_multinormal(dargs: &[Expr], x: &Expr) -> Result<Expr, InterpreterError> {
   if matrix_symmetric_positive_definite(sigma) == Some(false) {
     crate::emit_message(&format!(
       "MultinormalDistribution::posdefprm: The value {} at position 2 in {} is expected to be a symmetric positive definite matrix.",
-      crate::syntax::expr_to_string(sigma_expr),
-      crate::syntax::expr_to_string(&unevaluated(
-        "MultinormalDistribution",
-        dargs
-      ))
+      expr_to_string(sigma_expr),
+      expr_to_string(&unevaluated("MultinormalDistribution", dargs))
     ));
     return Ok(unevaluated_call());
   }
@@ -6273,7 +6270,7 @@ fn expectation_numerical(
   var: &str,
   dist_name: &str,
   dargs: &[Expr],
-) -> crate::syntax::Expr {
+) -> Expr {
   use crate::functions::plot::substitute_var;
 
   // Get integration range and PDF for quadrature
@@ -7579,7 +7576,7 @@ fn failure_distribution_cdf_value(
   if has_not(bexpr) {
     crate::emit_message(&format!(
       "FailureDistribution::nonunate: The Boolean expression {} is not positive unate. Use UnateQ to test if a Boolean expression is unate.",
-      crate::syntax::expr_to_string(bexpr).trim()
+      expr_to_string(bexpr).trim()
     ));
     return Ok(None);
   }
@@ -8363,13 +8360,12 @@ fn wakeby_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = try_eval_to_f64;
-  let dist =
-    || crate::syntax::expr_to_string(&unevaluated("WakebyDistribution", dargs));
+  let dist = || expr_to_string(&unevaluated("WakebyDistribution", dargs));
   for pos in [0usize, 2] {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
       crate::emit_message(&format!(
         "WakebyDistribution::posprm: Parameter {} at position {} in {} is expected to be positive.",
-        crate::syntax::expr_to_string(&dargs[pos]),
+        expr_to_string(&dargs[pos]),
         pos + 1,
         dist()
       ));
@@ -8571,16 +8567,12 @@ fn compound_poisson_mean_variance(
     return bail();
   }
   let num = try_eval_to_f64;
-  let dist_str = || {
-    crate::syntax::expr_to_string(&unevaluated(
-      "CompoundPoissonDistribution",
-      dargs,
-    ))
-  };
+  let dist_str =
+    || expr_to_string(&unevaluated("CompoundPoissonDistribution", dargs));
   if num(&dargs[0]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
       "CompoundPoissonDistribution::posprm: Parameter {} at position 1 in {} is expected to be positive.",
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[0]),
       dist_str()
     ));
     return bail();
@@ -8594,8 +8586,8 @@ fn compound_poisson_mean_variance(
     // the raw fallback, which we replicate verbatim.
     crate::emit_message(&format!(
       "CompoundPoissonDistribution::univ: -- Message text not found -- ({}) ({}) ({})",
-      crate::syntax::expr_to_string(&dargs[1]),
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[0]),
       dist_str()
     ));
     return bail();
@@ -8603,8 +8595,8 @@ fn compound_poisson_mean_variance(
   if !inner_name.ends_with("Distribution") {
     crate::emit_message(&format!(
       "CompoundPoissonDistribution::univ: -- Message text not found -- ({}) ({}) ({})",
-      crate::syntax::expr_to_string(&dargs[1]),
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[0]),
       dist_str()
     ));
     return bail();
@@ -8634,12 +8626,11 @@ fn hoyt_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = try_eval_to_f64;
-  let dist =
-    || crate::syntax::expr_to_string(&unevaluated("HoytDistribution", dargs));
+  let dist = || expr_to_string(&unevaluated("HoytDistribution", dargs));
   if num(&dargs[0]).is_some_and(|v| !(v > 0.0 && v <= 1.0)) {
     crate::emit_message(&format!(
       "HoytDistribution::pprobprm: Parameter {} at position 1 in {} is expected to be positive and less than or equal to 1.",
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[0]),
       dist()
     ));
     return None;
@@ -8647,7 +8638,7 @@ fn hoyt_checked(dargs: &[Expr]) -> Option<()> {
   if num(&dargs[1]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
       "HoytDistribution::posprm: Parameter {} at position 2 in {} is expected to be positive.",
-      crate::syntax::expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[1]),
       dist()
     ));
     return None;
@@ -8755,17 +8746,13 @@ fn variance_gamma_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = try_eval_to_f64;
-  let dist = || {
-    crate::syntax::expr_to_string(&unevaluated(
-      "VarianceGammaDistribution",
-      dargs,
-    ))
-  };
+  let dist =
+    || expr_to_string(&unevaluated("VarianceGammaDistribution", dargs));
   for pos in 0..2 {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
       crate::emit_message(&format!(
         "VarianceGammaDistribution::posprm: Parameter {} at position {} in {} is expected to be positive.",
-        crate::syntax::expr_to_string(&dargs[pos]),
+        expr_to_string(&dargs[pos]),
         pos + 1,
         dist()
       ));
@@ -8935,16 +8922,12 @@ fn tsallis_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = try_eval_to_f64;
-  let dist = || {
-    crate::syntax::expr_to_string(&unevaluated(
-      "TsallisQGaussianDistribution",
-      dargs,
-    ))
-  };
+  let dist =
+    || expr_to_string(&unevaluated("TsallisQGaussianDistribution", dargs));
   if num(&dargs[1]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
       "TsallisQGaussianDistribution::posprm: Parameter {} at position 2 in {} is expected to be positive.",
-      crate::syntax::expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[1]),
       dist()
     ));
     return None;
@@ -8952,7 +8935,7 @@ fn tsallis_checked(dargs: &[Expr]) -> Option<()> {
   if num(&dargs[2]).is_some_and(|v| v >= 3.0) {
     crate::emit_message(&format!(
       "TsallisQGaussianDistribution::lss: Parameter {} at position 3 in {} is expected to be less than 3.",
-      crate::syntax::expr_to_string(&dargs[2]),
+      expr_to_string(&dargs[2]),
       dist()
     ));
     return None;
@@ -9499,12 +9482,9 @@ fn hotelling_checked(dargs: &[Expr]) -> Option<()> {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
       crate::emit_message(&format!(
         "HotellingTSquareDistribution::posprm: Parameter {} at position {} in {} is expected to be positive.",
-        crate::syntax::expr_to_string(&dargs[pos]),
+        expr_to_string(&dargs[pos]),
         pos + 1,
-        crate::syntax::expr_to_string(&unevaluated(
-          "HotellingTSquareDistribution",
-          dargs
-        ))
+        expr_to_string(&unevaluated("HotellingTSquareDistribution", dargs))
       ));
       return None;
     }
@@ -9729,13 +9709,12 @@ fn benini_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = try_eval_to_f64;
-  let dist =
-    || crate::syntax::expr_to_string(&unevaluated("BeniniDistribution", dargs));
+  let dist = || expr_to_string(&unevaluated("BeniniDistribution", dargs));
   for pos in 0..2 {
     if num(&dargs[pos]).is_some_and(|v| v < 0.0) {
       crate::emit_message(&format!(
         "BeniniDistribution::nnegprm: Parameter {} at position {} in {} is expected to be non-negative.",
-        crate::syntax::expr_to_string(&dargs[pos]),
+        expr_to_string(&dargs[pos]),
         pos + 1,
         dist()
       ));
@@ -9745,7 +9724,7 @@ fn benini_checked(dargs: &[Expr]) -> Option<()> {
   if num(&dargs[2]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
       "BeniniDistribution::posprm: Parameter {} at position 3 in {} is expected to be positive.",
-      crate::syntax::expr_to_string(&dargs[2]),
+      expr_to_string(&dargs[2]),
       dist()
     ));
     return None;
@@ -9926,11 +9905,8 @@ fn vonmises_checked(dargs: &[Expr]) -> Option<()> {
   if num(&dargs[1]).is_some_and(|v| v < 0.0) {
     crate::emit_message(&format!(
       "VonMisesDistribution::nnegprm: Parameter {} at position 2 in {} is expected to be non-negative.",
-      crate::syntax::expr_to_string(&dargs[1]),
-      crate::syntax::expr_to_string(&unevaluated(
-        "VonMisesDistribution",
-        dargs
-      ))
+      expr_to_string(&dargs[1]),
+      expr_to_string(&unevaluated("VonMisesDistribution", dargs))
     ));
     return None;
   }
@@ -9977,17 +9953,13 @@ fn hyperexponential_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   let [Expr::List(probs), Expr::List(rates)] = dargs else {
     return None;
   };
-  let dist = || {
-    crate::syntax::expr_to_string(&unevaluated(
-      "HyperexponentialDistribution",
-      dargs,
-    ))
-  };
+  let dist =
+    || expr_to_string(&unevaluated("HyperexponentialDistribution", dargs));
   if probs.len() != rates.len() {
     crate::emit_message(&format!(
       "HyperexponentialDistribution::eqln: The values {} and {} at positions 1 and 2 in {} are expected to have the same length.",
-      crate::syntax::expr_to_string(&dargs[0]),
-      crate::syntax::expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[1]),
       dist()
     ));
     return None;
@@ -10000,7 +9972,7 @@ fn hyperexponential_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   if negative || bad_sum {
     crate::emit_message(&format!(
       "HyperexponentialDistribution::vprobprm: The value {} at position 1 in {} is expected to be a list of non-negative numbers summing to 1.",
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[0]),
       dist()
     ));
     return None;
@@ -10008,7 +9980,7 @@ fn hyperexponential_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   if rates.iter().any(|r| num(r).is_some_and(|v| v <= 0.0)) {
     crate::emit_message(&format!(
       "HyperexponentialDistribution::vrpos: The value {} at position 2 in {} is expected to be a list of positive numbers.",
-      crate::syntax::expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[1]),
       dist()
     ));
     return None;
@@ -10162,13 +10134,12 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   let [Expr::List(alphas), Expr::List(rates)] = dargs else {
     return None;
   };
-  let dist =
-    || crate::syntax::expr_to_string(&unevaluated("CoxianDistribution", dargs));
+  let dist = || expr_to_string(&unevaluated("CoxianDistribution", dargs));
   if rates.len() != alphas.len() + 1 {
     crate::emit_message(&format!(
       "CoxianDistribution::eqln2: The length of {} at position 2 should be 1 more than the length of {} at position 1 in {}.",
-      crate::syntax::expr_to_string(&dargs[1]),
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[0]),
       dist()
     ));
     return None;
@@ -10180,7 +10151,7 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   {
     crate::emit_message(&format!(
       "CoxianDistribution::vprobprm2: The value {} at position 1 in {} is expected to be a list of numbers between 0 and 1, inclusive.",
-      crate::syntax::expr_to_string(&dargs[0]),
+      expr_to_string(&dargs[0]),
       dist()
     ));
     return None;
@@ -10188,7 +10159,7 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   if rates.iter().any(|r| num(r).is_some_and(|v| v <= 0.0)) {
     crate::emit_message(&format!(
       "CoxianDistribution::vrpos: The value {} at position 2 in {} is expected to be a list of positive numbers.",
-      crate::syntax::expr_to_string(&dargs[1]),
+      expr_to_string(&dargs[1]),
       dist()
     ));
     return None;
@@ -10936,12 +10907,8 @@ pub fn negative_multinomial_covariance(
 pub fn wishart_mean_variance(
   dargs: &[Expr],
 ) -> Result<(Expr, Expr), InterpreterError> {
-  let dist_str = || {
-    crate::syntax::expr_to_string(&unevaluated(
-      "WishartMatrixDistribution",
-      dargs,
-    ))
-  };
+  let dist_str =
+    || expr_to_string(&unevaluated("WishartMatrixDistribution", dargs));
   let fail = |msg: String| -> Result<(Expr, Expr), InterpreterError> {
     crate::emit_message(&msg);
     Err(InterpreterError::EvaluationError(
@@ -10959,7 +10926,7 @@ pub fn wishart_mean_variance(
   let posdefprm = |s: &Expr| {
     format!(
       "WishartMatrixDistribution::posdefprm: The value {} at position 2 in {} is expected to be a symmetric positive definite matrix.",
-      crate::syntax::expr_to_string(s),
+      expr_to_string(s),
       dist_str()
     )
   };
@@ -13180,7 +13147,7 @@ fn data_distribution_pdf_cdf(
 /// support conditions, and the coefficient quirks (6*E^...,
 /// E^.../Sqrt[2*Pi], (3*E^...)/Sqrt[2*Pi], and the lambda = 2 special
 /// case E^...*Sqrt[2/Pi]).
-fn pdf_product_distribution(dargs: &[Expr], x: &Expr) -> crate::syntax::Expr {
+fn pdf_product_distribution(dargs: &[Expr], x: &Expr) -> Expr {
   let unevaluated = || {
     call(
       "PDF",
@@ -17758,9 +17725,7 @@ fn singh_maddala_mean_variance(
 
 /// Mean and variance for the 4-argument BetaPrimeDistribution[p, q, b, a]
 /// (power b, scale a), each existing only above a moment threshold in b*q.
-fn beta_prime4_mean_variance(
-  dargs: &[Expr],
-) -> (crate::syntax::Expr, crate::syntax::Expr) {
+fn beta_prime4_mean_variance(dargs: &[Expr]) -> (Expr, Expr) {
   let (p, q, b, a) = (
     dargs[0].clone(),
     dargs[1].clone(),
@@ -17805,9 +17770,7 @@ fn beta_prime4_mean_variance(
 
 /// Mean and variance for the 3-argument ParetoDistribution[k, a, m]
 /// (Type II / Lomax, scale k, location m).
-fn pareto3_mean_variance(
-  dargs: &[Expr],
-) -> (crate::syntax::Expr, crate::syntax::Expr) {
+fn pareto3_mean_variance(dargs: &[Expr]) -> (Expr, Expr) {
   let (k, a, m) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
   // Mean = k/(a - 1) + m, for a > 1.
   let mean = piecewise(
@@ -17836,9 +17799,7 @@ fn pareto3_mean_variance(
 
 /// Mean and variance for the 4-argument ParetoDistribution[k, a, g, m]
 /// (extra shape g), each existing only above a threshold in a/g.
-fn pareto4_mean_variance(
-  dargs: &[Expr],
-) -> (crate::syntax::Expr, crate::syntax::Expr) {
+fn pareto4_mean_variance(dargs: &[Expr]) -> (Expr, Expr) {
   let (k, a, g, m) = (
     dargs[0].clone(),
     dargs[1].clone(),
@@ -17983,11 +17944,11 @@ pub fn truncated_distribution_value(
       vec![
         Expr::Comparison {
           operands: vec![lo.clone(), x.clone()],
-          operators: vec![crate::syntax::ComparisonOp::LessEqual],
+          operators: vec![ComparisonOp::LessEqual],
         },
         Expr::Comparison {
           operands: vec![x.clone(), hi.clone()],
-          operators: vec![crate::syntax::ComparisonOp::LessEqual],
+          operators: vec![ComparisonOp::LessEqual],
         },
       ],
     )
@@ -18079,19 +18040,18 @@ pub fn censored_distribution_value(
   let eval = |name: &str, args: Vec<Expr>| -> Result<Expr, InterpreterError> {
     crate::evaluator::evaluate_expr_to_expr(&call(name, args))
   };
-  let decides =
-    |a: &Expr, op: crate::syntax::ComparisonOp, b: &Expr| -> Option<bool> {
-      let r = crate::evaluator::evaluate_expr_to_expr(&Expr::Comparison {
-        operands: vec![a.clone(), b.clone()],
-        operators: vec![op],
-      })
-      .ok()?;
-      match r {
-        Expr::Identifier(ref t) if t == "True" => Some(true),
-        Expr::Identifier(ref t) if t == "False" => Some(false),
-        _ => None,
-      }
-    };
+  let decides = |a: &Expr, op: ComparisonOp, b: &Expr| -> Option<bool> {
+    let r = crate::evaluator::evaluate_expr_to_expr(&Expr::Comparison {
+      operands: vec![a.clone(), b.clone()],
+      operators: vec![op],
+    })
+    .ok()?;
+    match r {
+      Expr::Identifier(ref t) if t == "True" => Some(true),
+      Expr::Identifier(ref t) if t == "False" => Some(false),
+      _ => None,
+    }
+  };
 
   match head {
     "CDF" => {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -220,7 +220,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() == 3 {
     let (a, z0, z1) = (&args[0], &args[1], &args[2]);
     // Gamma[a, z, z] = 0
-    if crate::syntax::expr_to_string(z0) == crate::syntax::expr_to_string(z1) {
+    if expr_to_string(z0) == expr_to_string(z1) {
       return Ok(Expr::Integer(0));
     }
     // Gamma[a, z0, Infinity] = Gamma[a, z0]   (Gamma[a, Infinity] = 0)

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1932,7 +1932,7 @@ fn wigner_d_small_symbolic(
   m1_2: i64,
   m2_2: i64,
   theta: &Expr,
-) -> crate::syntax::Expr {
+) -> Expr {
   let jpm1 = i64::midpoint(j2, m1_2);
   let jmm1 = (j2 - m1_2) / 2;
   let jpm2 = i64::midpoint(j2, m2_2);

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -2958,7 +2958,7 @@ fn factor_integer_rational(
   Ok(Expr::List(result.into()))
 }
 
-fn factor_integer_i128(n: i128) -> crate::syntax::Expr {
+fn factor_integer_i128(n: i128) -> Expr {
   if n == 0 {
     // wolframscript: FactorInteger[0] = {{0, 1}} (0 treated as 0^1).
     return Expr::List(
@@ -3024,7 +3024,7 @@ fn factor_integer_i128(n: i128) -> crate::syntax::Expr {
   Expr::List(factors.into())
 }
 
-fn factor_integer_bigint(n: &BigInt) -> crate::syntax::Expr {
+fn factor_integer_bigint(n: &BigInt) -> Expr {
   use num_traits::{One, Signed, Zero};
 
   if n.is_zero() {
@@ -3170,7 +3170,7 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let nninfseq = || {
     crate::emit_message(&format!(
       "IntegerPartitions::nninfseq: Position 2 of {} must be All, Infinity, nmax, {{nmin}}, {{nmin, nmax}} or {{nmin, nmax, dn}}, where nmin is a non-negative integer, nmax is a non-negative integer or Infinity, and dn is a nonzero integer.",
-      crate::syntax::expr_to_string(&unevaluated("IntegerPartitions", args))
+      expr_to_string(&unevaluated("IntegerPartitions", args))
     ));
     Ok(unevaluated("IntegerPartitions", args))
   };

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -2426,7 +2426,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if let Some(p) = &p_expr {
       crate::emit_message(&format!(
         "Norm::ptype: The second argument of Norm, {}, should be a symbol, Infinity or an integer or real number not less than 1 for vector p-norms; or 1, 2, Infinity or \"Frobenius\" for matrix norms.",
-        crate::syntax::expr_to_string(p)
+        expr_to_string(p)
       ));
     }
     Ok(unevaluated("Norm", args))
@@ -7172,7 +7172,7 @@ pub fn list_z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let Expr::List(items) = &args[0] else {
     crate::emit_message(&format!(
       "ListZTransform::arg1: Expected a numeric array instead of {}.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return uneval();
   };
@@ -7220,7 +7220,7 @@ pub fn discrete_hadamard_transform_ast(
   let data_err = || {
     crate::emit_message(&format!(
       "DiscreteHadamardTransform::data: {} is not a numerical array.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     Ok(unevaluated("DiscreteHadamardTransform", args))
   };

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1684,7 +1684,7 @@ fn legendre_q_associated_ast(
   n_expr: &Expr,
   m_expr: &Expr,
   z_expr: &Expr,
-) -> crate::syntax::Expr {
+) -> Expr {
   let unevaluated = || {
     call(
       "LegendreQ",
@@ -3208,7 +3208,7 @@ fn laguerre_eval_f64(n: usize, x: f64) -> f64 {
 
 /// Build symbolic Laguerre polynomial L_n(x)
 /// Output as (c_0 + c_1*x + c_2*x^2 + ...) / n!
-fn laguerre_polynomial_symbolic(n: usize, x: &Expr) -> crate::syntax::Expr {
+fn laguerre_polynomial_symbolic(n: usize, x: &Expr) -> Expr {
   use num_traits::Zero;
   let (n_fact, coeffs) = laguerre_scaled_coefficients(n);
   let mut terms: Vec<Expr> = Vec::new();
@@ -3500,7 +3500,7 @@ fn hermite_coefficients(n: usize) -> Option<Vec<i128>> {
 /// canonical Sin-based form. Treats both `Power[..., Rational[1, 2]]` and
 /// the equivalent BinaryOp tree.
 fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
-  let theta_str = crate::syntax::expr_to_string(theta);
+  let theta_str = expr_to_string(theta);
   // Match Cos[θ]^2 in any form (BinaryOp::Power or Power FunctionCall).
   let is_cos_theta_sq = |e: &Expr| -> bool {
     let (base, exp) = match e {
@@ -3519,7 +3519,7 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
     if !matches!(exp, Expr::Integer(2)) {
       return false;
     }
-    matches!(base, Expr::FunctionCall { name, args } if name == "Cos" && args.len() == 1 && crate::syntax::expr_to_string(&args[0]) == theta_str)
+    matches!(base, Expr::FunctionCall { name, args } if name == "Cos" && args.len() == 1 && expr_to_string(&args[0]) == theta_str)
   };
   let is_one_minus_cos_sq = |e: &Expr| -> bool {
     // Match: 1 - Cos[θ]^2 in either `BinaryOp::Minus` or

--- a/src/functions/math_ast/polylog.rs
+++ b/src/functions/math_ast/polylog.rs
@@ -182,7 +182,7 @@ fn polylog_s1(z_expr: &Expr) -> Result<Expr, InterpreterError> {
   }
 }
 
-fn polylog_s1_symbolic(z_expr: &Expr) -> crate::syntax::Expr {
+fn polylog_s1_symbolic(z_expr: &Expr) -> Expr {
   let one_minus_z = minus2(Expr::Integer(1), z_expr.clone());
   times2(Expr::Integer(-1), call1("Log", one_minus_z))
 }
@@ -293,7 +293,7 @@ fn eulerian_numbers(n: usize) -> Vec<i128> {
 }
 
 /// PolyLog[s, -1] = -(1 - 2^{1-s}) * Zeta[s] for s >= 2
-fn polylog_at_neg1(s: i128) -> crate::syntax::Expr {
+fn polylog_at_neg1(s: i128) -> Expr {
   let s_usize = s as usize;
 
   if s % 2 == 0 {

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -5,13 +5,13 @@ use super::*;
 /// invalid dimension specification (a negative integer, a non-integer, or a
 /// list containing one) in position 2 of a Random* array generator, matching
 /// wolframscript instead of raising a hard evaluation error.
-fn random_array_dims_error(name: &str, args: &[Expr]) -> crate::syntax::Expr {
+fn random_array_dims_error(name: &str, args: &[Expr]) -> Expr {
   let call = unevaluated(name, args);
   crate::emit_message(&format!(
     "{}::array: The array dimensions {} given in position 2 of {} should be a list of non-negative machine-sized integers giving the dimensions for the result.",
     name,
-    crate::syntax::expr_to_string(&args[1]),
-    crate::syntax::expr_to_string(&call)
+    expr_to_string(&args[1]),
+    expr_to_string(&call)
   ));
   call
 }
@@ -951,7 +951,7 @@ pub fn random_choice_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // raising a hard error (wolframscript parity).
         crate::emit_message(&format!(
           "RandomChoice::lrwl: The items for choice {} should be a nonempty list or a rule weights -> choices.",
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Ok(unevaluated("RandomChoice", args));
       }
@@ -1120,8 +1120,7 @@ pub fn random_sample_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Match wolframscript: emit RandomSample::intnm and return the
         // call unevaluated rather than aborting. Covers the dim-list
         // form (e.g. {2, 3}) which Wolfram doesn't support either.
-        let arg_strs: Vec<String> =
-          args.iter().map(crate::syntax::expr_to_output).collect();
+        let arg_strs: Vec<String> = args.iter().map(expr_to_output).collect();
         crate::emit_message(&format!(
           "RandomSample::intnm: Non-negative machine-sized integer expected at position 2 in RandomSample[{}].",
           arg_strs.join(", "),
@@ -1635,7 +1634,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(_) => {
       crate::emit_message(&format!(
         "RandomPrime::intp: {} is not a positive integer.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return uneval();
     }
@@ -1647,7 +1646,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Expr::Integer(_) | Expr::Real(_) => {
             crate::emit_message(&format!(
               "RandomPrime::intp: {} is not a positive integer.",
-              crate::syntax::expr_to_string(it)
+              expr_to_string(it)
             ));
             return uneval();
           }
@@ -1675,7 +1674,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let posdim = || {
     crate::emit_message(&format!(
       "RandomPrime::posdim: The dimensions parameter {} is expected to be a positive integer or a list of positive integers.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     Ok(unevaluated("RandomPrime", args))
   };

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -4023,7 +4023,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if invalid {
     crate::emit_message(&format!(
       "Quantile::nquan: The Quantile specification {} should be a number or a list of numbers between 0 and 1.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated("Quantile", args));
   }
@@ -4150,7 +4150,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(quantile_single(&sorted, &args[1]))
 }
 
-fn quantile_single(sorted: &[&Expr], q: &Expr) -> crate::syntax::Expr {
+fn quantile_single(sorted: &[&Expr], q: &Expr) -> Expr {
   let n = sorted.len();
   // Default Quantile uses Type 1 (inverse of CDF)
   // Index = Ceiling[q * n]
@@ -4754,7 +4754,7 @@ fn format_location_test_result(
   df: f64,
   property: &str,
   test_name: &str,
-) -> crate::syntax::Expr {
+) -> Expr {
   match property {
     "TestStatistic" => num_to_expr(t_stat),
     "PValue" => {
@@ -7017,7 +7017,7 @@ pub fn absolute_correlation_function_ast(
   let bdlag = || {
     crate::emit_message(&format!(
       "AbsoluteCorrelationFunction::bdlag: The lag specification {} should be a symbol, an integer with magnitude less than the length of the data or a range specification indicating such integers.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
   };
   let single = |h: i128| -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -2345,9 +2345,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return crate::evaluator::evaluate_expr_to_expr(&neg1(erf_z0));
     }
     // Erf[z, z] = 0
-    if crate::syntax::expr_to_string(&args[0])
-      == crate::syntax::expr_to_string(&args[1])
-    {
+    if expr_to_string(&args[0]) == expr_to_string(&args[1]) {
       return Ok(Expr::Integer(0));
     }
     // Numeric: as soon as either argument is inexact, wolframscript
@@ -6083,9 +6081,7 @@ pub fn trig_reduce_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::evaluator::evaluate_function_call_ast("Expand", &[evaluated])?;
     let combined =
       crate::evaluator::evaluate_function_call_ast("Together", &[expanded])?;
-    if crate::syntax::expr_to_string(&combined)
-      == crate::syntax::expr_to_string(&current)
-    {
+    if expr_to_string(&combined) == expr_to_string(&current) {
       break;
     }
     current = combined;

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -1695,11 +1695,8 @@ fn compound_head_renamings(vars: &Expr, domain: &Expr) -> Vec<(Expr, String)> {
     if matches!(head, Expr::Identifier(_)) {
       continue;
     }
-    let key = crate::syntax::expr_to_string(&head);
-    if renames
-      .iter()
-      .any(|(h, _)| crate::syntax::expr_to_string(h) == key)
-    {
+    let key = expr_to_string(&head);
+    if renames.iter().any(|(h, _)| expr_to_string(h) == key) {
       continue;
     }
     let fresh = format!("NDSolve$fn${}", renames.len() + 1);
@@ -1712,9 +1709,9 @@ fn compound_head_renamings(vars: &Expr, domain: &Expr) -> Vec<(Expr, String)> {
 /// `Subscript[c, 1][t]` into `NDSolve$fn$1[t]` and
 /// `Derivative[1][Subscript[c, 1]][t]` into `Derivative[1][NDSolve$fn$1][t]`.
 fn rename_compound_heads(expr: &Expr, renames: &[(Expr, String)]) -> Expr {
-  let key = crate::syntax::expr_to_string(expr);
+  let key = expr_to_string(expr);
   for (head, fresh) in renames {
-    if crate::syntax::expr_to_string(head) == key {
+    if expr_to_string(head) == key {
       return Expr::Identifier(fresh.clone());
     }
   }
@@ -1803,10 +1800,11 @@ fn indexed_family_renamings(vars: &Expr, domain: &Expr) -> Vec<IndexedRename> {
       continue;
     }
     let index = args[0].clone();
-    let index_key = crate::syntax::expr_to_string(&index);
-    if renames.iter().any(|r| {
-      r.head == *name && crate::syntax::expr_to_string(&r.index) == index_key
-    }) {
+    let index_key = expr_to_string(&index);
+    if renames
+      .iter()
+      .any(|r| r.head == *name && expr_to_string(&r.index) == index_key)
+    {
       continue;
     }
     let fresh = format!("NDSolve$idx${name}${}", renames.len() + 1);
@@ -1846,10 +1844,11 @@ fn rename_indexed_vars(expr: &Expr, renames: &[IndexedRename]) -> Expr {
     && orders.len() == 2
     && matches!(orders[0], Expr::Integer(0))
   {
-    let index_key = crate::syntax::expr_to_string(&args[0]);
-    if let Some(r) = renames.iter().find(|r| {
-      r.head == *fname && crate::syntax::expr_to_string(&r.index) == index_key
-    }) {
+    let index_key = expr_to_string(&args[0]);
+    if let Some(r) = renames
+      .iter()
+      .find(|r| r.head == *fname && expr_to_string(&r.index) == index_key)
+    {
       let other = rename_indexed_vars(&args[1], renames);
       return Expr::CurriedCall {
         func: Box::new(Expr::CurriedCall {
@@ -1863,10 +1862,11 @@ fn rename_indexed_vars(expr: &Expr, renames: &[IndexedRename]) -> Expr {
   if let Expr::FunctionCall { name, args } = expr
     && args.len() == 2
   {
-    let index_key = crate::syntax::expr_to_string(&args[0]);
-    if let Some(r) = renames.iter().find(|r| {
-      r.head == *name && crate::syntax::expr_to_string(&r.index) == index_key
-    }) {
+    let index_key = expr_to_string(&args[0]);
+    if let Some(r) = renames
+      .iter()
+      .find(|r| r.head == *name && expr_to_string(&r.index) == index_key)
+    {
       let other = rename_indexed_vars(&args[1], renames);
       return Expr::FunctionCall {
         name: r.fresh.clone(),
@@ -5453,7 +5453,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
     }
     _ => Err(InterpreterError::EvaluationError(format!(
       "cannot convert {} to a numeric value",
-      crate::syntax::expr_to_string(expr)
+      expr_to_string(expr)
     ))),
   }
 }
@@ -5751,7 +5751,7 @@ fn build_2d_list_interpolation(
   grid: &Grid,
   interp_order: i128,
   head: &str,
-) -> crate::syntax::Expr {
+) -> Expr {
   let (exprs, _vals) = &grid;
   let nr = exprs.len();
   let nc = exprs[0].len();
@@ -6780,7 +6780,7 @@ fn lagrange_polynomial(
     for j in 0..m {
       if j != i {
         factors.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(minus(var, &xs[j])),
           right: Box::new(minus(&xs[i], &xs[j])),
         });
@@ -7684,7 +7684,7 @@ fn collect_second_order_pde_terms(
 
 /// Whether `name` occurs anywhere in `expr` as a symbol.
 fn expr_mentions(expr: &Expr, name: &str) -> bool {
-  crate::syntax::expr_to_string(expr)
+  expr_to_string(expr)
     .split(|c: char| !(c.is_alphanumeric() || c == '$'))
     .any(|tok| tok == name)
 }

--- a/src/functions/paclet.rs
+++ b/src/functions/paclet.rs
@@ -13,10 +13,9 @@
 //!                     "Context" -> {"MyPaclet`"}}}|>]
 //! ```
 
+use super::*;
 use std::cell::RefCell;
 use std::path::{Component, Path, PathBuf};
-
-use crate::syntax::Expr;
 
 thread_local! {
   /// Directories registered by `PacletDirectoryLoad`, in registration order.

--- a/src/functions/periodic_table_plot.rs
+++ b/src/functions/periodic_table_plot.rs
@@ -309,7 +309,7 @@ fn parse_highlights(first: Option<&Expr>) -> HighlightSpec {
           crate::emit_message_to_stdout(&format!(
             "PeriodicTablePlot::inpt: Input {} should be an \"Element\" \
              Entity or EntityProperty.",
-            crate::syntax::expr_to_output(other)
+            expr_to_output(other)
           ));
           HighlightSpec::Unevaluated
         }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -8074,7 +8074,7 @@ pub(crate) fn bare_tick_label(e: &Expr, pos: f64) -> String {
       // A negative literal may arrive either folded into the number or as
       // a minus applied to it, depending on how the list was written.
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => is_literal_number(operand),
       _ => false,
@@ -8271,7 +8271,7 @@ pub(crate) fn parse_plot_legends(
         .iter()
         .map(|item| {
           crate::functions::chart::expr_to_label(item)
-            .unwrap_or_else(|| crate::syntax::expr_to_string(item))
+            .unwrap_or_else(|| expr_to_string(item))
         })
         .collect();
       (labels, false, false, LegendPosition::Right)
@@ -8860,7 +8860,7 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       bodies.push(&cargs[0]);
       let label = match &cargs[1] {
         Expr::String(s) => s.clone(),
-        other => crate::syntax::expr_to_output(other),
+        other => expr_to_output(other),
       };
       plot_opts.callout_labels.push(Some(label));
     } else {
@@ -8874,9 +8874,7 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && plot_opts.plot_legends.is_empty()
   {
     for b in &bodies {
-      plot_opts
-        .plot_legends
-        .push(crate::syntax::expr_to_output(b));
+      plot_opts.plot_legends.push(expr_to_output(b));
     }
   }
 
@@ -9198,9 +9196,7 @@ fn log_scale_plot_ast(
     && plot_opts.plot_legends.is_empty()
   {
     for b in &bodies {
-      plot_opts
-        .plot_legends
-        .push(crate::syntax::expr_to_output(b));
+      plot_opts.plot_legends.push(expr_to_output(b));
     }
   }
 

--- a/src/functions/plot_epilog.rs
+++ b/src/functions/plot_epilog.rs
@@ -602,7 +602,7 @@ fn render_item(
           // SVG markup; a plain one goes through the same path, which
           // escapes it.
           let label = styled.as_ref().map_or_else(
-            || svg_escape_text(&crate::syntax::expr_to_output(body)),
+            || svg_escape_text(&expr_to_output(body)),
             super::chart::StyledLabel::svg,
           );
           let font_size =

--- a/src/functions/polygon_holes.rs
+++ b/src/functions/polygon_holes.rs
@@ -14,7 +14,7 @@
 //! outer boundary through a bridge edge, and the resulting simple polygon
 //! is ear-clipped.
 
-use crate::syntax::Expr;
+use super::*;
 
 /// Split a `Polygon`/`Triangle` first argument into its outer boundary and
 /// hole boundaries. Returns `None` when the argument is not a rule, i.e.

--- a/src/functions/polyhedron_operations.rs
+++ b/src/functions/polyhedron_operations.rs
@@ -13,10 +13,10 @@
 //! coordinates). [`resolve_transforms`] does the equivalent resolution so
 //! the truncation/stellation itself can run per `Polygon` face.
 
+use super::*;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot3d::rotation_matrix;
 use crate::helpers::call1;
-use crate::syntax::Expr;
 
 /// `Truncate[expr]` truncates to this fraction of each edge's length.
 pub(crate) const DEFAULT_TRUNCATE_RATIO: f64 = 0.3;

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -199,7 +199,7 @@ fn apart_expr_raw(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
 }
 
 /// Perform partial fraction decomposition for a proper fraction (deg(num) < deg(den))
-fn apart_proper_fraction(expr: &Expr, var: &str) -> crate::syntax::Expr {
+fn apart_proper_fraction(expr: &Expr, var: &str) -> Expr {
   let (num, den) = match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Divide,

--- a/src/functions/polynomial_ast/coefficient.rs
+++ b/src/functions/polynomial_ast/coefficient.rs
@@ -335,10 +335,7 @@ fn factor_subset_remainder(
 /// variable monomial — e.g. `2*x`, `(-2)*x`, `b*x`. Each expanded term
 /// must contain the form's factor multiset literally; the leftover
 /// factors form the contribution.
-fn coefficient_of_general_form(
-  expr: &Expr,
-  form_factors: &[Expr],
-) -> crate::syntax::Expr {
+fn coefficient_of_general_form(expr: &Expr, form_factors: &[Expr]) -> Expr {
   let expanded = expand_expr(expr);
   let terms = collect_additive_terms(&expanded);
   let mut contributions: Vec<Expr> = Vec::new();
@@ -364,10 +361,7 @@ fn coefficient_of_general_form(
 }
 
 /// Extract the coefficient of a multivariate monomial from a polynomial.
-fn coefficient_of_monomial(
-  expr: &Expr,
-  var_powers: &[(String, i128)],
-) -> crate::syntax::Expr {
+fn coefficient_of_monomial(expr: &Expr, var_powers: &[(String, i128)]) -> Expr {
   let expanded = expand_expr(expr);
   let terms = collect_additive_terms(&expanded);
   let mut coeff_sum: Vec<Expr> = Vec::new();

--- a/src/functions/polynomial_ast/collect.rs
+++ b/src/functions/polynomial_ast/collect.rs
@@ -205,7 +205,7 @@ pub fn collect_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: if let Expr::Identifier(n) = h {
           n.clone()
         } else {
-          crate::syntax::expr_to_string(h)
+          expr_to_string(h)
         },
         args: vec![combined_coeff].into(),
       };
@@ -607,8 +607,7 @@ fn build_times_chain(factors: &[Expr]) -> Expr {
 /// Recursively replace every occurrence of `from` with `to` in `expr`,
 /// using structural equality (via pretty-printed form).
 fn substitute_expr_local(expr: &Expr, from: &Expr, to: &Expr) -> Expr {
-  if crate::syntax::expr_to_string(expr) == crate::syntax::expr_to_string(from)
-  {
+  if expr_to_string(expr) == expr_to_string(from) {
     return to.clone();
   }
   match expr {

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -156,7 +156,7 @@ pub fn contains_var(expr: &Expr, var: &str) -> bool {
 fn eliminate_one_variable(
   equations: &[Expr],
   var: &str,
-) -> std::vec::Vec<crate::syntax::Expr> {
+) -> std::vec::Vec<Expr> {
   // Find an equation containing the variable, preferring linear ones
   let mut solve_idx = None;
   let mut solve_degree = i128::MAX;
@@ -209,7 +209,7 @@ fn eliminate_one_variable(
 }
 
 /// Simplify an equation by evaluating both sides
-fn simplify_equation(eq: &Expr) -> crate::syntax::Expr {
+fn simplify_equation(eq: &Expr) -> Expr {
   match eq {
     Expr::Comparison {
       operands,

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -182,7 +182,7 @@ pub fn exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// across the additive terms of `expr`. The expression is NOT expanded, so a
 /// compound form such as `x + 1` keeps its structure
 /// (Exponent[(x + 1)^2, x + 1] = 2). A form that never appears contributes 0.
-fn exponent_of_form(args: &[Expr]) -> crate::syntax::Expr {
+fn exponent_of_form(args: &[Expr]) -> Expr {
   let form = &args[1];
   let terms = super::coefficient::collect_additive_terms(&args[0]);
   let mut powers: Vec<Rat> =
@@ -344,7 +344,7 @@ fn build_max_expr(mut exprs: Vec<Expr>) -> Expr {
   let mut seen: std::collections::HashSet<String> =
     std::collections::HashSet::new();
   exprs.retain(|e| {
-    let key = crate::syntax::expr_to_string(e);
+    let key = expr_to_string(e);
     seen.insert(key)
   });
   // Defer to Max's own evaluator: it will pick the max when all entries are

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -1885,10 +1885,7 @@ fn divide_terms_by(
 }
 
 /// Factor out the GCD of numeric coefficients from all terms.
-pub(crate) fn factor_terms_numeric(
-  expanded: &Expr,
-  terms: &[Expr],
-) -> crate::syntax::Expr {
+pub(crate) fn factor_terms_numeric(expanded: &Expr, terms: &[Expr]) -> Expr {
   let Some((num_gcd, den_lcm, coeffs)) = rational_content(terms) else {
     return expanded.clone();
   };
@@ -1932,7 +1929,7 @@ pub(crate) fn factor_terms_numeric(
 /// FactorTerms[poly, x] — factor out terms that don't depend on x.
 /// Groups terms by power of x, collects the coefficient of each power,
 /// then factors out the polynomial GCD of those coefficient expressions.
-fn factor_terms_wrt_var(expr: &Expr, var: &str) -> crate::syntax::Expr {
+fn factor_terms_wrt_var(expr: &Expr, var: &str) -> Expr {
   let terms = collect_additive_terms(expr);
 
   // Collect coefficients for each power of x
@@ -2368,10 +2365,9 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
   let mut items: Vec<(Expr, i128)> = Vec::new();
   let mut sum_changed = false;
   let merge = |base: Expr, exp: i128, items: &mut Vec<(Expr, i128)>| {
-    let key = crate::syntax::expr_to_string(&base);
-    if let Some(entry) = items
-      .iter_mut()
-      .find(|(b, _)| crate::syntax::expr_to_string(b) == key)
+    let key = expr_to_string(&base);
+    if let Some(entry) =
+      items.iter_mut().find(|(b, _)| expr_to_string(b) == key)
     {
       entry.1 += exp;
     } else {
@@ -2414,9 +2410,7 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
     // Square-free factor the primitive (a sum, so this recursion cannot
     // re-enter the product path).
     let factored = factor_square_free_ast(std::slice::from_ref(&primitive))?;
-    if crate::syntax::expr_to_string(&factored)
-      != crate::syntax::expr_to_string(&primitive)
-    {
+    if expr_to_string(&factored) != expr_to_string(&primitive) {
       sum_changed = true;
     }
     let Some((n2, d2, sub_items)) = decompose_content_factors(&factored) else {
@@ -3568,7 +3562,7 @@ fn min_term_coefficient(expr: &Expr) -> i128 {
 fn factor_multivariate(
   expanded: &Expr,
   vars: std::collections::HashSet<String>,
-) -> crate::syntax::Expr {
+) -> Expr {
   // Fast path: a^n ± b^n decomposes directly via cyclotomic polynomials.
   // Skips the expensive Kronecker substitution path, which was effectively
   // hanging on inputs like `Factor[x^10 - y^10]` (degree-110 sparse trial

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -255,7 +255,7 @@ fn negate_if_negative(t: &Expr) -> Option<Expr> {
   };
   match t {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some((**operand).clone()),
     Expr::Integer(n) if *n < 0 => Some(mk_int(-n)),
@@ -568,8 +568,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
         return Some(result);
       }
       if let Ok(split) = function_expand_inner(&result)
-        && crate::syntax::expr_to_string(&split)
-          != crate::syntax::expr_to_string(&result)
+        && expr_to_string(&split) != expr_to_string(&result)
         && let Ok(v) = crate::evaluator::evaluate_expr_to_expr(&split)
       {
         return Some(v);

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -110,7 +110,7 @@ fn expr_to_rat(e: &Expr) -> Option<Rat> {
     Expr::BigInteger(n) => Some(Rat::from_int(n.clone())),
     Expr::Real(f) => rat_from_f64(*f),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => expr_to_rat(operand).map(|r| r.neg()),
     Expr::FunctionCall { name, args }

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -2147,7 +2147,7 @@ pub fn number_field_signature_ast(
   }
   crate::emit_message(&format!(
     "NumberFieldSignature::nalg: {} is not an explicit algebraic number.",
-    crate::syntax::expr_to_string(&alpha)
+    expr_to_string(&alpha)
   ));
   Ok(unevaluated("NumberFieldSignature", args))
 }
@@ -2172,7 +2172,7 @@ fn algebraic_minpoly(
 fn nalg_unevaluated(head: &str, args: &[Expr]) -> Expr {
   crate::emit_message(&format!(
     "{head}::nalg: {} is not an explicit algebraic number.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   unevaluated(head, args)
 }
@@ -2376,7 +2376,7 @@ pub fn number_field_discriminant_ast(
   {
     crate::emit_message(&format!(
       "NumberFieldDiscriminant::nalg: {} is not an explicit algebraic number.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return unevaluated();
   }

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -11,7 +11,8 @@ use crate::helpers::{
   unevaluated,
 };
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
+  expr_to_string,
 };
 use num_bigint::BigInt;
 

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -1549,7 +1549,7 @@ fn reduce_linear_inequality(
   var: &str,
   op: CompOp,
   domain: Option<&str>,
-) -> crate::syntax::Expr {
+) -> Expr {
   let terms = collect_additive_terms(poly);
   let mut a_parts: Vec<Expr> = Vec::new();
   let mut b_parts: Vec<Expr> = Vec::new();
@@ -1603,7 +1603,7 @@ fn reduce_quadratic_inequality(
   var: &str,
   op: CompOp,
   domain: Option<&str>,
-) -> crate::syntax::Expr {
+) -> Expr {
   let terms = collect_additive_terms(poly);
   let mut coeffs: Vec<Expr> = Vec::new();
   for d in 0..=2 {

--- a/src/functions/polynomial_ast/resultant.rs
+++ b/src/functions/polynomial_ast/resultant.rs
@@ -418,8 +418,8 @@ pub fn subresultant_polynomials_ast(
   }
 
   let npolys_message = |poly1: &Expr, poly2: &Expr| {
-    let p1 = crate::syntax::expr_to_string(poly1);
-    let p2 = crate::syntax::expr_to_string(poly2);
+    let p1 = expr_to_string(poly1);
+    let p2 = expr_to_string(poly2);
     crate::emit_message(&format!(
       "SubresultantPolynomials::npolys: {p1} and {p2} should be polynomials \
        with exact coefficients and the degree of {p1} in {var} should not \
@@ -612,8 +612,8 @@ pub fn subresultant_polynomial_remainders_ast(
   };
 
   let npolys_message = |poly1: &Expr, poly2: &Expr| {
-    let p1 = crate::syntax::expr_to_string(poly1);
-    let p2 = crate::syntax::expr_to_string(poly2);
+    let p1 = expr_to_string(poly1);
+    let p2 = expr_to_string(poly2);
     crate::emit_message(&format!(
       "SubresultantPolynomialRemainders::npolys: {p1} and {p2} should be \
        polynomials with exact coefficients and the degree of {p1} in {var} \

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -5834,7 +5834,7 @@ fn simplify_cost_key(e: &Expr) -> (usize, usize) {
 }
 
 fn exprs_equal(a: &Expr, b: &Expr) -> bool {
-  crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+  expr_to_string(a) == expr_to_string(b)
 }
 
 /// Apply `together_expr` only to proper sub-expressions of `expr`, leaving the
@@ -5960,11 +5960,7 @@ pub(crate) fn apply_active_assumptions(expr: &Expr) -> Expr {
 /// predicate like `x > 0`) or the option form `Simplify[expr, Assumptions -> assum]`.
 /// The assumption is combined with any existing `$Assumptions` (e.g. set by a
 /// surrounding `Assuming[...]`) using `And`, so nested assumptions accumulate.
-fn simplify_with_assumptions(
-  expr: &Expr,
-  opts: &Expr,
-  full: bool,
-) -> crate::syntax::Expr {
+fn simplify_with_assumptions(expr: &Expr, opts: &Expr, full: bool) -> Expr {
   // Extract the assumption value and decide whether it should *replace*
   // or *combine* with `$Assumptions`. wolframscript treats the option
   // form `Simplify[expr, Assumptions -> asn]` as a per-call override
@@ -6301,9 +6297,7 @@ fn full_simplify_expr(expr: &Expr) -> Expr {
   // front; if anything changed, continue simplifying the denested form so that
   // e.g. Sqrt[5+2Sqrt[6]] + Sqrt[5-2Sqrt[6]] combines to 2 Sqrt[3].
   let denested = denest_nested_radicals(expr);
-  if crate::syntax::expr_to_string(&denested)
-    != crate::syntax::expr_to_string(expr)
-  {
+  if expr_to_string(&denested) != expr_to_string(expr) {
     return full_simplify_expr(&denested);
   }
   let expr = &denested;
@@ -6515,10 +6509,10 @@ fn gamma_factor_absorb(expr: &Expr) -> Option<Expr> {
     let Some(arg) = gamma_arg(&factors[gi]) else {
       continue;
     };
-    let arg_key = crate::syntax::expr_to_string(&arg);
-    let Some(fi) = (0..factors.len()).find(|&fi| {
-      fi != gi && crate::syntax::expr_to_string(&factors[fi]) == arg_key
-    }) else {
+    let arg_key = expr_to_string(&arg);
+    let Some(fi) = (0..factors.len())
+      .find(|&fi| fi != gi && expr_to_string(&factors[fi]) == arg_key)
+    else {
       continue;
     };
     // Gamma[arg + 1].

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2274,7 +2274,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
           {
             specialized = true;
             for c in concrete {
-              let key = crate::syntax::expr_to_string(&c);
+              let key = expr_to_string(&c);
               if seen.insert(key) {
                 out.push(c);
               }
@@ -2325,7 +2325,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
               if ineqs.iter().any(|ineq| ineq_false(ineq, replacement)))
           }));
           if !violated {
-            let key = crate::syntax::expr_to_string(sol);
+            let key = expr_to_string(sol);
             if seen.insert(key) {
               out.push(sol.clone());
             }
@@ -2387,9 +2387,9 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       if is_eq {
         // Check if lhs matches target → solve for target
-        let target_str = crate::syntax::expr_to_string(target_expr);
-        let lhs_str = crate::syntax::expr_to_string(&lhs);
-        let rhs_str = crate::syntax::expr_to_string(&rhs);
+        let target_str = expr_to_string(target_expr);
+        let lhs_str = expr_to_string(&lhs);
+        let rhs_str = expr_to_string(&rhs);
         if lhs_str == target_str {
           return Ok(Expr::List(
             vec![Expr::List(
@@ -2456,7 +2456,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {
       // Solve::naqs: expr is not a quantified system of equations and inequalities.
-      let expr_str = crate::syntax::expr_to_string(&args[0]);
+      let expr_str = expr_to_string(&args[0]);
       crate::emit_message(&format!(
         "Solve::naqs: {expr_str} is not a quantified system of equations and inequalities."
       ));
@@ -9105,7 +9105,7 @@ fn minimize_try_ilp(
   vars: &[String],
   maximize: bool,
   func_name: &str,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   use std::collections::HashSet;
 
   // Walk an `Element[…, Integers]` subject and collect identifier leaves.
@@ -9781,7 +9781,7 @@ fn minimize_constrained_nd(
   vars: &[String],
   maximize: bool,
   func_name: &str,
-) -> crate::syntax::Expr {
+) -> Expr {
   // First try pure LP (linear objective + linear constraints)
   if vars.len() >= 2
     && let Some(result) = minimize_lp_2d(f, constraints, vars, maximize)
@@ -9930,7 +9930,7 @@ fn minimize_constrained_boundary(
   constraints: &[Expr],
   vars: &[String],
   maximize: bool,
-) -> std::option::Option<crate::syntax::Expr> {
+) -> std::option::Option<Expr> {
   let n = vars.len();
 
   // Collect all linear constraints
@@ -10581,7 +10581,7 @@ pub fn find_minimum_ast(
         &Expr::Real(x[i]),
       );
     }
-    let value_str = crate::syntax::expr_to_output(&substituted);
+    let value_str = expr_to_output(&substituted);
     let var_str: String = if vars.len() == 1 {
       format!("{{{}}} = {{{}}}", vars[0], x[0])
     } else {
@@ -10821,7 +10821,7 @@ fn specialize_periodic_solution(
   for ineq in ineqs {
     if let Expr::Comparison { operands, .. } = ineq {
       for op in operands {
-        if crate::syntax::expr_to_string(op) == var_name {
+        if expr_to_string(op) == var_name {
           continue;
         }
         if let Some(v) = try_eval_to_f64(op) {
@@ -12193,15 +12193,13 @@ fn nminimize_infeasible_result(
     } = term
     {
       for i in 0..operators.len() {
-        constraint_strs.push(crate::syntax::expr_to_output(
-          &Expr::Comparison {
-            operands: vec![operands[i].clone(), operands[i + 1].clone()],
-            operators: vec![operators[i]],
-          },
-        ));
+        constraint_strs.push(expr_to_output(&Expr::Comparison {
+          operands: vec![operands[i].clone(), operands[i + 1].clone()],
+          operators: vec![operators[i]],
+        }));
       }
     } else {
-      constraint_strs.push(crate::syntax::expr_to_output(term));
+      constraint_strs.push(expr_to_output(term));
     }
   }
   crate::emit_message(&format!(
@@ -12292,7 +12290,7 @@ fn pick_best_optimum(
   constraints: &[Expr],
   vars: &[String],
   maximize: bool,
-) -> crate::syntax::Expr {
+) -> Expr {
   let comparisons = collect_atomic_comparisons(constraints);
   let mut best: Option<(Expr, f64, bool)> = None;
 

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -239,7 +239,7 @@ fn contains_slot(expr: &Expr) -> bool {
 }
 
 /// Convert Root[f&, k] to radical form.
-fn root_to_radical(func: &Expr, k_expr: &Expr) -> crate::syntax::Expr {
+fn root_to_radical(func: &Expr, k_expr: &Expr) -> Expr {
   let k = match k_expr {
     Expr::Integer(n) => *n,
     _ => {
@@ -266,9 +266,7 @@ fn root_to_radical(func: &Expr, k_expr: &Expr) -> crate::syntax::Expr {
 
   // Generate all roots and sort them, then pick the k-th one
   // Check if it's a pure polynomial x^n + c = 0 (only leading and constant terms)
-  let is_pure = coeffs[1..degree]
-    .iter()
-    .all(|c| crate::syntax::expr_to_string(c) == "0");
+  let is_pure = coeffs[1..degree].iter().all(|c| expr_to_string(c) == "0");
 
   let roots = if is_pure && degree >= 1 {
     Some(solve_pure_nth(&coeffs[degree], &coeffs[0], degree as i128))
@@ -304,7 +302,7 @@ fn root_to_radical(func: &Expr, k_expr: &Expr) -> crate::syntax::Expr {
 }
 
 /// Solve linear: a0 + a1*x = 0 → x = -a0/a1
-fn solve_linear(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
+fn solve_linear(coeffs: &[Expr]) -> std::vec::Vec<Expr> {
   vec![call(
     "Times",
     vec![
@@ -316,7 +314,7 @@ fn solve_linear(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
 }
 
 /// Solve quadratic: a0 + a1*x + a2*x^2 = 0
-fn solve_quadratic(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
+fn solve_quadratic(coeffs: &[Expr]) -> std::vec::Vec<Expr> {
   let a = &coeffs[2];
   let b = &coeffs[1];
   let c = &coeffs[0];
@@ -347,7 +345,7 @@ fn solve_quadratic(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
 
 /// Solve depressed cubic x^3 + px + q = 0 using Cardano's formula.
 /// Then shift for general cubic a0 + a1*x + a2*x^2 + a3*x^3 = 0.
-fn solve_cubic(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
+fn solve_cubic(coeffs: &[Expr]) -> std::vec::Vec<Expr> {
   // Normalize: divide by leading coefficient
   let a3 = &coeffs[3];
   let a2 = &coeffs[2];
@@ -356,8 +354,8 @@ fn solve_cubic(coeffs: &[Expr]) -> std::vec::Vec<crate::syntax::Expr> {
 
   // For now, handle the common case: x^n - c = 0 (binomial)
   // Check if a2 == 0 and a1 == 0: pure cubic a3*x^3 + a0 = 0
-  let a2_str = crate::syntax::expr_to_string(a2);
-  let a1_str = crate::syntax::expr_to_string(a1);
+  let a2_str = expr_to_string(a2);
+  let a1_str = expr_to_string(a1);
 
   if a2_str == "0" && a1_str == "0" {
     return solve_pure_nth(a3, a0, 3);
@@ -470,7 +468,7 @@ fn solve_pure_nth(
   leading: &Expr,
   constant: &Expr,
   n: i128,
-) -> std::vec::Vec<crate::syntax::Expr> {
+) -> std::vec::Vec<Expr> {
   // x^n = -a0/an
   let base = mk_times(
     mk_times(mk_int(-1), constant.clone()),
@@ -547,9 +545,9 @@ fn solve_quartic(coeffs: &[Expr]) -> Option<Vec<Expr>> {
   let a1 = &coeffs[1];
   let a0 = &coeffs[0];
 
-  let a3_str = crate::syntax::expr_to_string(a3);
-  let a2_str = crate::syntax::expr_to_string(a2);
-  let a1_str = crate::syntax::expr_to_string(a1);
+  let a3_str = expr_to_string(a3);
+  let a2_str = expr_to_string(a2);
+  let a1_str = expr_to_string(a1);
 
   // Pure quartic: a4*x^4 + a0 = 0
   if a3_str == "0" && a2_str == "0" && a1_str == "0" {

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -613,7 +613,7 @@ pub fn is_numeric_q(expr: &Expr) -> bool {
                 && let Expr::Identifier(cond_val) = &operands[1]
                 && cond_val == name
               {
-                let body_str = crate::syntax::expr_to_string(body);
+                let body_str = expr_to_string(body);
                 return body_str == "True";
               }
             }
@@ -1645,7 +1645,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   let form = &args[1];
-  let form_str = crate::syntax::expr_to_string(form);
+  let form_str = expr_to_string(form);
 
   // A packed array object or a tree is an atom: nothing inside it counts as
   // a part, so only the object itself can match.
@@ -1687,7 +1687,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if crate::functions::list_helpers_ast::matches_pattern_ast(expr, form) {
         return true;
       }
-    } else if crate::syntax::expr_to_string(expr) == form_str {
+    } else if expr_to_string(expr) == form_str {
       return true;
     }
     // Rational and Complex are atoms: their internal parts (numerator/
@@ -2013,9 +2013,10 @@ pub fn palindrome_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(bool_expr(is_palindrome))
     }
     Expr::List(items) => {
-      let is_palindrome = items.iter().zip(items.iter().rev()).all(|(a, b)| {
-        crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
-      });
+      let is_palindrome = items
+        .iter()
+        .zip(items.iter().rev())
+        .all(|(a, b)| expr_to_string(a) == expr_to_string(b));
       Ok(bool_expr(is_palindrome))
     }
     Expr::Integer(n) => {
@@ -2076,8 +2077,8 @@ pub fn divisible_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let exact_message = |e: &Expr| {
     crate::emit_message(&format!(
       "Divisible::exact: Argument {} in {} is not an exact number.",
-      crate::syntax::expr_to_output(e),
-      crate::syntax::expr_to_output(&unevaluated())
+      expr_to_output(e),
+      expr_to_output(&unevaluated())
     ));
   };
 
@@ -2640,7 +2641,7 @@ pub fn construct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: inner_args,
     } if inner_args.is_empty() => name.clone(),
     // If head is already a function call like f[a], we need to use it as string for nested application
-    _ => crate::syntax::expr_to_string(head),
+    _ => expr_to_string(head),
   };
 
   // Construct[f, a, b, c] => f[a, b, c]
@@ -2834,9 +2835,9 @@ pub fn subset_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Default: structural membership.
   let superset_strs: Vec<String> =
-    superset.iter().map(crate::syntax::expr_to_string).collect();
+    superset.iter().map(expr_to_string).collect();
   for elem in subset {
-    let s = crate::syntax::expr_to_string(elem);
+    let s = expr_to_string(elem);
     if !superset_strs.contains(&s) {
       return Ok(bool_expr(false));
     }
@@ -2918,10 +2919,8 @@ fn intersecting_or_disjoint(
       })
     })
   } else {
-    let a_strs: Vec<String> =
-      a.iter().map(crate::syntax::expr_to_string).collect();
-    b.iter()
-      .any(|e| a_strs.contains(&crate::syntax::expr_to_string(e)))
+    let a_strs: Vec<String> = a.iter().map(expr_to_string).collect();
+    b.iter().any(|e| a_strs.contains(&expr_to_string(e)))
   };
   Ok(Expr::Identifier(
     if has_common == want_common {
@@ -2949,7 +2948,7 @@ pub fn duplicate_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "DuplicateFreeQ::normal: Nonatomic expression expected at position 1 in DuplicateFreeQ[{}].",
-        crate::syntax::expr_to_output(&args[0])
+        expr_to_output(&args[0])
       ));
       return Ok(unevaluated("DuplicateFreeQ", args));
     }
@@ -2979,7 +2978,7 @@ pub fn duplicate_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut seen: std::collections::HashSet<String> =
     std::collections::HashSet::new();
   for elem in elements {
-    if !seen.insert(crate::syntax::expr_to_string(elem)) {
+    if !seen.insert(expr_to_string(elem)) {
       return Ok(bool_expr(false));
     }
   }
@@ -3107,7 +3106,7 @@ pub fn mandelbrot_set_iteration_count_ast(
       "MandelbrotSetIterationCount[{}]",
       args
         .iter()
-        .map(crate::syntax::expr_to_output)
+        .map(expr_to_output)
         .collect::<Vec<_>>()
         .join(", ")
     )
@@ -3145,7 +3144,7 @@ pub fn mandelbrot_set_iteration_count_ast(
       other => {
         crate::emit_message(&format!(
           "MandelbrotSetIterationCount::nonopt: Options expected (instead of {}) beyond position {} in {}. An option must be a rule or a list of rules.",
-          crate::syntax::expr_to_output(other),
+          expr_to_output(other),
           i + 1,
           call_str()
         ));
@@ -3162,7 +3161,7 @@ pub fn mandelbrot_set_iteration_count_ast(
       _ => {
         crate::emit_message(&format!(
           "MandelbrotSetIterationCount::optx: Unknown option {} in {}.",
-          crate::syntax::expr_to_output(arg),
+          expr_to_output(arg),
           call_str()
         ));
         return unevaluated();
@@ -3240,7 +3239,7 @@ pub fn mandelbrot_set_member_q_ast(
       "MandelbrotSetMemberQ[{}]",
       args
         .iter()
-        .map(crate::syntax::expr_to_output)
+        .map(expr_to_output)
         .collect::<Vec<_>>()
         .join(", ")
     )
@@ -3268,7 +3267,7 @@ pub fn mandelbrot_set_member_q_ast(
   let nonopt = |offender: &Expr, position: usize| {
     crate::emit_message(&format!(
       "MandelbrotSetMemberQ::nonopt: Options expected (instead of {}) beyond position {} in {}. An option must be a rule or a list of rules.",
-      crate::syntax::expr_to_output(offender),
+      expr_to_output(offender),
       position,
       call_str()
     ));
@@ -3321,7 +3320,7 @@ pub fn mandelbrot_set_member_q_ast(
       _ => {
         crate::emit_message(&format!(
           "MandelbrotSetMemberQ::optx: Unknown option {} in {}.",
-          crate::syntax::expr_to_output(opt),
+          expr_to_output(opt),
           call_str()
         ));
         return unevaluated();

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1280,12 +1280,12 @@ fn units_compatible(u1: &Expr, u2: &Expr) -> bool {
     return info1.dimensions == info2.dimensions;
   }
   // If we can't decompose, they're compatible only if identical
-  crate::syntax::expr_to_string(u1) == crate::syntax::expr_to_string(u2)
+  expr_to_string(u1) == expr_to_string(u2)
 }
 
 /// Check if two unit expressions are the same unit.
 fn units_equal(u1: &Expr, u2: &Expr) -> bool {
-  crate::syntax::expr_to_string(u1) == crate::syntax::expr_to_string(u2)
+  expr_to_string(u1) == expr_to_string(u2)
 }
 
 /// Normalize input spelling/case variants to the canonical unit-table key.
@@ -1615,7 +1615,7 @@ pub fn quantity_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if is_pure_number(&args[0]) {
         crate::emit_message(&format!(
           "Quantity::unkunit: Unable to interpret unit specification {}.",
-          crate::syntax::expr_to_output(&args[0])
+          expr_to_output(&args[0])
         ));
         return Ok(unevaluated("Quantity", args));
       }
@@ -2044,8 +2044,8 @@ pub fn unit_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if from.dimensions != to.dimensions {
         return Err(InterpreterError::EvaluationError(format!(
           "{} and {} are incompatible units.",
-          crate::syntax::expr_to_string(unit),
-          crate::syntax::expr_to_string(target)
+          expr_to_string(unit),
+          expr_to_string(target)
         )));
       }
       // Convert: new_mag = mag * (from_si / to_si)
@@ -2164,8 +2164,8 @@ pub fn try_quantity_plus(
   for q in &quantity_args[1..] {
     let (_m, u) = is_quantity(q).unwrap();
     if !units_compatible(ref_unit, u) {
-      let u1_name = crate::syntax::expr_to_string(ref_unit);
-      let u2_name = crate::syntax::expr_to_string(u);
+      let u1_name = expr_to_string(ref_unit);
+      let u2_name = expr_to_string(u);
       crate::emit_message(&format!(
         "Quantity::compat: {u1_name} and {u2_name} are incompatible units."
       ));

--- a/src/functions/query_ast.rs
+++ b/src/functions/query_ast.rs
@@ -191,18 +191,15 @@ fn query_take_parts(data: &Expr, specs: &[Expr]) -> Option<Expr> {
         } else {
           let found = pairs
             .iter()
-            .find(|(k, _)| {
-              crate::syntax::expr_to_string(k)
-                == crate::syntax::expr_to_string(s)
-            })
+            .find(|(k, _)| expr_to_string(k) == expr_to_string(s))
             .map(|(_, v)| v.clone());
           (s.clone(), found.unwrap_or_else(|| missing("KeyAbsent", s)))
         };
         // Repeating a key does not repeat the entry.
-        if !picked.iter().any(|(k, _)| {
-          crate::syntax::expr_to_string(k)
-            == crate::syntax::expr_to_string(&key)
-        }) {
+        if !picked
+          .iter()
+          .any(|(k, _)| expr_to_string(k) == expr_to_string(&key))
+        {
           picked.push((key, value));
         }
       }

--- a/src/functions/socket_ast.rs
+++ b/src/functions/socket_ast.rs
@@ -302,7 +302,7 @@ fn listener_object_id(expr: &Expr) -> Option<i128> {
 fn invalid_socket_message(uuid: &str) {
   crate::emit_message_to_stdout(&format!(
     "The socket object {} is invalid or not open.",
-    crate::syntax::expr_to_string(&socket_expr(uuid))
+    expr_to_string(&socket_expr(uuid))
   ));
 }
 
@@ -1674,7 +1674,7 @@ fn dispatch_native(
         if !stop_listener(id) {
           crate::emit_message_to_stdout(&format!(
             "The socket listener {} is invalid or not open.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
           return Some(Ok(Expr::Identifier("$Failed".to_string())));
         }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -89,7 +89,7 @@ fn expr_to_str(expr: &Expr) -> std::string::String {
     Expr::Real(f) => crate::syntax::format_real(*f),
     _ => {
       // Try to get string representation
-      let s = crate::syntax::expr_to_string(expr);
+      let s = expr_to_string(expr);
       // If it's a quoted string, strip the quotes
       if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
         s[1..s.len() - 1].to_string()
@@ -140,7 +140,7 @@ pub fn string_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Non-string argument: emit message and return unevaluated (matches wolframscript).
   crate::emit_message(&format!(
     "StringLength::string: String expected at position 1 in {}.",
-    crate::syntax::expr_to_string(&unevaluated("StringLength", args))
+    expr_to_string(&unevaluated("StringLength", args))
   ));
   Ok(unevaluated("StringLength", args))
 }
@@ -600,7 +600,7 @@ pub fn string_join_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::StringJoin,
+        op: BinaryOperator::StringJoin,
         left,
         right,
       } => {
@@ -632,7 +632,7 @@ pub fn string_join_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .iter()
       .map(|a| match a {
         Expr::String(s) => s.clone(),
-        _ => crate::syntax::expr_to_string(a),
+        _ => expr_to_string(a),
       })
       .collect::<Vec<_>>()
       .join("<>");
@@ -1355,8 +1355,8 @@ fn has_ignore_case_option(args: &[Expr]) -> bool {
       pattern,
       replacement,
     } = arg
-      && crate::syntax::expr_to_string(pattern) == "IgnoreCase"
-      && crate::syntax::expr_to_string(replacement) == "True"
+      && expr_to_string(pattern) == "IgnoreCase"
+      && expr_to_string(replacement) == "True"
     {
       return true;
     }
@@ -4698,9 +4698,7 @@ fn table_form_to_string(arg: &Expr) -> Option<String> {
     let rows: Vec<Vec<String>> = items
       .iter()
       .map(|row| match row {
-        Expr::List(cells) => {
-          cells.iter().map(crate::syntax::expr_to_output).collect()
-        }
+        Expr::List(cells) => cells.iter().map(expr_to_output).collect(),
         _ => vec![],
       })
       .collect();
@@ -4728,8 +4726,7 @@ fn table_form_to_string(arg: &Expr) -> Option<String> {
     Some(lines.join("\n\n"))
   } else {
     // A flat vector renders one element per row.
-    let lines: Vec<String> =
-      items.iter().map(crate::syntax::expr_to_output).collect();
+    let lines: Vec<String> = items.iter().map(expr_to_output).collect();
     Some(lines.join("\n\n"))
   }
 }
@@ -4749,9 +4746,7 @@ fn matrix_form_to_string(arg: &Expr) -> Option<String> {
     let rows: Vec<Vec<String>> = items
       .iter()
       .map(|row| match row {
-        Expr::List(cells) => {
-          cells.iter().map(crate::syntax::expr_to_output).collect()
-        }
+        Expr::List(cells) => cells.iter().map(expr_to_output).collect(),
         _ => vec![],
       })
       .collect();
@@ -4778,8 +4773,7 @@ fn matrix_form_to_string(arg: &Expr) -> Option<String> {
     Some(lines.join("\n\n"))
   } else {
     // A flat vector renders one element per row (single column).
-    let lines: Vec<String> =
-      items.iter().map(crate::syntax::expr_to_output).collect();
+    let lines: Vec<String> = items.iter().map(expr_to_output).collect();
     Some(lines.join("\n\n"))
   }
 }
@@ -4856,7 +4850,7 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if is_numeric_form {
       crate::emit_message(&format!(
         "ToString::fmtval: {} is not a valid format type.",
-        crate::syntax::expr_to_output(&args[1])
+        expr_to_output(&args[1])
       ));
       return Ok(unevaluated("ToString", args));
     }
@@ -4941,8 +4935,7 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && !inner_args.is_empty()
     && let Expr::List(items) = &inner_args[0]
   {
-    let lines: Vec<String> =
-      items.iter().map(crate::syntax::expr_to_output).collect();
+    let lines: Vec<String> = items.iter().map(expr_to_output).collect();
     return Ok(Expr::String(lines.join("\n")));
   }
 
@@ -5034,8 +5027,8 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
       recursed[0] = e.clone();
       match to_string_ast(&recursed) {
         Ok(Expr::String(ref s)) => s.clone(),
-        Ok(other) => crate::syntax::expr_to_output(&other),
-        Err(_) => crate::syntax::expr_to_output(e),
+        Ok(other) => expr_to_output(&other),
+        Err(_) => expr_to_output(e),
       }
     };
     let parts: Vec<String> = items.iter().map(&render).collect();
@@ -5316,7 +5309,7 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
       // Use OutputForm-style rendering (strings without surrounding
       // quotes), then escape `{` / `}` using TeX's `$\{$` / `$\}$`.
-      let input_text = crate::syntax::expr_to_output(&formatted);
+      let input_text = expr_to_output(&formatted);
       let escaped = input_text.replace('{', "$\\{$").replace('}', "$\\}$");
       return Ok(Expr::String(format!("\\text{{{escaped}}}")));
     }
@@ -5580,7 +5573,7 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// noise in e.g. `0.47000000000000003` renders as `0.47`). Used for chart
 /// labels, which Wolfram typesets in OutputForm rather than full precision.
 pub fn to_string_default_form(expr: &Expr) -> String {
-  crate::syntax::expr_to_output(&truncate_machine_reals_for_to_string(expr))
+  expr_to_output(&truncate_machine_reals_for_to_string(expr))
 }
 
 /// Round a machine-precision Real to 6 significant decimal digits — the
@@ -6000,9 +5993,9 @@ pub fn expr_to_tex(expr: &Expr) -> String {
       {
         return tex_derivative(orders, &inner_args[0], Some(args));
       }
-      crate::syntax::expr_to_output(expr)
+      expr_to_output(expr)
     }
-    _ => crate::syntax::expr_to_output(expr),
+    _ => expr_to_output(expr),
   }
 }
 
@@ -7821,7 +7814,7 @@ fn mathml_inner(expr: &Expr, depth: usize) -> String {
 
     // Fallback: render via output form
     _ => {
-      let s = crate::syntax::expr_to_output(expr);
+      let s = expr_to_output(expr);
       format!("{}<mi>{}</mi>", indent, mathml_escape(&s))
     }
   }
@@ -8318,7 +8311,7 @@ pub fn expr_to_boxes(expr: &Expr) -> String {
     Expr::FunctionCall { name, args } => box_function_call(name, args),
 
     // Fallback
-    _ => crate::syntax::expr_to_output(expr),
+    _ => expr_to_output(expr),
   }
 }
 
@@ -8487,7 +8480,7 @@ fn box_function_call(name: &str, args: &[Expr]) -> String {
 /// Out-of-range indices leave the placeholder literal in the output and
 /// emit a StringForm::sfr warning, matching wolframscript.
 pub(crate) fn format_string_form(template: &str, values: &[Expr]) -> String {
-  format_string_form_with(template, values, crate::syntax::expr_to_output)
+  format_string_form_with(template, values, expr_to_output)
 }
 
 /// Fill a message's template slots — the same `` `` `` / `` `n` ``
@@ -8500,7 +8493,7 @@ pub(crate) fn format_message_template(
   template: &str,
   values: &[Expr],
 ) -> String {
-  format_slots(template, values, crate::syntax::expr_to_output, false)
+  format_slots(template, values, expr_to_output, false)
 }
 
 /// `format_string_form`, rendering each substituted value with `fmt` instead
@@ -8635,7 +8628,7 @@ pub fn apply_string_template(
     for (k, v) in pairs {
       let key = match k {
         Expr::String(s) => s.clone(),
-        other => crate::syntax::expr_to_string(other),
+        other => expr_to_string(other),
       };
       named.insert(key, v.clone());
     }
@@ -8663,7 +8656,7 @@ pub fn apply_string_template(
         named.get(&content)
       };
       if let Some(v) = value {
-        result.push_str(&crate::syntax::expr_to_output(v));
+        result.push_str(&expr_to_output(v));
       }
       // Unfilled slots contribute nothing.
       i = close + 1;
@@ -8708,7 +8701,7 @@ pub fn to_expression_ast_as(
     let interpreted = crate::evaluator::evaluate_expr_to_expr(&ib_args[1])?;
     if args.len() == 3 {
       let wrapped = Expr::FunctionCall {
-        name: crate::syntax::expr_to_string(&args[2]),
+        name: expr_to_string(&args[2]),
         args: vec![interpreted].into(),
       };
       return crate::evaluator::evaluate_expr_to_expr(&wrapped);
@@ -8733,7 +8726,7 @@ pub fn to_expression_ast_as(
   if args.len() == 3 {
     let parsed = parse_program_to_expr(&s)?;
     let wrapped = Expr::FunctionCall {
-      name: crate::syntax::expr_to_string(&args[2]),
+      name: expr_to_string(&args[2]),
       args: vec![parsed].into(),
     };
     return crate::evaluator::evaluate_expr_to_expr(&wrapped);
@@ -9315,7 +9308,7 @@ pub fn to_character_code_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // codepoints directly.
   let encoding = args.get(1).map(|e| match e {
     Expr::String(s) => s.clone(),
-    _ => crate::syntax::expr_to_string(e),
+    _ => expr_to_string(e),
   });
   let is_utf8 = encoding.as_deref().is_some_and(|e| {
     let e = e.replace('-', "").to_ascii_lowercase();
@@ -9341,7 +9334,7 @@ pub fn to_character_code_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "ToCharacterCode::strse: A string or list of strings is \
          expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated("ToCharacterCode", args))
+        expr_to_string(&unevaluated("ToCharacterCode", args))
       ));
       return Ok(unevaluated("ToCharacterCode", args));
     }
@@ -9358,7 +9351,7 @@ pub fn to_character_code_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "ToCharacterCode::strse: A string or list of strings is \
        expected at position 1 in {}.",
-      crate::syntax::expr_to_string(&unevaluated("ToCharacterCode", args))
+      expr_to_string(&unevaluated("ToCharacterCode", args))
     ));
     return Ok(unevaluated("ToCharacterCode", args));
   }
@@ -10448,7 +10441,7 @@ pub fn capitalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() == 2 {
     let kind = match &args[1] {
       Expr::String(k) => k.clone(),
-      _ => crate::syntax::expr_to_string(&args[1]),
+      _ => expr_to_string(&args[1]),
     };
     if !matches!(kind.as_str(), "AllWords" | "FirstWord" | "LongWords") {
       // "TitleCase" depends on part-of-speech data we do not model; any
@@ -10560,9 +10553,7 @@ pub fn edit_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let s = if lower { s.to_lowercase() } else { s.clone() };
         s.chars().map(|c| c.to_string()).collect()
       }
-      Expr::List(items) => {
-        items.iter().map(crate::syntax::expr_to_output).collect()
-      }
+      Expr::List(items) => items.iter().map(expr_to_output).collect(),
       _ => {
         let s = expr_to_str(expr);
         let s = if lower { s.to_lowercase() } else { s };
@@ -10599,9 +10590,7 @@ pub fn edit_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 fn alignment_tokens(expr: &Expr) -> std::vec::Vec<std::string::String> {
   match expr {
     Expr::String(s) => s.chars().map(|c| c.to_string()).collect(),
-    Expr::List(items) => {
-      items.iter().map(crate::syntax::expr_to_output).collect()
-    }
+    Expr::List(items) => items.iter().map(expr_to_output).collect(),
     _ => {
       let s = expr_to_str(expr);
       s.chars().map(|c| c.to_string()).collect()
@@ -10689,9 +10678,7 @@ pub fn damerau_levenshtein_distance_ast(
         let s = if lower { s.to_lowercase() } else { s.clone() };
         s.chars().map(|c| c.to_string()).collect()
       }
-      Expr::List(items) => {
-        items.iter().map(crate::syntax::expr_to_output).collect()
-      }
+      Expr::List(items) => items.iter().map(expr_to_output).collect(),
       _ => {
         let s = expr_to_str(expr);
         let s = if lower { s.to_lowercase() } else { s };
@@ -10786,9 +10773,7 @@ fn longest_common_run(a: &[String], b: &[String]) -> (usize, usize, usize) {
 /// characters or a list's elements (compared by their output form).
 fn lcs_tokens(expr: &Expr) -> Option<Vec<String>> {
   match expr {
-    Expr::List(items) => {
-      Some(items.iter().map(crate::syntax::expr_to_output).collect())
-    }
+    Expr::List(items) => Some(items.iter().map(expr_to_output).collect()),
     Expr::String(s) => Some(s.chars().map(|c| c.to_string()).collect()),
     _ => None,
   }
@@ -10808,10 +10793,8 @@ pub fn longest_common_subsequence_ast(
 
   // List inputs compare whole elements and return the matching sublist.
   if let (Expr::List(l1), Expr::List(l2)) = (&args[0], &args[1]) {
-    let t1: Vec<String> =
-      l1.iter().map(crate::syntax::expr_to_output).collect();
-    let t2: Vec<String> =
-      l2.iter().map(crate::syntax::expr_to_output).collect();
+    let t1: Vec<String> = l1.iter().map(expr_to_output).collect();
+    let t2: Vec<String> = l2.iter().map(expr_to_output).collect();
     let (start, _, len) = longest_common_run(&t1, &t2);
     let sub: Vec<Expr> = l1[start..start + len].to_vec();
     return Ok(Expr::List(sub.into()));
@@ -10882,10 +10865,8 @@ pub fn longest_common_sequence_ast(
 
   // List inputs compare whole elements and return the matching sublist.
   if let (Expr::List(l1), Expr::List(l2)) = (&args[0], &args[1]) {
-    let t1: Vec<String> =
-      l1.iter().map(crate::syntax::expr_to_output).collect();
-    let t2: Vec<String> =
-      l2.iter().map(crate::syntax::expr_to_output).collect();
+    let t1: Vec<String> = l1.iter().map(expr_to_output).collect();
+    let t2: Vec<String> = l2.iter().map(expr_to_output).collect();
     let sub: Vec<Expr> = lcs_index_pairs(&t1, &t2)
       .iter()
       .map(|&(i, _)| l1[i].clone())
@@ -11024,10 +11005,8 @@ pub fn sequence_alignment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (true, c1, c2, Vec::<Expr>::new(), Vec::<Expr>::new())
     }
     (Expr::List(l1), Expr::List(l2)) => {
-      let c1: Vec<String> =
-        l1.iter().map(crate::syntax::expr_to_output).collect();
-      let c2: Vec<String> =
-        l2.iter().map(crate::syntax::expr_to_output).collect();
+      let c1: Vec<String> = l1.iter().map(expr_to_output).collect();
+      let c2: Vec<String> = l2.iter().map(expr_to_output).collect();
       let o1: Vec<Expr> = l1.iter().cloned().collect();
       let o2: Vec<Expr> = l2.iter().cloned().collect();
       (false, c1, c2, o1, o2)
@@ -11985,8 +11964,8 @@ pub fn alphabetic_sort_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) => {
       let mut sorted = items.clone();
       sorted.sort_by(|a, b| {
-        let sa = crate::syntax::expr_to_string(a).to_lowercase();
-        let sb = crate::syntax::expr_to_string(b).to_lowercase();
+        let sa = expr_to_string(a).to_lowercase();
+        let sb = expr_to_string(b).to_lowercase();
         sa.cmp(&sb)
       });
       Ok(Expr::List(sorted))
@@ -12104,7 +12083,7 @@ pub fn hash_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if hash_type == "Expression" {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
-    let repr = crate::syntax::expr_to_string(&args[0]);
+    let repr = expr_to_string(&args[0]);
     let mut hasher = DefaultHasher::new();
     repr.hash(&mut hasher);
     let h = hasher.finish();
@@ -12272,7 +12251,7 @@ pub fn compress_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     )));
   }
   let evaluated = crate::evaluator::evaluate_expr_to_expr(&args[0])?;
-  let repr = crate::syntax::expr_to_string(&evaluated);
+  let repr = expr_to_string(&evaluated);
 
   use flate2::Compression;
   use flate2::write::ZlibEncoder;
@@ -12475,7 +12454,7 @@ pub fn read_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       _ => {
         let formatted_args = args
           .iter()
-          .map(crate::syntax::expr_to_string)
+          .map(expr_to_string)
           .collect::<Vec<_>>()
           .join(", ");
         crate::emit_message(&format!(
@@ -12572,7 +12551,7 @@ fn read_list_record(
   text: &str,
   types: &[Expr],
   max_count: Option<usize>,
-) -> crate::syntax::Expr {
+) -> Expr {
   let mut results = Vec::new();
 
   for line in text.lines() {
@@ -13031,7 +13010,7 @@ pub fn expr_to_c(expr: &Expr) -> String {
     } => c_like_comparison(operands, operators, &expr_to_c, false),
     // Rational numbers are FunctionCall{name:"Rational", args:[num, den]}
     // but they get evaluated before reaching here, so this pattern is rare
-    _ => crate::syntax::expr_to_string(expr),
+    _ => expr_to_string(expr),
   }
 }
 
@@ -13157,7 +13136,7 @@ pub fn expr_to_fortran(expr: &Expr) -> String {
       operands,
       operators,
     } => c_like_comparison(operands, operators, &expr_to_fortran, true),
-    _ => crate::syntax::expr_to_string(expr),
+    _ => expr_to_string(expr),
   }
 }
 
@@ -13532,13 +13511,13 @@ fn template_slot_value(key: &Expr, args: &Expr) -> Option<Expr> {
       let key_str = match key {
         Expr::String(s) => s.clone(),
         Expr::Identifier(s) => s.clone(),
-        other => crate::syntax::expr_to_string(other),
+        other => expr_to_string(other),
       };
       pairs.iter().find_map(|(k, v)| {
         let k_str = match k {
           Expr::String(s) => s.clone(),
           Expr::Identifier(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         (k_str == key_str).then(|| v.clone())
       })
@@ -13547,7 +13526,7 @@ fn template_slot_value(key: &Expr, args: &Expr) -> Option<Expr> {
       let key_str = match key {
         Expr::String(s) => s.clone(),
         Expr::Identifier(s) => s.clone(),
-        other => crate::syntax::expr_to_string(other),
+        other => expr_to_string(other),
       };
       pairs.iter().find_map(|rule| {
         let (k, v) = match rule {
@@ -13564,7 +13543,7 @@ fn template_slot_value(key: &Expr, args: &Expr) -> Option<Expr> {
         let k_str = match k {
           Expr::String(s) => s.clone(),
           Expr::Identifier(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         (k_str == key_str).then(|| v.clone())
       })
@@ -13585,7 +13564,7 @@ fn template_object_apply(
   let render = |e: &Expr| -> String {
     match e {
       Expr::String(s) => s.clone(),
-      other => crate::syntax::expr_to_string(other),
+      other => expr_to_string(other),
     }
   };
 
@@ -13618,7 +13597,7 @@ fn template_object_apply(
         let evaluated = crate::evaluator::evaluate_expr_to_expr(&substituted)?;
         result.push_str(&render(&evaluated));
       }
-      other => result.push_str(&crate::syntax::expr_to_string(other)),
+      other => result.push_str(&expr_to_string(other)),
     }
   }
   Ok(Expr::String(result))
@@ -13688,7 +13667,7 @@ pub fn template_apply_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for (i, item) in items.iter().enumerate() {
         let value_str = match item {
           Expr::String(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         map.insert((i + 1).to_string(), value_str);
       }
@@ -13699,11 +13678,11 @@ pub fn template_apply_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for (k, v) in pairs {
         let key = match k {
           Expr::String(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         let value = match v {
           Expr::String(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         map.insert(key, value);
       }
@@ -13736,11 +13715,11 @@ pub fn template_apply_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         let key = match key_expr {
           Expr::String(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         let value = match val_expr {
           Expr::String(s) => s.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         };
         map.insert(key, value);
       }
@@ -13934,7 +13913,7 @@ fn query_stringify(e: &Expr) -> String {
     Expr::String(s) => s.clone(),
     Expr::Identifier(id) if id == "True" => "true".to_string(),
     Expr::Identifier(id) if id == "False" => "false".to_string(),
-    _ => crate::syntax::expr_to_string(e),
+    _ => expr_to_string(e),
   }
 }
 
@@ -14123,7 +14102,7 @@ pub fn byte_array_to_string_ast(
   }
   crate::emit_message(&format!(
     "ByteArrayToString::barray: {} is not a ByteArray object or {{}}.",
-    crate::syntax::expr_to_string(&args[0])
+    expr_to_string(&args[0])
   ));
   Ok(unevaluated("ByteArrayToString", args))
 }
@@ -15317,7 +15296,7 @@ fn padded_form_to_string(
       _ => {
         // Reals/rationals: render via output form, padded to width n+1.
         crate::functions::math_ast::expr_to_num(value)?;
-        let body = crate::syntax::expr_to_output(value);
+        let body = expr_to_output(value);
         Some(pad_left(&body, (*n as usize) + 1, lpad))
       }
     },
@@ -15600,7 +15579,7 @@ fn expand_expression_slots(
         let value = crate::evaluator::evaluate_expr_to_expr(&substituted)?;
         out.push_str(&match &value {
           Expr::String(text) => text.clone(),
-          other => crate::syntax::expr_to_string(other),
+          other => expr_to_string(other),
         });
       }
       Err(_) => out.push_str(&rest[start..end + 2]),
@@ -15778,7 +15757,7 @@ pub fn snippet_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         crate::emit_message(&format!(
           "Snippet::invspec: Specification {} should be an integer or Span.",
-          crate::syntax::expr_to_output(spec)
+          expr_to_output(spec)
         ));
         return Ok(Expr::Identifier("$Failed".to_string()));
       }
@@ -15921,11 +15900,11 @@ pub fn character_normalize_ast(
       // Strings show quoted in the message; anything else in OutputForm.
       let shown = match other {
         Expr::String(s) => format!("\"{s}\""),
-        _ => crate::syntax::expr_to_output(other),
+        _ => expr_to_output(other),
       };
       let text = match other {
         Expr::String(s) => s.clone(),
-        _ => crate::syntax::expr_to_output(other),
+        _ => expr_to_output(other),
       };
       let listing = |skip: Option<&str>| {
         let names: Vec<String> = NORMALIZATION_FORMS

--- a/src/functions/tabular_ast.rs
+++ b/src/functions/tabular_ast.rs
@@ -174,7 +174,7 @@ fn tabular_from_list_of_associations(rows: &[Expr], args: &[Expr]) -> Expr {
   for row in rows {
     if let Expr::Association(pairs) = row {
       for (k, _) in pairs {
-        let key_str = crate::syntax::expr_to_string(k);
+        let key_str = expr_to_string(k);
         if key_set.insert(key_str.clone()) {
           col_keys.push(k.clone());
           col_key_strs.push(key_str);
@@ -188,7 +188,7 @@ fn tabular_from_list_of_associations(rows: &[Expr], args: &[Expr]) -> Expr {
     && let Expr::List(names) = &args[1]
   {
     col_keys = names.to_vec();
-    col_key_strs = names.iter().map(crate::syntax::expr_to_string).collect();
+    col_key_strs = names.iter().map(expr_to_string).collect();
   }
 
   // Infer column types
@@ -201,7 +201,7 @@ fn tabular_from_list_of_associations(rows: &[Expr], args: &[Expr]) -> Expr {
         if let Expr::Association(pairs) = r {
           pairs
             .iter()
-            .find(|(k, _)| crate::syntax::expr_to_string(k) == *key_str)
+            .find(|(k, _)| expr_to_string(k) == *key_str)
             .map(|(_, v)| v)
         } else {
           None

--- a/src/functions/timeline_plot.rs
+++ b/src/functions/timeline_plot.rs
@@ -216,7 +216,7 @@ fn expr_to_label(expr: &Expr) -> String {
   let evaluated = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
   match &evaluated {
     Expr::String(s) => s.clone(),
-    other => crate::syntax::expr_to_output(other),
+    other => expr_to_output(other),
   }
 }
 

--- a/src/functions/timeseries_ast.rs
+++ b/src/functions/timeseries_ast.rs
@@ -391,7 +391,7 @@ pub fn time_series_rescale_ast(
     crate::emit_message(&format!(
       "TimeSeriesRescale::trng: The argument {} is not a valid pair of \
        strictly increasing time points.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return echo();
   }
@@ -487,10 +487,7 @@ pub fn time_series_thread_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for series in &all {
       let found = series.iter().find(|(t, _)| match (to_time(t), key) {
         (Some(a), Some(b)) => a == b,
-        _ => {
-          crate::syntax::expr_to_string(t)
-            == crate::syntax::expr_to_string(time)
-        }
+        _ => expr_to_string(t) == expr_to_string(time),
       });
       match found {
         Some((_, v)) => values.push(v.clone()),
@@ -687,10 +684,7 @@ fn split_component_paths(pairs: Vec<(Expr, Expr)>) -> Vec<Vec<(Expr, Expr)>> {
         .filter_map(|(t, v)| match v {
           Expr::Association(kv) => kv
             .iter()
-            .find(|(k, _)| {
-              crate::syntax::expr_to_output(k)
-                == crate::syntax::expr_to_output(key)
-            })
+            .find(|(k, _)| expr_to_output(k) == expr_to_output(key))
             .map(|(_, val)| (t.clone(), val.clone())),
           _ => None,
         })
@@ -1154,7 +1148,7 @@ fn window_bound(e: &Expr) -> Option<f64> {
   if matches!(e, Expr::Identifier(s) | Expr::Constant(s) if s == "Infinity") {
     return Some(f64::INFINITY);
   }
-  if crate::syntax::expr_to_string(e) == "-Infinity" {
+  if expr_to_string(e) == "-Infinity" {
     return Some(f64::NEG_INFINITY);
   }
   to_time(e)
@@ -1511,7 +1505,7 @@ mod tests {
   }
 
   fn render(e: &Expr) -> String {
-    crate::syntax::expr_to_string(e)
+    expr_to_string(e)
   }
 
   #[test]

--- a/src/functions/trig_factor_ast.rs
+++ b/src/functions/trig_factor_ast.rs
@@ -175,7 +175,7 @@ fn negated(e: &Expr) -> Option<&Expr> {
 }
 
 fn same(a: &Expr, b: &Expr) -> bool {
-  crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+  expr_to_string(a) == expr_to_string(b)
 }
 
 fn factor(expr: &Expr) -> Option<Expr> {

--- a/src/functions/turing_machine_ast.rs
+++ b/src/functions/turing_machine_ast.rs
@@ -47,7 +47,7 @@ pub fn turing_machine_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[2], Expr::Integer(n) if *n >= 0) {
     crate::emit_message(&format!(
       "TuringMachine::tspec: The time specification {} must be an integer >= 0.",
-      crate::syntax::expr_to_string(&args[2])
+      expr_to_string(&args[2])
     ));
     return Ok(unevaluated("TuringMachine", args));
   }

--- a/src/functions/voronoi.rs
+++ b/src/functions/voronoi.rs
@@ -262,7 +262,7 @@ fn are_collinear(sites: &[(f64, f64)]) -> bool {
   true
 }
 
-fn voronoi_collinear(sites: &[(f64, f64)]) -> crate::syntax::Expr {
+fn voronoi_collinear(sites: &[(f64, f64)]) -> Expr {
   // Sort sites along their collinear direction
   let (x0, y0) = sites[0];
   let (x1, y1) = sites[1];
@@ -394,7 +394,7 @@ fn voronoi_collinear(sites: &[(f64, f64)]) -> crate::syntax::Expr {
   build_mesh_region(&all_verts, &cells)
 }
 
-fn voronoi_2_sites(sites: &[(f64, f64)]) -> crate::syntax::Expr {
+fn voronoi_2_sites(sites: &[(f64, f64)]) -> Expr {
   let (x0, y0) = sites[0];
   let (x1, y1) = sites[1];
 
@@ -508,10 +508,7 @@ fn voronoi_2_sites(sites: &[(f64, f64)]) -> crate::syntax::Expr {
   build_mesh_region(&all_verts, &cells)
 }
 
-fn build_mesh_region(
-  all_verts: &[(f64, f64)],
-  cells: &[Vec<usize>],
-) -> crate::syntax::Expr {
+fn build_mesh_region(all_verts: &[(f64, f64)], cells: &[Vec<usize>]) -> Expr {
   // Build MeshRegion[{{x1,y1},...}, {Polygon[{{i1,i2,...},{j1,j2,...}}]}]
   // Vertices list (1-indexed coordinates)
   let verts_expr: Vec<Expr> = all_verts

--- a/src/functions/wavelet_ast/continuous.rs
+++ b/src/functions/wavelet_ast/continuous.rs
@@ -717,7 +717,7 @@ fn select_single(spec: &Expr) -> bool {
   false
 }
 
-fn cwd_property(cwd: &Cwd, prop: &str) -> crate::syntax::Expr {
+fn cwd_property(cwd: &Cwd, prop: &str) -> Expr {
   match prop {
     "Properties" => Expr::List(
       [

--- a/src/functions/wavelet_ast/data.rs
+++ b/src/functions/wavelet_ast/data.rs
@@ -740,7 +740,7 @@ fn partial_inverse(
   dwd: &Dwd,
   filters: &super::filters::WaveletFilters,
   r: usize,
-) -> crate::syntax::Expr {
+) -> Expr {
   let n = dwd.refinement();
   let keep = n - r;
   let mut coeffs: BTreeMap<Vec<u8>, CoefArray> = BTreeMap::new();
@@ -1088,7 +1088,7 @@ pub fn apply_dwd(func: &Expr, args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(Expr::List(out.into()))
 }
 
-fn dwd_property(dwd: &Dwd, prop: &str) -> crate::syntax::Expr {
+fn dwd_property(dwd: &Dwd, prop: &str) -> Expr {
   match prop {
     "Properties" => Expr::List(
       [

--- a/src/functions/wavelet_ast/filters.rs
+++ b/src/functions/wavelet_ast/filters.rs
@@ -694,9 +694,7 @@ pub(crate) fn wavelet_filters(spec: &WaveletSpec) -> Option<WaveletFilters> {
 /// WaveletFilterCoefficients[wave], [wave, filtspec] — filter coefficients
 /// as {{n, c_n}, …} pairs. Exact values are returned for the families with
 /// closed-form filters; other families give machine-precision values.
-pub(crate) fn wavelet_filter_coefficients_ast(
-  args: &[Expr],
-) -> crate::syntax::Expr {
+pub(crate) fn wavelet_filter_coefficients_ast(args: &[Expr]) -> Expr {
   // Strip options (WorkingPrecision) from the tail.
   let mut positional: Vec<&Expr> = Vec::new();
   let mut exact_requested = false;
@@ -748,7 +746,7 @@ fn single_filter_result(
   filt_spec: &Expr,
   exact_requested: bool,
   orig_args: &[Expr],
-) -> crate::syntax::Expr {
+) -> Expr {
   let Expr::String(kind) = filt_spec else {
     crate::emit_message(&format!(
       "WaveletFilterCoefficients::invspec: {} is not a valid filter specification.",

--- a/src/functions/wavelet_ast/phipsi.rs
+++ b/src/functions/wavelet_ast/phipsi.rs
@@ -49,7 +49,7 @@ pub fn wavelet_phi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(wavelet_phi_psi_ast(args, true))
 }
 
-fn wavelet_phi_psi_ast(args: &[Expr], phi: bool) -> crate::syntax::Expr {
+fn wavelet_phi_psi_ast(args: &[Expr], phi: bool) -> Expr {
   let fname = if phi { "WaveletPhi" } else { "WaveletPsi" };
   let positional: Vec<&Expr> = args
     .iter()

--- a/src/functions/wikidata_ast.rs
+++ b/src/functions/wikidata_ast.rs
@@ -727,7 +727,6 @@ mod tests {
 
   #[test]
   fn times_map_to_date_objects_at_precision() {
-    use crate::syntax::expr_to_output;
     let day = time_to_date_object("+1879-03-14T00:00:00Z", 11).unwrap();
     assert_eq!(expr_to_output(&day), "DateObject[{1879, 3, 14}, Day]");
     let month = time_to_date_object("+1879-03-14T00:00:00Z", 10).unwrap();

--- a/src/functions/wl_serialize.rs
+++ b/src/functions/wl_serialize.rs
@@ -125,7 +125,7 @@ fn build_normal(head: &Expr, args: Vec<Expr>) -> Expr {
       args: args.into(),
     },
     other => Expr::FunctionCall {
-      name: crate::syntax::expr_to_string(other),
+      name: expr_to_string(other),
       args: args.into(),
     },
   }
@@ -296,7 +296,7 @@ mod tests {
   use super::*;
 
   fn render(data: &[u8]) -> String {
-    crate::syntax::expr_to_string(&deserialize(data).unwrap())
+    expr_to_string(&deserialize(data).unwrap())
   }
 
   #[test]

--- a/src/functions/xlsx_ast.rs
+++ b/src/functions/xlsx_ast.rs
@@ -171,7 +171,7 @@ fn write_cell(
       } else {
         // Fall back to the canonical textual form (e.g. unbound symbols,
         // complex numbers, nested expressions).
-        let text = crate::syntax::expr_to_string(value);
+        let text = expr_to_string(value);
         worksheet.write_string(row, col, &text).map_err(to_err)?;
       }
     }
@@ -225,7 +225,7 @@ pub fn xlsx_export_file(
   } else {
     return Err(InterpreterError::EvaluationError(format!(
       "Export: xlsx data must be a list, got {}",
-      crate::syntax::expr_to_string(data)
+      expr_to_string(data)
     )));
   };
 

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -698,9 +698,8 @@ pub fn inverse_z_transform_ast(
     sign = norm_sign;
     let a_pow_n = pow2(a.clone(), n.clone());
     let factors = times_factors(&num);
-    let fstr: Vec<String> =
-      factors.iter().map(crate::syntax::expr_to_string).collect();
-    let a_str = crate::syntax::expr_to_string(&a);
+    let fstr: Vec<String> = factors.iter().map(expr_to_string).collect();
+    let a_str = expr_to_string(&a);
     let matches_multiset = |expected: &[String]| {
       let mut want = expected.to_vec();
       want.sort();
@@ -723,10 +722,7 @@ pub fn inverse_z_transform_ast(
       && matches_multiset(&[
         a_str.clone(),
         z_var.clone(),
-        crate::syntax::expr_to_string(&plus(vec![
-          a.clone(),
-          Expr::Identifier(z_var.clone()),
-        ])),
+        expr_to_string(&plus(vec![a.clone(), Expr::Identifier(z_var.clone())])),
       ])
     {
       return Ok(times(vec![a_pow_n, pow2(n.clone(), Expr::Integer(2))]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5075,7 +5075,7 @@ pub fn insert_statement_separators(input: &str) -> String {
         && !ends_with_tag_set
         && !ends_with_operator
         && !ends_with_prefix_not
-        && !crate::syntax::ends_with_continuing_named_operator(&code_tail);
+        && !syntax::ends_with_continuing_named_operator(&code_tail);
 
       if needs_semi {
         // Defer the semicolon — record position before the newline
@@ -5296,7 +5296,7 @@ pub fn split_into_statements(input: &str) -> Vec<String> {
         && !ends_with_condition
         && !ends_with_operator
         && !ends_with_prefix_not
-        && !crate::syntax::ends_with_continuing_named_operator(&code_tail);
+        && !syntax::ends_with_continuing_named_operator(&code_tail);
 
       if should_split {
         let stmt = current.trim().to_string();


### PR DESCRIPTION
expr_to_output and expr_to_string calls are so common Woxi places use statements for them in most mod.rs files, so we can strip the prefixes from the callers in most cases, adding use statements in a few places to cover missed exports.

Similarly, crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator} should usually not need the prefix, so remove tham and add use super::*; to some files that are missing them.