### PR TITLE
Add PDF import and RunProcess functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.1",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,7 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cc",
  "cesu8",
  "jni",
@@ -645,9 +656,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -689,6 +700,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -805,7 +834,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -819,7 +848,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "polling",
  "rustix 1.1.3",
  "slab",
@@ -857,6 +886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +923,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -935,6 +984,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -1090,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,7 +1210,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1174,7 +1239,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fontdb",
  "harfrust",
  "linebender_resource_handle",
@@ -1193,10 +1258,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1308,6 +1388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,8 +1446,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1394,7 +1494,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -1440,6 +1540,15 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "ecb"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f2a8b3e564eba0877223dc343703ad0385794e882e6d13f3a4dd5c6b1f41ac"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "either"
@@ -1959,8 +2068,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1970,7 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -1980,7 +2101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12",
 ]
 
 [[package]]
@@ -2058,7 +2179,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-alloc-types",
 ]
 
@@ -2068,7 +2189,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2089,7 +2210,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2100,7 +2221,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2131,7 +2252,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "core_maths",
  "read-fonts",
@@ -2157,6 +2278,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2189,6 +2316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2238,7 +2374,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ab1937d699403e7e69252ae743a902bcee9f4ab2052cc4c9a46fcf34729d85"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "glam",
  "lilt",
@@ -2282,7 +2418,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234ca1c2cec4155055f68fa5fad1b5242c496ac8238d80a259bca382fb44a102"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cosmic-text",
  "half",
@@ -2357,7 +2493,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff144a999b0ca0f8a10257934500060240825c42e950ec0ebee9c8ae30561c13"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cryoglyph",
  "futures",
@@ -2584,12 +2720,12 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2599,6 +2735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2764,7 +2910,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2884,7 +3030,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.5.18",
 ]
@@ -2956,6 +3102,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
+dependencies = [
+ "aes",
+ "bitflags 2.13.1",
+ "cbc",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.3",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "nom",
+ "rand 0.10.2",
+ "rangemap",
+ "sha2 0.11.0",
+ "stringprep",
+ "thiserror 2.0.17",
+ "weezl 0.2.1",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,7 +3168,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3005,7 +3187,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3038,7 +3220,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -3117,7 +3299,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -3141,7 +3323,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -3186,7 +3368,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3358,7 +3540,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -3374,7 +3556,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -3395,7 +3577,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3408,7 +3590,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -3430,7 +3612,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3442,7 +3624,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -3453,7 +3635,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -3464,7 +3646,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -3511,7 +3693,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3523,7 +3705,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3542,7 +3724,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -3555,7 +3737,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -3568,7 +3750,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3591,7 +3773,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3603,7 +3785,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3616,7 +3798,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3638,7 +3820,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit 0.2.2",
@@ -3670,7 +3852,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3795,7 +3977,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3847,7 +4029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3982,7 +4164,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4093,7 +4275,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -4242,6 +4424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4464,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4315,6 +4514,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -4458,7 +4663,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4577,7 +4782,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4637,7 +4842,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4650,7 +4855,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -4681,7 +4886,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -4699,7 +4904,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -4845,8 +5050,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4862,8 +5067,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4872,7 +5088,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -4973,7 +5189,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -4998,7 +5214,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -5096,7 +5312,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5131,6 +5347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5322,7 +5549,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error 2.0.1",
- "weezl",
+ "weezl 0.1.12",
  "zune-jpeg 0.4.21",
 ]
 
@@ -5521,9 +5748,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5855,7 +6082,7 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "rustix 1.1.3",
  "wayland-backend",
  "wayland-scanner",
@@ -5867,7 +6094,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5889,7 +6116,7 @@ version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5901,7 +6128,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5914,7 +6141,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791c58fdeec5406aa37169dd815327d1e47f334219b523444bc26d70ceb4c34e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5927,7 +6154,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa98634619300a535a9a97f338aed9a5ff1e01a461943e8346ff4ae26007306b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5940,7 +6167,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5997,13 +6224,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "weezl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
+
+[[package]]
 name = "wgpu"
 version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -6034,7 +6267,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -6094,7 +6327,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "bytemuck",
  "cfg-if",
@@ -6139,7 +6372,7 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
@@ -6672,7 +6905,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -6768,8 +7001,9 @@ dependencies = [
  "libc",
  "libm",
  "log",
+ "lopdf",
  "lz4_flex",
- "md-5",
+ "md-5 0.10.6",
  "md4",
  "num-bigint",
  "num-prime",
@@ -6790,7 +7024,7 @@ dependencies = [
  "rustyline",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "snailquote",
  "stacker",
@@ -6903,7 +7137,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,6 +287,13 @@ version = "0.13"
 default-features = false
 features = ["text"]
 
+# Reads PDF files for `Import`: object parsing, xref/object streams and
+# stream decompression. The page content is interpreted in
+# `functions::pdf_import`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.lopdf]
+version = "0.44"
+default-features = false
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc = "0.2"
 calamine = "0.34"

--- a/functions.csv
+++ b/functions.csv
@@ -232,7 +232,7 @@ ColumnForm,Legacy display directive stacking elements one per line (renders at t
 FontColor,Option symbol for specifying text color in Style,✅,pure,3.0,175
 NIntegrate,Computes a numerical integral by tanh-sinh quadrature — which handles an endpoint singularity — falling back to an adaptive Simpson rule for oscillatory integrands and using a tangent substitution for infinite bounds,✅,pure,1.0,176
 Dashed,Shorthand for Dashing[{Small Small}] line style,✅,pure,6.0,177
-Import,"Imports data from a file (images CSV XLSX TXT PPM/PGM/PBM/PNM WAV and other audio; CERN ROOT incl. TH1/TH2 histograms and TTree branch data via element paths; CSV/TSV row/column subsets via {""Data"" rowspec colspec} position specs); an .xml file reads into symbolic XML",✅,effectful,4.0,178
+Import,"Imports data from a file (images CSV XLSX TXT PPM/PGM/PBM/PNM WAV and other audio; CERN ROOT incl. TH1/TH2 histograms and TTree branch data via element paths; CSV/TSV row/column subsets via {""Data"" rowspec colspec} position specs); an .xml file reads into symbolic XML; a PDF gives one Graphics per page with PageCount and Plaintext elements",✅,effectful,4.0,178
 Thread,Threads a function over corresponding list elements,✅,pure,1.0,179
 Arrow,Represents an arrow graphics primitive,✅,pure,6.0,181
 Scaled,Represents a scaled position or size,✅,pure,1.0,183
@@ -1752,7 +1752,7 @@ JoinedCurve,Joined curve graphics primitive,✅,unevaluated,8.0,1754
 DefaultButton,Default button control,,unevaluated,6.0,1760
 GeoMarker,Geographic marker primitive for GeoGraphics,✅,pure,10.0,1760
 MultiplicativeOrder,Multiplicative order modulo n,✅,computation,4.0,1760
-RunProcess,Run external process,,unevaluated,10.0,1760
+RunProcess,Runs a program to completion (a string names it; a list adds its arguments) and returns its ExitCode StandardOutput and StandardError as an association; a property name picks one; a third argument is fed to its standard input; ProcessDirectory and ProcessEnvironment set where and with which variables it runs,✅,effectful,10.0,1760
 StartingStepSize,Starting step size option,,unevaluated,4.0,1760
 Trigger,Trigger control (stays symbolic in script mode),✅,unevaluated,6.0,1760
 ContentSelectable,Content selectable option,,unevaluated,6.0,1761
@@ -3803,7 +3803,7 @@ HostLookup,,🚫,,10.3,3889
 ImageCooccurrence,,🚫,,8.0,3889
 LindleyDistribution,Lindley distribution (Mean Variance and exponential PDF/CDF on positive reals),✅,pure,8.0,3889
 MardiaKurtosisTest,,,,8.0,3889
-ProcessDirectory,,🚫,,10.0,3889
+ProcessDirectory,Option of RunProcess naming the directory the program runs in,✅,pure,10.0,3889
 ResourceUpdate,,🚫,,11.2,3889
 ResponseForm,,🚫,,10.0,3889
 Subresultants,Principal subresultant coefficients of two polynomials,✅,pure,4.0,3889
@@ -4179,7 +4179,7 @@ ObservableDecomposition,,,,8.0,4291
 OutputNamePacket,,🚫,,3.0,4291
 ParametricRampLayer,,🚫,,12.1,4291
 PolygonDecomposition,,,,12.0,4291
-ProcessEnvironment,,🚫,,10.0,4291
+ProcessEnvironment,Option of RunProcess giving the environment variables of the program as an association or list of rules (Inherited keeps the interpreter’s own),✅,pure,10.0,4291
 RudinShapiro,Returns -1 raised to the number of overlapping 11 pairs in the binary expansion of n (Listable),✅,pure,10.2,4291
 SliderBox,,🚫,,6.0,4291
 UnconstrainedParameters,,,,12.0,4291

--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -559,6 +559,50 @@ fn collect_binary_children(
 /// tests, upvalue/downvalue placeholders) rather than a pattern variable the
 /// user wrote. Synthetic names already carry their slot index, so they never
 /// repeat and must never be mistaken for a repeated pattern variable.
+/// How many arguments a pattern can stand for, as the blank type a
+/// definition slot records: 1 for exactly one, 2 for one or more
+/// (`Repeated`, a multi-element `PatternSequence`), 3 for zero or more
+/// (`RepeatedNull`, `BlankNullSequence`). A named body such as
+/// `r : (_Rule | _RuleDelayed)...` has to claim every argument its
+/// sequence admits, not the single one a plain named slot takes.
+pub fn pattern_blank_type(pattern: &Expr) -> u8 {
+  match pattern {
+    Expr::Pattern { blank_type, .. } | Expr::PatternTest { blank_type, .. } => {
+      *blank_type
+    }
+    Expr::Identifier(name) if name.starts_with('_') => {
+      name.chars().take_while(|c| *c == '_').count().min(3) as u8
+    }
+    Expr::FunctionCall { name, args } => match name.as_str() {
+      "BlankSequence" => 2,
+      "BlankNullSequence" | "RepeatedNull" => 3,
+      // `Repeated[p, {0, n}]` admits an empty run.
+      "Repeated" => match args.get(1) {
+        Some(Expr::List(spec))
+          if spec.len() == 2 && matches!(spec[0], Expr::Integer(0)) =>
+        {
+          3
+        }
+        _ => 2,
+      },
+      "PatternSequence" => match args.len() {
+        0 => 3,
+        1 => pattern_blank_type(&args[0]),
+        _ => 2,
+      },
+      "Longest" | "Shortest" | "Condition" | "HoldPattern"
+        if !args.is_empty() =>
+      {
+        pattern_blank_type(&args[0])
+      }
+      "Pattern" if args.len() == 2 => pattern_blank_type(&args[1]),
+      "Alternatives" => args.iter().map(pattern_blank_type).max().unwrap_or(1),
+      _ => 1,
+    },
+    _ => 1,
+  }
+}
+
 fn is_synthetic_param(name: &str) -> bool {
   name.is_empty()
     || name.starts_with("_lp")
@@ -2279,15 +2323,37 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
 
       if is_pattern {
         let (pat_name, head, blank_type) = extract_pattern_info(arg);
-        let final_name = if pat_name.is_empty() {
-          param_name
+        // `Pattern[name, body]` with a body beyond a blank (`r : _Rule..`,
+        // `x : (_Integer | _Real)`): keep the body as a structural pattern
+        // so the constraint holds at dispatch, and let a sequence body
+        // claim its whole run of arguments.
+        if pat_name.is_empty()
+          && let Expr::FunctionCall {
+            name: pat_head,
+            args: pat_args,
+          } = arg
+          && pat_head == "Pattern"
+          && pat_args.len() == 2
+          && let Expr::Identifier(bound) = &pat_args[0]
+        {
+          conditions.push(Some(call(
+            "__StructuralPattern__",
+            vec![Expr::Identifier(bound.clone()), arg.clone()],
+          )));
+          params.push(bound.clone());
+          heads.push(None);
+          blank_types.push(pattern_blank_type(arg));
         } else {
-          pat_name
-        };
-        params.push(final_name);
-        conditions.push(None);
-        heads.push(head);
-        blank_types.push(blank_type);
+          let final_name = if pat_name.is_empty() {
+            param_name
+          } else {
+            pat_name
+          };
+          params.push(final_name);
+          conditions.push(None);
+          heads.push(head);
+          blank_types.push(blank_type);
+        }
       } else {
         // Evaluate the literal argument value
         let eval_arg = evaluate_expr_to_expr(arg)?;
@@ -3182,6 +3248,8 @@ pub fn set_delayed_ast(
             // body] as a structural pattern matched at dispatch time —
             // previously the constraint was silently dropped, so
             // s[x : (_Integer | _Real)] matched any argument at all.
+            // A sequence body (`r : (_Rule)..`) spans as many arguments
+            // as its run takes, so the slot is recorded as a sequence.
             _ => {
               conditions.push(Some(call(
                 "__StructuralPattern__",
@@ -3190,7 +3258,7 @@ pub fn set_delayed_ast(
               params.push(pname);
               defaults.push(None);
               heads.push(None);
-              blank_types.push(1);
+              blank_types.push(pattern_blank_type(arg));
             }
           }
         }
@@ -3695,8 +3763,23 @@ fn build_list_pattern_match(
   let last_pat_idx = patterns.len().saturating_sub(1);
   for (eidx, pat) in patterns.iter().enumerate() {
     // The trailing sequence element matches the (length-checked) tail; it has
-    // no single Part to test against.
+    // no single Part to test against. A constrained one (`__String`,
+    // `__?test`) is matched against the tail as a whole, so `{__String}`
+    // takes `{"a", "b"}` and not `{x}`.
     if trailing_seq && eidx == last_pat_idx {
+      let constrained = match pat {
+        Expr::PatternTest { .. } => true,
+        other => extract_pattern_info(other).1.is_some(),
+      };
+      if constrained {
+        rule_conds.push(call(
+          "MatchQ",
+          vec![
+            call("Drop", vec![base.clone(), Expr::Integer(eidx as i128)]),
+            Expr::List(vec![pat.clone()].into()),
+          ],
+        ));
+      }
       continue;
     }
     // Emit a `MatchQ` guard for every element. For a constrained element
@@ -4202,11 +4285,17 @@ pub fn extract_pattern_info(expr: &Expr) -> (String, Option<String>, u8) {
       if name == "Pattern" && args.len() == 2 =>
     {
       // Pattern[name, Blank[head]], Pattern[name, BlankSequence[head]], Pattern[name, BlankNullSequence[head]]
+      // Any other body (`Repeated`, `Except`, `Alternatives`, …) is not a
+      // plain named blank: it is left for the structural-pattern handling.
       if let Expr::Identifier(pat_name) = &args[0]
         && let Expr::FunctionCall {
           name: blank_name,
           args: blank_args,
         } = &args[1]
+        && matches!(
+          blank_name.as_str(),
+          "Blank" | "BlankSequence" | "BlankNullSequence"
+        )
       {
         let blank_type = match blank_name.as_str() {
           "Blank" => 1,

--- a/src/evaluator/contexts.rs
+++ b/src/evaluator/contexts.rs
@@ -220,15 +220,22 @@ fn is_user_symbol(name: &str) -> bool {
   {
     return false;
   }
-  if is_system_variable_name(short_name(name)) {
-    return false;
-  }
   // A pattern variable arrives with its blank suffix stripped, but a stray
   // `_` (or a slot) is not a symbol name.
   if name.contains(['_', '#', '%']) {
     return false;
   }
+  // A name that spells out a context of its own (or a relative one) is a
+  // symbol of that context whatever its short name: `Foo`Info`$Version`
+  // is the package's, not the system variable, and `Foo`Print` is not the
+  // built-in `Print`.
+  if name.contains('`') && !name.starts_with("System`") {
+    return true;
+  }
   let bare = short_name(name);
+  if is_system_variable_name(bare) {
+    return false;
+  }
   !is_builtin_symbol(bare) && get_builtin_attributes(bare).is_empty()
 }
 
@@ -312,7 +319,15 @@ pub fn resolve(name: &str) -> String {
   {
     return bare.to_string();
   }
-  if !contexts_active() || !is_user_symbol(name) {
+  if !contexts_active() {
+    // With no package open a relative name lives under `Global``:
+    // `` `a`b `` is `Global`a`b`.
+    return match name.strip_prefix('`') {
+      Some(relative) if is_user_symbol(name) => format!("Global`{relative}"),
+      _ => name.to_string(),
+    };
+  }
+  if !is_user_symbol(name) {
     return name.to_string();
   }
   // A name that starts with a backtick is relative to the current context;

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -108,6 +108,20 @@ fn needs_reevaluation(expr: &Expr, self_name: &str) -> bool {
     Expr::BinaryOp { .. } => true,
     Expr::UnaryOp { .. } => true,
     Expr::CurriedCall { .. } => true,
+    // `line := lines[[i]]` reads the part afresh each time, like a call.
+    Expr::Part { .. } => true,
+    Expr::Comparison { .. } => true,
+    Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } => {
+      needs_reevaluation(pattern, self_name)
+        || needs_reevaluation(replacement, self_name)
+    }
     _ => false,
   }
 }
@@ -1557,12 +1571,26 @@ pub fn evaluate_expr_to_expr_inner(
               | Expr::Part { .. }
               | Expr::FunctionCall { .. }
               | Expr::CurriedCall { .. }
+              | Expr::List(_)
           ) {
             emit_rvalue(name, &args[0]);
             return Ok(Expr::FunctionCall {
               name: name.clone(),
               args: args.clone(),
             });
+          }
+          // `{w, h} *= k` is `{w, h} = {w, h} k`: the list of targets is
+          // read, combined, and assigned back element by element.
+          if let Expr::List(_) = &args[0] {
+            let current_val = evaluate_expr_to_expr(&args[0])?;
+            let rhs = evaluate_expr_to_expr(&args[1])?;
+            let new_val = evaluate_expr_to_expr(&Expr::BinaryOp {
+              op,
+              left: Box::new(current_val),
+              right: Box::new(rhs),
+            })?;
+            crate::evaluator::assignment::set_ast(&args[0], &new_val)?;
+            return Ok(new_val);
           }
           if let Expr::Identifier(var_name) = &args[0] {
             let current = ENV.with(|e| e.borrow().get(var_name).cloned());
@@ -1818,6 +1846,17 @@ pub fn evaluate_expr_to_expr_inner(
             Some(StoredValue::ExprVal(e)) => e,
             Some(StoredValue::Raw(s)) => crate::syntax::string_to_expr(&s)
               .unwrap_or(Expr::List(vec![].into())),
+            // An association gains the appended rule as an entry — the same
+            // write `Append[assoc, rule]` followed by `Set` would make.
+            Some(StoredValue::Association(_)) => {
+              let assoc = evaluate_expr_to_expr(&args[0])?;
+              let appended = evaluate_expr_to_expr(&Expr::FunctionCall {
+                name: if is_append { "Append" } else { "Prepend" }.to_string(),
+                args: vec![assoc, elem].into(),
+              })?;
+              crate::evaluator::assignment::set_ast(&args[0], &appended)?;
+              return Ok(appended);
+            }
             // System variables like `$BoxForms` aren't in ENV until written —
             // first AppendTo seeds the env from the built-in default.
             _ => {
@@ -2644,22 +2683,49 @@ pub fn evaluate_expr_to_expr_inner(
             Expr::Function { .. }
             | Expr::NamedFunction { .. }
             | Expr::FunctionCall { .. } => {
-              // For Function[{params}, body, attrs] with HoldAll/HoldFirst/
-              // HoldRest, suppress argument evaluation so the function body
-              // sees the unevaluated forms.
-              let hold_attrs = function_hold_attributes(stored_expr);
-              let mut prepared: Vec<Expr> = Vec::with_capacity(args.len());
-              for (i, a) in args.iter().enumerate() {
-                let hold = hold_attrs.0
-                  || (hold_attrs.1 && i == 0)
-                  || (hold_attrs.2 && i > 0);
-                if hold {
-                  prepared.push(a.clone());
-                } else {
-                  prepared.push(evaluate_expr_to_expr(a)?);
+              // A stored call is a delayed body to evaluate first — the
+              // memoization idiom `tpl := tpl = StringTemplate[…]` yields
+              // the template, not the `Set` — and what it yields is what
+              // gets applied.
+              let head_value = match stored_expr {
+                Expr::FunctionCall { .. } => {
+                  evaluate_expr_to_expr(&Expr::Identifier(name.clone()))?
                 }
+                other => other.clone(),
+              };
+              if let Expr::Identifier(new_head) = &head_value
+                && new_head != name
+              {
+                return Err(InterpreterError::TailCall(Box::new(
+                  Expr::FunctionCall {
+                    name: new_head.clone(),
+                    args: args.to_vec().into(),
+                  },
+                )));
               }
-              return apply_curried_call(stored_expr, &prepared);
+              if matches!(
+                head_value,
+                Expr::Function { .. }
+                  | Expr::NamedFunction { .. }
+                  | Expr::FunctionCall { .. }
+              ) {
+                // For Function[{params}, body, attrs] with HoldAll/HoldFirst/
+                // HoldRest, suppress argument evaluation so the function body
+                // sees the unevaluated forms.
+                let hold_attrs = function_hold_attributes(&head_value);
+                let mut prepared: Vec<Expr> = Vec::with_capacity(args.len());
+                for (i, a) in args.iter().enumerate() {
+                  let hold = hold_attrs.0
+                    || (hold_attrs.1 && i == 0)
+                    || (hold_attrs.2 && i > 0);
+                  if hold {
+                    prepared.push(a.clone());
+                  } else {
+                    prepared.push(evaluate_expr_to_expr(a)?);
+                  }
+                }
+                return apply_curried_call(&head_value, &prepared);
+              }
             }
             _ => {}
           }

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -730,7 +730,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "ImageType" => Some((1, 1)),
     "Implies" => Some((2, 2)),
     "Indexed" => Some((2, 2)),
-    "Import" => Some((1, 2)),
+    "Import" => Some((1, usize::MAX)),
     // Beyond the format come options, which the handler checks itself.
     "ImportString" => Some((1, usize::MAX)),
     "IncidenceGraph" => Some((1, 2)),
@@ -1277,6 +1277,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "Rule" => Some((2, 2)),
     "RulePlot" => Some((1, usize::MAX)),
     "Run" => Some((1, 1)),
+    "RunProcess" => Some((1, usize::MAX)),
     "Save" => Some((2, 2)),
     "SawtoothWave" => Some((1, 2)),
     "ScalarTripleProduct" => Some((3, 3)),

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -272,6 +272,29 @@ fn repeat_ok(
   true
 }
 
+/// Match the argument(s) a structural slot received against its pattern.
+/// A sequence slot (`r : (_Rule)..`) may hold several arguments packed as
+/// `Sequence[…]`, or none: they are matched as the elements of a list
+/// against the one-element list pattern, which is how the pattern sees the
+/// arguments of a call.
+fn structural_slot_match(
+  arg: &Expr,
+  pattern: &Expr,
+  is_sequence: bool,
+) -> Option<Vec<(String, Expr)>> {
+  if !is_sequence {
+    return crate::evaluator::pattern_matching::match_pattern(arg, pattern);
+  }
+  let items: Vec<Expr> = match arg {
+    Expr::FunctionCall { name, args } if name == "Sequence" => args.to_vec(),
+    other => vec![other.clone()],
+  };
+  crate::evaluator::pattern_matching::match_pattern(
+    &Expr::List(items.into()),
+    &Expr::List(vec![pattern.clone()].into()),
+  )
+}
+
 /// The pattern-variable names the argument splitter must treat as repeated.
 ///
 /// `constrain_repeated_params` stores every slot after the first occurrence of
@@ -1214,11 +1237,11 @@ fn evaluate_function_call_ast_inner(
                 crate::evaluator::pattern_matching::push_match_context(
                   &positional_ctx,
                 );
-                let match_result =
-                  crate::evaluator::pattern_matching::match_pattern(
-                    &canonical_arg,
-                    pattern,
-                  );
+                let match_result = structural_slot_match(
+                  &canonical_arg,
+                  pattern,
+                  blank_types[idx] >= 2,
+                );
                 crate::evaluator::pattern_matching::pop_match_context();
                 if let Some(bindings) = match_result {
                   // Check consistency: structural bindings must not conflict
@@ -1541,11 +1564,11 @@ fn evaluate_function_call_ast_inner(
                   crate::evaluator::pattern_matching::push_match_context(
                     &positional_ctx,
                   );
-                  let match_result =
-                    crate::evaluator::pattern_matching::match_pattern(
-                      &canonical_arg,
-                      pattern,
-                    );
+                  let match_result = structural_slot_match(
+                    &canonical_arg,
+                    pattern,
+                    blank_types[idx] >= 2,
+                  );
                   crate::evaluator::pattern_matching::pop_match_context();
                   if let Some(bindings) = match_result {
                     // Check consistency: structural bindings must not conflict

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -251,6 +251,7 @@ fn import_format_name(name: &str) -> Option<&'static str> {
     "TSV" => "tsv",
     "JSON" | "RawJSON" => "json",
     "SVG" => "svg",
+    "PDF" => "pdf",
     "XLSX" => "xlsx",
     "XLS" => "xls",
     "ODS" => "ods",
@@ -339,6 +340,73 @@ fn import_svg(path: &str, is_url: bool) -> Result<Expr, InterpreterError> {
   }
   let svg = import_read_text(path, is_url)?;
   Ok(crate::graphics_result(svg))
+}
+
+/// `Import[pdf, element]`: the pages as `Graphics` by default or for
+/// `"Pages"`, one page for `{"Pages", n}`, the page count, or the text.
+#[cfg(not(target_arch = "wasm32"))]
+fn import_pdf_element(
+  path: &str,
+  element: Option<&Expr>,
+) -> Result<Expr, InterpreterError> {
+  if !crate::vfs::exists(path) {
+    crate::emit_message(&format!(
+      "Import::nffil: File {path} not found during Import."
+    ));
+    return Ok(Expr::Identifier("$Failed".to_string()));
+  }
+  use crate::functions::pdf_import;
+  let pages =
+    |path: &str| pdf_import::import_pages(path).map(|p| Expr::List(p.into()));
+  match element {
+    None => pages(path),
+    Some(Expr::String(e)) => match e.as_str() {
+      "Pages" | "Graphics" => pages(path),
+      "PageCount" => {
+        pdf_import::page_count(path).map(|n| Expr::Integer(n as i128))
+      }
+      "Plaintext" | "Text" => pdf_import::plaintext(path).map(Expr::String),
+      "Elements" => Ok(Expr::List(
+        ["PageCount", "Pages", "Plaintext"]
+          .iter()
+          .map(|e| Expr::String((*e).to_string()))
+          .collect::<Vec<_>>()
+          .into(),
+      )),
+      _ => {
+        crate::emit_message(&format!(
+          "Import::noelem: The Import element \"{e}\" is not present when importing as PDF."
+        ));
+        Ok(Expr::Identifier("$Failed".to_string()))
+      }
+    },
+    // {"Pages", n} — one page, counted from 1.
+    Some(Expr::List(items))
+      if items.len() == 2
+        && matches!(&items[0], Expr::String(e) if e == "Pages")
+        && matches!(&items[1], Expr::Integer(_)) =>
+    {
+      let Expr::Integer(n) = &items[1] else {
+        unreachable!()
+      };
+      let all = pdf_import::import_pages(path)?;
+      if let Some(page) = usize::try_from(*n - 1).ok().and_then(|i| all.get(i))
+      {
+        return Ok(page.clone());
+      }
+      crate::emit_message(&format!(
+        "Import::noelem: The Import element {{\"Pages\", {n}}} is not present when importing as PDF."
+      ));
+      Ok(Expr::Identifier("$Failed".to_string()))
+    }
+    Some(other) => {
+      crate::emit_message(&format!(
+        "Import::noelem: The Import element {} is not present when importing as PDF.",
+        crate::syntax::expr_to_string(other)
+      ));
+      Ok(Expr::Identifier("$Failed".to_string()))
+    }
+  }
 }
 
 /// Read the textual contents of a path that is either a local file or an
@@ -1142,6 +1210,28 @@ pub fn dispatch_image_functions(
       let _ = std::fs::remove_file(&temp);
       return result;
     }
+    // Import[file, (elem,) opt -> value, …] — the options (CharacterEncoding
+    // and the like) do not change what is read here; import the file as
+    // the arguments before them say.
+    "Import"
+      if args.len() >= 2
+        && matches!(
+          args[args.len() - 1],
+          Expr::Rule { .. } | Expr::RuleDelayed { .. }
+        ) =>
+    {
+      let core: Vec<Expr> = args
+        .iter()
+        .take_while(|a| {
+          !matches!(a, Expr::Rule { .. } | Expr::RuleDelayed { .. })
+        })
+        .cloned()
+        .collect();
+      if core.is_empty() || core.len() > 2 {
+        return Some(Ok(unevaluated("Import", args)));
+      }
+      return dispatch_image_functions("Import", &core);
+    }
     "Import" if args.len() == 1 => {
       let Some(path) = import_path_spec(&args[0]) else {
         return Some(Ok(unevaluated("Import", args)));
@@ -1154,6 +1244,19 @@ pub fn dispatch_image_functions(
       #[cfg(target_arch = "wasm32")]
       if !is_url {
         return Some(import_virtual(&path, None));
+      }
+
+      if ext == "pdf" && !is_url {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+          return Some(import_pdf_element(&path, None));
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+          return Some(Err(InterpreterError::EvaluationError(
+            "Import: PDF import is not available in the browser".into(),
+          )));
+        }
       }
 
       if ext == "svg" {
@@ -1466,6 +1569,23 @@ pub fn dispatch_image_functions(
             )));
           }
         }
+      }
+
+      // A PDF's elements: "Pages" (the default), "PageCount", "Plaintext".
+      #[cfg(not(target_arch = "wasm32"))]
+      if (file_ext == "pdf" || ext == "pdf") && !is_url {
+        let element: Option<Expr> = match &args[1] {
+          Expr::List(items) if matches!(items.first(), Some(Expr::String(f)) if f == "PDF") => {
+            match items.len() {
+              1 => None,
+              2 => Some(items[1].clone()),
+              _ => Some(Expr::List(items[1..].to_vec().into())),
+            }
+          }
+          Expr::String(f) if f == "PDF" => None,
+          other => Some(other.clone()),
+        };
+        return Some(import_pdf_element(&path, element.as_ref()));
       }
 
       // Formats with handling of their own have claimed the call by now.

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -212,6 +212,194 @@ pub(crate) fn run_command_capture(command: &str) -> Option<String> {
     .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
 }
 
+/// `RunProcess[cmd, (prop, (input,)) opts…]` — see the dispatch arm.
+#[cfg(not(target_arch = "wasm32"))]
+fn run_process_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  use std::io::{Read, Write};
+  use std::process::{Command, Stdio};
+
+  let is_option =
+    |e: &Expr| matches!(e, Expr::Rule { .. } | Expr::RuleDelayed { .. });
+  let positional: Vec<&Expr> =
+    args.iter().take_while(|a| !is_option(a)).collect();
+  let options: Vec<&Expr> = args.iter().skip(positional.len()).collect();
+  if positional.is_empty()
+    || positional.len() > 3
+    || !options.iter().all(|o| is_option(o))
+  {
+    return Ok(unevaluated("RunProcess", args));
+  }
+
+  // The program and its arguments: a string is a program name, a list is
+  // the program followed by its arguments. Neither goes through a shell.
+  let words: Vec<String> = match positional[0] {
+    Expr::String(s) => vec![s.clone()],
+    Expr::List(items) => {
+      let mut words = Vec::with_capacity(items.len());
+      for item in items {
+        match item {
+          Expr::String(s) => words.push(s.clone()),
+          other => words.push(crate::syntax::expr_to_string(other)),
+        }
+      }
+      words
+    }
+    _ => return Ok(unevaluated("RunProcess", args)),
+  };
+  let Some((program, program_args)) = words.split_first() else {
+    return Ok(unevaluated("RunProcess", args));
+  };
+
+  // Which of the results to return.
+  let property = match positional.get(1) {
+    None => None,
+    Some(Expr::Identifier(a)) if a == "All" => None,
+    Some(Expr::String(p))
+      if matches!(
+        p.as_str(),
+        "ExitCode" | "StandardOutput" | "StandardError"
+      ) =>
+    {
+      Some(p.clone())
+    }
+    Some(other) => {
+      crate::emit_message(&format!(
+        "RunProcess::pbad: {} is not a valid RunProcess property.",
+        crate::syntax::expr_to_string(other)
+      ));
+      return Ok(Expr::Identifier("$Failed".to_string()));
+    }
+  };
+  let input: Option<String> = match positional.get(2) {
+    None => None,
+    Some(Expr::String(s)) => Some(s.clone()),
+    Some(other) => Some(crate::syntax::expr_to_string(other)),
+  };
+
+  let mut command = Command::new(program);
+  command.args(program_args);
+  for option in options {
+    let (Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }) = option
+    else {
+      continue;
+    };
+    let Expr::Identifier(name) = pattern.as_ref() else {
+      continue;
+    };
+    let value = crate::evaluator::evaluate_expr_to_expr(replacement)?;
+    match name.as_str() {
+      "ProcessDirectory" => {
+        if let Expr::String(dir) = &value {
+          command.current_dir(crate::vfs::resolve(dir));
+        }
+      }
+      "ProcessEnvironment" => {
+        let pairs: Vec<(Expr, Expr)> = match &value {
+          Expr::Association(pairs) => pairs.clone(),
+          Expr::List(rules) => rules
+            .iter()
+            .filter_map(|r| match r {
+              Expr::Rule {
+                pattern,
+                replacement,
+              }
+              | Expr::RuleDelayed {
+                pattern,
+                replacement,
+              } => Some(((**pattern).clone(), (**replacement).clone())),
+              _ => None,
+            })
+            .collect(),
+          // Inherited (the default) keeps the interpreter's environment.
+          _ => continue,
+        };
+        command.env_clear();
+        let text = |e: &Expr| match e {
+          Expr::String(s) => s.clone(),
+          other => crate::syntax::expr_to_string(other),
+        };
+        for (key, val) in &pairs {
+          command.env(text(key), text(val));
+        }
+      }
+      _ => {}
+    }
+  }
+  command
+    .stdin(if input.is_some() {
+      Stdio::piped()
+    } else {
+      Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+  let Ok(mut child) = command.spawn() else {
+    crate::emit_message(&format!(
+      "RunProcess::pnfd: Program {program} not found. Check the path and file permissions."
+    ));
+    return Ok(Expr::Identifier("$Failed".to_string()));
+  };
+  // Feed the input on its own thread: a program that writes a lot before
+  // reading would otherwise deadlock against our reads below.
+  let feeder = input.and_then(|text| {
+    child.stdin.take().map(|mut stdin| {
+      std::thread::spawn(move || {
+        let _ = stdin.write_all(text.as_bytes());
+      })
+    })
+  });
+  let stderr_reader = child.stderr.take().map(|mut stderr| {
+    std::thread::spawn(move || {
+      let mut buf = Vec::new();
+      let _ = stderr.read_to_end(&mut buf);
+      buf
+    })
+  });
+  let mut stdout_bytes = Vec::new();
+  if let Some(mut stdout) = child.stdout.take() {
+    let _ = stdout.read_to_end(&mut stdout_bytes);
+  }
+  let stderr_bytes = stderr_reader
+    .and_then(|t| t.join().ok())
+    .unwrap_or_default();
+  if let Some(t) = feeder {
+    let _ = t.join();
+  }
+  let status = child.wait();
+
+  // A process that was killed by a signal has no exit code.
+  let exit_code = match status {
+    Ok(s) => s.code().map_or_else(
+      || Expr::Identifier("None".to_string()),
+      |c| Expr::Integer(i128::from(c)),
+    ),
+    Err(_) => Expr::Identifier("None".to_string()),
+  };
+  let stdout =
+    Expr::String(String::from_utf8_lossy(&stdout_bytes).into_owned());
+  let stderr =
+    Expr::String(String::from_utf8_lossy(&stderr_bytes).into_owned());
+
+  Ok(match property.as_deref() {
+    Some("ExitCode") => exit_code,
+    Some("StandardOutput") => stdout,
+    Some("StandardError") => stderr,
+    _ => Expr::Association(vec![
+      (Expr::String("ExitCode".to_string()), exit_code),
+      (Expr::String("StandardOutput".to_string()), stdout),
+      (Expr::String("StandardError".to_string()), stderr),
+    ]),
+  })
+}
+
 /// Split a Wolfram file specification into the external command it names.
 /// `"!sort -u"` runs `sort -u`; anything without the leading `!` is a
 /// plain file path.
@@ -896,6 +1084,16 @@ pub fn dispatch_io_functions(
         "so"
       };
       return Some(Ok(Expr::String(extension.to_string())));
+    }
+    // RunProcess[prog], RunProcess[{prog, arg, …}] — run a program to
+    // completion and report its exit code and output streams.
+    // RunProcess[cmd, "StandardOutput" | "StandardError" | "ExitCode" | All]
+    // picks one of them; a third argument is fed to its standard input.
+    // ProcessDirectory -> dir runs it there, ProcessEnvironment -> env
+    // (an association or list of rules, or Inherited) sets its variables.
+    #[cfg(not(target_arch = "wasm32"))]
+    "RunProcess" if !args.is_empty() => {
+      return Some(run_process_ast(args));
     }
     // GetEnvironment[] — all environment variables as a List of rules.
     "GetEnvironment" if args.is_empty() => {

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1485,6 +1485,31 @@ pub fn dispatch_predicate_functions(
           Err(e) => return Some(Err(e)),
         },
       };
+      // A rendered graphic carries the options it was drawn with.
+      if let Some(opts) =
+        crate::functions::graphics::graphics_options(&func_arg)
+      {
+        if args.len() == 1 {
+          return Some(Ok(Expr::List(opts.into())));
+        }
+        let opt_arg = match evaluate_expr_to_expr(&args[1]) {
+          Ok(v) => v,
+          Err(e) => return Some(Err(e)),
+        };
+        let Expr::Identifier(opt_name) = &opt_arg else {
+          return Some(Ok(Expr::List(vec![].into())));
+        };
+        let matching: Vec<Expr> = opts
+          .into_iter()
+          .filter(|rule| match rule {
+            Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. } => {
+              matches!(pattern.as_ref(), Expr::Identifier(n) if n == opt_name)
+            }
+            _ => false,
+          })
+          .collect();
+        return Some(Ok(Expr::List(matching.into())));
+      }
       let func_name = match &func_arg {
         Expr::Identifier(name) => name.clone(),
         _ => {

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -598,12 +598,18 @@ pub fn apply_function_to_arg(
 ) -> Result<Expr, InterpreterError> {
   match func {
     Expr::Identifier(name) => {
-      // Check if this identifier is a variable holding another function/value
+      // Check if this identifier is a variable holding another function/value.
+      // The symbol is evaluated rather than its stored body applied as it
+      // stands: a delayed value (`tpl := tpl = StringTemplate[…]`, the
+      // memoization idiom) yields the function it computes, not the `Set`.
       let resolved = ENV.with(|e| e.borrow().get(name).cloned());
       match &resolved {
         Some(StoredValue::ExprVal(expr)) if !matches!(expr, Expr::Identifier(n) if n == name) =>
         {
-          return apply_function_to_arg(expr, arg);
+          let value = evaluate_expr_to_expr(func)?;
+          if !matches!(&value, Expr::Identifier(n) if n == name) {
+            return apply_function_to_arg(&value, arg);
+          }
         }
         _ => {}
       }

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -2843,6 +2843,37 @@ fn merge_option_rules(defaults: &[Expr], explicit: &[Expr]) -> Vec<Expr> {
   result
 }
 
+/// Whether `pattern` is a `Repeated`, `RepeatedNull` or `PatternSequence`
+/// (possibly named, or under `Longest`/`Shortest`) — the sequence patterns
+/// that can stand in for a single expression outside a call.
+fn is_standalone_sequence_pattern(pattern: &Expr) -> bool {
+  match pattern {
+    Expr::FunctionCall { name, args } => match name.as_str() {
+      "Repeated" | "RepeatedNull" => !args.is_empty() && args.len() <= 2,
+      "PatternSequence" => true,
+      "Pattern" if args.len() == 2 => is_standalone_sequence_pattern(&args[1]),
+      "Longest" | "Shortest" if args.len() == 1 => {
+        is_standalone_sequence_pattern(&args[0])
+      }
+      _ => false,
+    },
+    _ => false,
+  }
+}
+
+/// The elements a standalone sequence pattern stands for inside a list:
+/// a `PatternSequence[p1, p2, …]` spreads into its members (so that
+/// `{1}` against `{_, _}` fails outright instead of re-entering the
+/// standalone rule for ever), anything else is the one element it is.
+fn sequence_pattern_elements(pattern: &Expr) -> Vec<Expr> {
+  match pattern {
+    Expr::FunctionCall { name, args } if name == "PatternSequence" => {
+      args.iter().flat_map(sequence_pattern_elements).collect()
+    }
+    other => vec![other.clone()],
+  }
+}
+
 /// Check if a pattern is a sequence pattern (BlankSequence or BlankNullSequence).
 fn get_sequence_info(pattern: &Expr) -> Option<SeqInfo> {
   match pattern {
@@ -3951,6 +3982,16 @@ fn match_pattern_impl(
     && args.len() == 1
   {
     return match_pattern_impl(expr, &args[0]);
+  }
+  // A sequence pattern on its own (`_Rule..`, `RepeatedNull[_]`,
+  // `r : PatternSequence[_, _]`) matches an expression as a one-element
+  // sequence: `MatchQ[a -> 1, _Rule..]` is True. The list matcher already
+  // runs a sequence against elements, so match `{expr}` against `{pattern}`.
+  if is_standalone_sequence_pattern(pattern) {
+    return match_pattern_impl(
+      &Expr::List(vec![expr.clone()].into()),
+      &Expr::List(sequence_pattern_elements(pattern).into()),
+    );
   }
   // Longest[p] / Shortest[p] only pick which split of a sequence to try
   // first (handled where the sequence is matched); around anything else

--- a/src/functions/association_ast.rs
+++ b/src/functions/association_ast.rs
@@ -380,46 +380,18 @@ pub fn lookup_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  // If the second argument is a list of keys, look up each one
-  if let Expr::List(keys) = &args[1]
-    && let Expr::Association(_) = &args[0]
-  {
-    let results: Result<Vec<Expr>, InterpreterError> = keys
-      .iter()
-      .map(|key| {
-        let mut new_args = vec![args[0].clone(), key.clone()];
-        if args.len() >= 3 {
-          new_args.push(args[2].clone());
-        }
-        lookup_ast(&new_args)
-      })
-      .collect();
-    return Ok(Expr::List(results?.into()));
-  }
-
-  let key_str = crate::syntax::expr_to_string(&args[1]);
-  // Compare keys structurally: a string key ("a") must NOT match a symbol
-  // key (a), matching wolframscript (and Woxi's part-access path).
-  let key_cmp = key_str.as_str();
-
   match &args[0] {
     Expr::Association(items) => {
-      for (k, v) in items {
-        let k_str = crate::syntax::expr_to_string(k);
-        let k_cmp = k_str.as_str();
-        if k_cmp == key_cmp {
-          return Ok(assoc_entry_value(k, v));
-        }
+      // A list of keys looks each one up — once: a key that is itself a
+      // list (`{"c", 3}`) is one key, not a list of keys to thread over.
+      if let Expr::List(keys) = &args[1] {
+        let results: Vec<Expr> = keys
+          .iter()
+          .map(|key| lookup_key(items, key, args.get(2)))
+          .collect();
+        return Ok(Expr::List(results.into()));
       }
-      // Default value if provided
-      if args.len() >= 3 {
-        return Ok(args[2].clone());
-      }
-      // Return Missing["KeyAbsent", key]
-      Ok(call(
-        "Missing",
-        vec![Expr::String("KeyAbsent".to_string()), args[1].clone()],
-      ))
+      Ok(lookup_key(items, &args[1], args.get(2)))
     }
     Expr::List(items) => {
       // Thread Lookup over a list of associations
@@ -440,6 +412,30 @@ pub fn lookup_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       &args[0],
       args,
     )),
+  }
+}
+
+/// The value stored under `key`, the given default when there is none, and
+/// `Missing["KeyAbsent", key]` without one. Keys compare structurally: a
+/// string key `"a"` does not match a symbol key `a`, matching wolframscript
+/// (and Woxi's part-access path).
+fn lookup_key(
+  items: &[(Expr, Expr)],
+  key: &Expr,
+  default: Option<&Expr>,
+) -> Expr {
+  let key_str = crate::syntax::expr_to_string(key);
+  for (k, v) in items {
+    if crate::syntax::expr_to_string(k) == key_str {
+      return assoc_entry_value(k, v);
+    }
+  }
+  match default {
+    Some(d) => d.clone(),
+    None => call(
+      "Missing",
+      vec![Expr::String("KeyAbsent".to_string()), key.clone()],
+    ),
   }
 }
 

--- a/src/functions/country_data.rs
+++ b/src/functions/country_data.rs
@@ -415,6 +415,15 @@ pub fn apply_interpreter(
     });
   }
 
+  // A list of inputs is interpreted element by element.
+  if let [Expr::List(items)] = applied {
+    let results: Result<Vec<Expr>, InterpreterError> = items
+      .iter()
+      .map(|item| apply_interpreter(domain, std::slice::from_ref(item)))
+      .collect();
+    return Ok(Expr::List(results?.into()));
+  }
+
   // Scalar interpreter types: parse a string (or numeric input) into a typed
   // value, matching wolframscript. Unparseable inputs stay unevaluated (the
   // Failure object wolframscript returns is not reproduced here).

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11692,6 +11692,24 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // return the rendered result directly. Single-arg Show just passes through.
   if merged_primitives.is_empty() && !rendered_graphics.is_empty() {
     if rendered_graphics.len() == 1 {
+      // `Show[g, ImageSize -> …]` on a picture with no primitives to
+      // redraw (an imported SVG or PDF page) resizes the picture it has.
+      let image_size = merged_options.iter().find_map(|opt| {
+        option_name_value(opt)
+          .filter(|(name, _)| *name == "ImageSize")
+          .map(|(_, value)| value.into_owned())
+      });
+      if let (Some(size), Expr::Graphics { svg, .. }) =
+        (image_size, &rendered_graphics[0])
+        && let Some(resized) = svg_with_image_size(svg, &size)
+      {
+        let mut shown = rendered_graphics[0].clone();
+        if let Expr::Graphics { svg, .. } = &mut shown {
+          *svg = resized;
+        }
+        crate::capture_graphics(shown_svg(&shown));
+        return Ok(shown);
+      }
       return Ok(rendered_graphics[0].clone());
     }
     // More than one opaque pre-rendered graphic (e.g. `Show[{regionPlot,
@@ -14141,6 +14159,136 @@ fn parse_svg_numeric_attr(svg: &str, attr: &str) -> Option<f64> {
     .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
     .unwrap_or(raw.len());
   raw[..numeric_end].parse().ok()
+}
+
+/// The options a rendered graphic was drawn with: the ones of its symbolic
+/// `Graphics[prims, opts…]` form, or — for a picture that has no such form,
+/// like an imported page — its `ImageSize`, read off the rendering.
+pub fn graphics_options(expr: &Expr) -> Option<Vec<Expr>> {
+  let option_rules = |args: &[Expr]| -> Vec<Expr> {
+    splice_option_lists(args)
+      .iter()
+      .skip(1)
+      .filter(|a| matches!(a, Expr::Rule { .. } | Expr::RuleDelayed { .. }))
+      .cloned()
+      .collect()
+  };
+  // A `Graphics[…]` call that has not been rendered yet.
+  if let Expr::FunctionCall { name, args } = expr
+    && (name == "Graphics" || name == "Graphics3D")
+    && !args.is_empty()
+  {
+    let args: Vec<Expr> = args.iter().cloned().collect();
+    return Some(option_rules(&args));
+  }
+  let Expr::Graphics { svg, structure, .. } = expr else {
+    return None;
+  };
+  if let Some(structure) = structure
+    && let Expr::FunctionCall { name, args } = structure.as_ref()
+    && (name == "Graphics" || name == "Graphics3D")
+  {
+    let args: Vec<Expr> = args.iter().cloned().collect();
+    return Some(option_rules(&args));
+  }
+  let (w, h) = svg_natural_size(svg)?;
+  let size = |v: f64| {
+    if v.fract() == 0.0 {
+      Expr::Integer(v as i128)
+    } else {
+      Expr::Real(v)
+    }
+  };
+  Some(vec![Expr::Rule {
+    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    replacement: Box::new(Expr::List(vec![size(w), size(h)].into())),
+  }])
+}
+
+/// The SVG of a rendered graphic.
+fn shown_svg(expr: &Expr) -> &str {
+  match expr {
+    Expr::Graphics { svg, .. } => svg,
+    _ => "",
+  }
+}
+
+/// `svg` displayed at an `ImageSize`: the root element's width and height
+/// are replaced, and its picture scales into them through a viewBox (one
+/// made from the old size when it had none). A width alone keeps the
+/// picture's aspect ratio.
+pub(crate) fn svg_with_image_size(svg: &str, size: &Expr) -> Option<String> {
+  use std::fmt::Write;
+  let (nat_w, nat_h) = svg_natural_size(svg)?;
+  // The size may still be arithmetic (`ImageSize -> 2. {w, h}` scales a
+  // picture); evaluate it before reading it.
+  let evaluated = match size {
+    Expr::List(_) | Expr::Integer(_) | Expr::Real(_) | Expr::Identifier(_) => {
+      None
+    }
+    other => evaluate_expr_to_expr(other).ok(),
+  };
+  let size = evaluated.as_ref().unwrap_or(size);
+  // An explicit `{w, h}` keeps its exact values (an imported page is sized
+  // in fractional points); any other spec goes through the usual parsing.
+  let numeric = |e: &Expr| match e {
+    Expr::Integer(n) => Some(*n as f64),
+    Expr::Real(r) => Some(*r),
+    _ => None,
+  };
+  let explicit = match size {
+    Expr::List(items) if items.len() == 2 => {
+      match (numeric(&items[0]), numeric(&items[1])) {
+        (Some(w), Some(h)) if w > 0.0 && h > 0.0 => Some((w, h)),
+        _ => None,
+      }
+    }
+    _ => None,
+  };
+  let (w, h) = if let Some(size) = explicit {
+    size
+  } else {
+    let (w, h, _) = crate::functions::plot::parse_image_size(
+      size,
+      nat_w.round().max(1.0) as u32,
+      nat_h.round().max(1.0) as u32,
+    )?;
+    (f64::from(w), f64::from(h))
+  };
+  let header = svg_root_header(svg)?;
+  let header_start = svg.find("<svg")?;
+  let header_end = header_start + header.len();
+  let mut new_header = String::from("<svg");
+  let mut rest = header["<svg".len()..].to_string();
+  for attr in ["width", "height"] {
+    rest = remove_svg_attr(&rest, attr);
+  }
+  let _ = write!(new_header, " width=\"{w}\" height=\"{h}\"");
+  if find_svg_attr(header, "viewBox").is_none() {
+    let _ = write!(new_header, " viewBox=\"0 0 {nat_w} {nat_h}\"");
+  }
+  new_header.push_str(&rest);
+  Some(format!(
+    "{}{}{}",
+    &svg[..header_start],
+    new_header,
+    &svg[header_end..]
+  ))
+}
+
+/// `header` without its `attr="…"` (or single-quoted) attribute.
+fn remove_svg_attr(header: &str, attr: &str) -> String {
+  for quote in ['"', '\''] {
+    let needle = format!(" {attr}={quote}");
+    if let Some(start) = header.find(&needle) {
+      let value_start = start + needle.len();
+      if let Some(rel_end) = header[value_start..].find(quote) {
+        let end = value_start + rel_end + 1;
+        return format!("{}{}", &header[..start], &header[end..]);
+      }
+    }
+  }
+  header.to_string()
 }
 
 /// The natural display size of a rendered picture, in pixels. That is the

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -68,6 +68,8 @@ pub mod ode_ast;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod paclet;
 pub mod parametric_plot;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod pdf_import;
 pub mod periodic_table_plot;
 pub mod plot;
 pub mod plot3d;

--- a/src/functions/pdf_import.rs
+++ b/src/functions/pdf_import.rs
@@ -1,0 +1,1318 @@
+//! `Import` of PDF files.
+//!
+//! Every page's content stream is interpreted into an SVG picture that
+//! becomes a `Graphics`, the way wolframscript's `Import["file.pdf"]` gives
+//! one `Graphics` per page. The interpreter covers the vector part of the
+//! content model — paths, transforms, colours, clipping, transparency,
+//! form and image XObjects — and draws text through SVG text elements
+//! under the font family the PDF names, since embedded font programs are
+//! not rasterised here.
+
+use crate::InterpreterError;
+use crate::syntax::Expr;
+use lopdf::content::Content;
+use lopdf::{Dictionary, Document, Object, ObjectId};
+use std::collections::HashSet;
+use std::fmt::Write as _;
+
+/// The pages of the PDF at `path`, each as a `Graphics`.
+pub fn import_pages(path: &str) -> Result<Vec<Expr>, InterpreterError> {
+  let doc = load(path)?;
+  Ok(
+    page_svgs(&doc)
+      .into_iter()
+      .map(crate::graphics_result)
+      .collect(),
+  )
+}
+
+/// The number of pages in the PDF at `path`.
+pub fn page_count(path: &str) -> Result<usize, InterpreterError> {
+  Ok(load(path)?.get_pages().len())
+}
+
+/// The text of every page of the PDF at `path`, pages separated by a form
+/// feed the way wolframscript's `"Plaintext"` element separates them.
+pub fn plaintext(path: &str) -> Result<String, InterpreterError> {
+  let doc = load(path)?;
+  let pages: Vec<u32> = doc.get_pages().keys().copied().collect();
+  let mut out = String::new();
+  for (i, page) in pages.iter().enumerate() {
+    if i > 0 {
+      out.push('\u{c}');
+    }
+    let text = doc.extract_text(&[*page]).unwrap_or_default();
+    out.push_str(text.trim_end());
+  }
+  Ok(out)
+}
+
+/// The SVG rendering of every page of a PDF given as bytes.
+pub fn pages_svg_from_bytes(bytes: &[u8]) -> Result<Vec<String>, String> {
+  let doc = Document::load_mem(bytes).map_err(|e| e.to_string())?;
+  Ok(page_svgs(&doc))
+}
+
+fn load(path: &str) -> Result<Document, InterpreterError> {
+  Document::load(crate::vfs::resolve(path)).map_err(|e| {
+    InterpreterError::EvaluationError(format!(
+      "Import: cannot read \"{path}\" as PDF: {e}"
+    ))
+  })
+}
+
+fn page_svgs(doc: &Document) -> Vec<String> {
+  doc
+    .get_pages()
+    .values()
+    .map(|&page_id| render_page(doc, page_id))
+    .collect()
+}
+
+/// A 2-D affine matrix in PDF's `[a b c d e f]` layout.
+type Matrix = [f64; 6];
+
+const IDENTITY: Matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+/// `m × n`: apply `m` first, then `n` (PDF's convention for `cm`).
+fn mul(m: &Matrix, n: &Matrix) -> Matrix {
+  [
+    m[0] * n[0] + m[1] * n[2],
+    m[0] * n[1] + m[1] * n[3],
+    m[2] * n[0] + m[3] * n[2],
+    m[2] * n[1] + m[3] * n[3],
+    m[4] * n[0] + m[5] * n[2] + n[4],
+    m[4] * n[1] + m[5] * n[3] + n[5],
+  ]
+}
+
+fn apply(m: &Matrix, x: f64, y: f64) -> (f64, f64) {
+  (m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5])
+}
+
+/// The length scale of a matrix, for widths given in user space.
+fn scale_of(m: &Matrix) -> f64 {
+  (m[0] * m[3] - m[1] * m[2]).abs().sqrt()
+}
+
+fn fmt(v: f64) -> String {
+  if !v.is_finite() {
+    return "0".to_string();
+  }
+  let s = format!("{v:.3}");
+  let s = s.trim_end_matches('0').trim_end_matches('.');
+  if s.is_empty() || s == "-0" {
+    "0".to_string()
+  } else {
+    s.to_string()
+  }
+}
+
+fn matrix_attr(m: &Matrix) -> String {
+  format!(
+    "matrix({} {} {} {} {} {})",
+    fmt(m[0]),
+    fmt(m[1]),
+    fmt(m[2]),
+    fmt(m[3]),
+    fmt(m[4]),
+    fmt(m[5])
+  )
+}
+
+/// A colour as an SVG paint, from PDF components by their count.
+fn paint(components: &[f64]) -> String {
+  let clamp = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+  match components {
+    [g] => {
+      let g = clamp(*g);
+      format!("rgb({g},{g},{g})")
+    }
+    [r, g, b] => format!("rgb({},{},{})", clamp(*r), clamp(*g), clamp(*b)),
+    [c, m, y, k] => {
+      let ch = |v: f64| clamp((1.0 - v) * (1.0 - k));
+      format!("rgb({},{},{})", ch(*c), ch(*m), ch(*y))
+    }
+    _ => "rgb(0,0,0)".to_string(),
+  }
+}
+
+/// The font a text run is drawn with.
+#[derive(Clone)]
+struct Font {
+  family: String,
+  weight: &'static str,
+  style: &'static str,
+  /// Glyph advances by character code, in text-space units (1/1000 em),
+  /// where the PDF lists them.
+  first_char: u32,
+  widths: Vec<f64>,
+  /// A CID-keyed font takes two-byte codes.
+  two_byte: bool,
+  /// How its codes decode to text.
+  encoding: Option<Dictionary>,
+}
+
+#[derive(Clone)]
+struct State {
+  ctm: Matrix,
+  fill: String,
+  stroke: String,
+  fill_alpha: f64,
+  stroke_alpha: f64,
+  line_width: f64,
+  line_cap: u8,
+  line_join: u8,
+  dash: Vec<f64>,
+  clip: Option<usize>,
+  font: Option<Font>,
+  font_size: f64,
+  char_spacing: f64,
+  word_spacing: f64,
+  hscale: f64,
+  leading: f64,
+  rise: f64,
+  render_mode: i64,
+}
+
+impl State {
+  fn new(ctm: Matrix) -> Self {
+    Self {
+      ctm,
+      fill: "rgb(0,0,0)".to_string(),
+      stroke: "rgb(0,0,0)".to_string(),
+      fill_alpha: 1.0,
+      stroke_alpha: 1.0,
+      line_width: 1.0,
+      line_cap: 0,
+      line_join: 0,
+      dash: Vec::new(),
+      clip: None,
+      font: None,
+      font_size: 0.0,
+      char_spacing: 0.0,
+      word_spacing: 0.0,
+      hscale: 1.0,
+      leading: 0.0,
+      rise: 0.0,
+      render_mode: 0,
+    }
+  }
+}
+
+struct Renderer<'a> {
+  doc: &'a Document,
+  /// The picture, in PDF page coordinates (flipped by the outer group).
+  body: String,
+  defs: String,
+  clip_count: usize,
+  image_count: usize,
+  /// Form XObjects currently being drawn, so a form that refers to itself
+  /// does not recurse for ever.
+  active_forms: HashSet<ObjectId>,
+}
+
+/// The state that path construction carries between operators.
+struct PathBuilder {
+  d: String,
+  current: (f64, f64),
+  start: (f64, f64),
+  /// A `W`/`W*` seen since the last painting operator, with its rule.
+  pending_clip: Option<&'static str>,
+}
+
+impl PathBuilder {
+  fn new() -> Self {
+    Self {
+      d: String::new(),
+      current: (0.0, 0.0),
+      start: (0.0, 0.0),
+      pending_clip: None,
+    }
+  }
+}
+
+/// Text object state: the text matrix and the line matrix.
+struct TextState {
+  tm: Matrix,
+  tlm: Matrix,
+}
+
+fn number(obj: &Object) -> Option<f64> {
+  match obj {
+    Object::Integer(i) => Some(*i as f64),
+    Object::Real(r) => Some(f64::from(*r)),
+    _ => None,
+  }
+}
+
+fn numbers(objs: &[Object]) -> Vec<f64> {
+  objs.iter().filter_map(number).collect()
+}
+
+/// A page attribute, inherited from the page tree when the page itself
+/// does not carry it.
+fn inherited<'a>(
+  doc: &'a Document,
+  page: &'a Dictionary,
+  key: &[u8],
+) -> Option<&'a Object> {
+  let mut node = page;
+  for _ in 0..64 {
+    if let Ok(value) = node.get(key) {
+      return doc.dereference(value).ok().map(|(_, o)| o);
+    }
+    let parent = node.get(b"Parent").ok()?;
+    let (_, parent) = doc.dereference(parent).ok()?;
+    node = parent.as_dict().ok()?;
+  }
+  None
+}
+
+fn rect(obj: Option<&Object>) -> Option<[f64; 4]> {
+  let items = obj?.as_array().ok()?;
+  let v = numbers(items);
+  if v.len() == 4 {
+    Some([
+      v[0].min(v[2]),
+      v[1].min(v[3]),
+      v[0].max(v[2]),
+      v[1].max(v[3]),
+    ])
+  } else {
+    None
+  }
+}
+
+fn render_page(doc: &Document, page_id: ObjectId) -> String {
+  let Ok(page) = doc.get_dictionary(page_id) else {
+    return empty_svg(1.0, 1.0);
+  };
+  let media =
+    rect(inherited(doc, page, b"MediaBox")).unwrap_or([0.0, 0.0, 612.0, 792.0]);
+  // The visible part of the page is its CropBox, clipped to the MediaBox.
+  let bbox = rect(inherited(doc, page, b"CropBox")).map_or(media, |c| {
+    [
+      c[0].max(media[0]),
+      c[1].max(media[1]),
+      c[2].min(media[2]),
+      c[3].min(media[3]),
+    ]
+  });
+  let width = (bbox[2] - bbox[0]).max(1.0);
+  let height = (bbox[3] - bbox[1]).max(1.0);
+  let rotate = inherited(doc, page, b"Rotate")
+    .and_then(number)
+    .map_or(0, |r| ((r as i64).rem_euclid(360) / 90) * 90);
+
+  let resources = inherited(doc, page, b"Resources")
+    .and_then(|r| r.as_dict().ok())
+    .cloned()
+    .unwrap_or_default();
+  let content = doc.get_page_content(page_id);
+
+  let mut renderer = Renderer {
+    doc,
+    body: String::new(),
+    defs: String::new(),
+    clip_count: 0,
+    image_count: 0,
+    active_forms: HashSet::new(),
+  };
+  renderer.run(&content, &resources, State::new(IDENTITY));
+
+  // Page space is y-up; the outer group flips it and moves the box's
+  // corner to the origin. A /Rotate turns the finished page.
+  let (out_w, out_h, turn) = match rotate {
+    90 => (
+      height,
+      width,
+      format!("translate({} 0) rotate(90) ", fmt(height)),
+    ),
+    180 => (
+      width,
+      height,
+      format!("translate({} {}) rotate(180) ", fmt(width), fmt(height)),
+    ),
+    270 => (
+      height,
+      width,
+      format!("translate(0 {}) rotate(270) ", fmt(width)),
+    ),
+    _ => (width, height, String::new()),
+  };
+  let flip = format!("matrix(1 0 0 -1 {} {})", fmt(-bbox[0]), fmt(bbox[3]));
+  let mut svg = String::new();
+  let _ = writeln!(
+    svg,
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\">",
+    fmt(out_w),
+    fmt(out_h),
+    fmt(out_w),
+    fmt(out_h)
+  );
+  if !renderer.defs.is_empty() {
+    let _ = write!(svg, "<defs>\n{}</defs>\n", renderer.defs);
+  }
+  let _ = write!(
+    svg,
+    "<g transform=\"{turn}{flip}\">\n{}</g>\n</svg>\n",
+    renderer.body
+  );
+  svg
+}
+
+fn empty_svg(w: f64, h: f64) -> String {
+  format!(
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\"></svg>\n",
+    fmt(w),
+    fmt(h),
+    fmt(w),
+    fmt(h)
+  )
+}
+
+impl Renderer<'_> {
+  /// A named entry of a resource category (`/XObject`, `/Font`, …),
+  /// dereferenced.
+  fn resource(
+    &self,
+    resources: &Dictionary,
+    category: &[u8],
+    name: &[u8],
+  ) -> Option<Object> {
+    let cat = resources.get(category).ok()?;
+    let (_, cat) = self.doc.dereference(cat).ok()?;
+    let entry = cat.as_dict().ok()?.get(name).ok()?;
+    let (_, entry) = self.doc.dereference(entry).ok()?;
+    Some(entry.clone())
+  }
+
+  /// The number of components a colour space takes.
+  fn colour_components(&self, resources: &Dictionary, space: &Object) -> usize {
+    match space {
+      Object::Name(n) => match n.as_slice() {
+        b"DeviceGray" | b"G" | b"CalGray" => 1,
+        b"DeviceRGB" | b"RGB" | b"CalRGB" | b"Lab" => 3,
+        b"DeviceCMYK" | b"CMYK" => 4,
+        b"Pattern" => 0,
+        other => self
+          .resource(resources, b"ColorSpace", other)
+          .map_or(3, |cs| self.colour_components(resources, &cs)),
+      },
+      Object::Array(items) => {
+        let family = items.first().and_then(|o| o.as_name().ok());
+        match family {
+          Some(b"ICCBased") => items
+            .get(1)
+            .and_then(|s| self.doc.dereference(s).ok())
+            .and_then(|(_, s)| s.as_stream().ok())
+            .and_then(|s| s.dict.get(b"N").ok())
+            .and_then(number)
+            .map_or(3, |n| n as usize),
+          Some(b"CalRGB" | b"Lab") => 3,
+          Some(b"CalGray" | b"Separation" | b"Indexed") => 1,
+          Some(b"DeviceN") => items
+            .get(1)
+            .and_then(|n| n.as_array().ok())
+            .map_or(1, Vec::len),
+          Some(b"Pattern") => 0,
+          Some(b"DeviceGray") => 1,
+          Some(b"DeviceCMYK") => 4,
+          _ => 3,
+        }
+      }
+      _ => 3,
+    }
+  }
+
+  /// Colour components as a paint, where a one-component value of a
+  /// `Separation`/`Indexed` space is read as ink coverage.
+  fn paint_for(components: &[f64], separation: bool) -> String {
+    if separation && components.len() == 1 {
+      return paint(&[1.0 - components[0]]);
+    }
+    paint(components)
+  }
+
+  fn clip_attr(state: &State) -> String {
+    state
+      .clip
+      .map_or_else(String::new, |id| format!(" clip-path=\"url(#clip{id})\""))
+  }
+
+  /// Emit the current path with the given painting, and turn it into a
+  /// clip when a `W` is pending.
+  fn paint_path(
+    &mut self,
+    pb: &mut PathBuilder,
+    state: &mut State,
+    fill: bool,
+    even_odd: bool,
+    stroke: bool,
+  ) {
+    let d = std::mem::take(&mut pb.d);
+    if !d.is_empty() && (fill || stroke) {
+      let mut attrs = String::new();
+      if fill {
+        let _ = write!(attrs, " fill=\"{}\"", state.fill);
+        if even_odd {
+          attrs.push_str(" fill-rule=\"evenodd\"");
+        }
+        if state.fill_alpha < 1.0 {
+          let _ = write!(attrs, " fill-opacity=\"{}\"", fmt(state.fill_alpha));
+        }
+      } else {
+        attrs.push_str(" fill=\"none\"");
+      }
+      if stroke {
+        // Width 0 asks for the thinnest line the device draws.
+        let width = state.line_width * scale_of(&state.ctm);
+        let width = if width <= 0.0 { 0.3 } else { width };
+        let _ = write!(
+          attrs,
+          " stroke=\"{}\" stroke-width=\"{}\"",
+          state.stroke,
+          fmt(width)
+        );
+        if state.stroke_alpha < 1.0 {
+          let _ =
+            write!(attrs, " stroke-opacity=\"{}\"", fmt(state.stroke_alpha));
+        }
+        match state.line_cap {
+          1 => attrs.push_str(" stroke-linecap=\"round\""),
+          2 => attrs.push_str(" stroke-linecap=\"square\""),
+          _ => {}
+        }
+        match state.line_join {
+          1 => attrs.push_str(" stroke-linejoin=\"round\""),
+          2 => attrs.push_str(" stroke-linejoin=\"bevel\""),
+          _ => {}
+        }
+        if !state.dash.is_empty() && state.dash.iter().any(|d| *d > 0.0) {
+          let scale = scale_of(&state.ctm);
+          let dashes: Vec<String> =
+            state.dash.iter().map(|d| fmt(d * scale)).collect();
+          let _ = write!(attrs, " stroke-dasharray=\"{}\"", dashes.join(" "));
+        }
+      }
+      let _ = writeln!(
+        self.body,
+        "<path d=\"{d}\"{attrs}{}/>",
+        Self::clip_attr(state)
+      );
+    }
+    if let Some(rule) = pb.pending_clip.take() {
+      self.clip_count += 1;
+      let id = self.clip_count;
+      let parent = Self::clip_attr(state);
+      let rule_attr = if rule == "evenodd" {
+        " clip-rule=\"evenodd\""
+      } else {
+        ""
+      };
+      // An empty clip path clips everything away, as it does in PDF.
+      let _ = writeln!(
+        self.defs,
+        "<clipPath id=\"clip{id}\"{parent}><path d=\"{d}\"{rule_attr}/></clipPath>"
+      );
+      state.clip = Some(id);
+    }
+  }
+
+  fn run(&mut self, content: &[u8], resources: &Dictionary, initial: State) {
+    let Ok(content) = Content::decode(content) else {
+      return;
+    };
+    let mut state = initial;
+    let mut stack: Vec<State> = Vec::new();
+    let mut pb = PathBuilder::new();
+    let mut text = TextState {
+      tm: IDENTITY,
+      tlm: IDENTITY,
+    };
+    // Whether the current fill/stroke colour space reads one component as
+    // ink coverage rather than gray.
+    let mut fill_sep = false;
+    let mut stroke_sep = false;
+    let mut fill_n = 1usize;
+    let mut stroke_n = 1usize;
+
+    for op in &content.operations {
+      let o = op.operands.as_slice();
+      match op.operator.as_str() {
+        // Graphics state
+        "q" => stack.push(state.clone()),
+        "Q" => {
+          if let Some(s) = stack.pop() {
+            state = s;
+          }
+        }
+        "cm" => {
+          let v = numbers(o);
+          if v.len() == 6 {
+            state.ctm = mul(&[v[0], v[1], v[2], v[3], v[4], v[5]], &state.ctm);
+          }
+        }
+        "w" => {
+          if let Some(w) = o.first().and_then(number) {
+            state.line_width = w;
+          }
+        }
+        "J" => {
+          if let Some(c) = o.first().and_then(number) {
+            state.line_cap = c as u8;
+          }
+        }
+        "j" => {
+          if let Some(j) = o.first().and_then(number) {
+            state.line_join = j as u8;
+          }
+        }
+        "d" => {
+          state.dash = o
+            .first()
+            .and_then(|a| a.as_array().ok())
+            .map(|a| numbers(a))
+            .unwrap_or_default();
+        }
+        "gs" => {
+          if let Some(name) = o.first().and_then(|n| n.as_name().ok())
+            && let Some(Object::Dictionary(gs)) =
+              self.resource(resources, b"ExtGState", name)
+          {
+            if let Some(a) = gs.get(b"CA").ok().and_then(number) {
+              state.stroke_alpha = a;
+            }
+            if let Some(a) = gs.get(b"ca").ok().and_then(number) {
+              state.fill_alpha = a;
+            }
+            if let Some(w) = gs.get(b"LW").ok().and_then(number) {
+              state.line_width = w;
+            }
+            if let Ok(Object::Array(d)) = gs.get(b"D")
+              && let Some(Object::Array(dashes)) = d.first()
+            {
+              state.dash = numbers(dashes);
+            }
+          }
+        }
+
+        // Colour
+        "g" | "G" => {
+          let v = numbers(o);
+          if v.len() == 1 {
+            let p = paint(&v);
+            if op.operator == "g" {
+              state.fill = p;
+              fill_sep = false;
+              fill_n = 1;
+            } else {
+              state.stroke = p;
+              stroke_sep = false;
+              stroke_n = 1;
+            }
+          }
+        }
+        "rg" | "RG" => {
+          let v = numbers(o);
+          if v.len() == 3 {
+            let p = paint(&v);
+            if op.operator == "rg" {
+              state.fill = p;
+              fill_sep = false;
+              fill_n = 3;
+            } else {
+              state.stroke = p;
+              stroke_sep = false;
+              stroke_n = 3;
+            }
+          }
+        }
+        "k" | "K" => {
+          let v = numbers(o);
+          if v.len() == 4 {
+            let p = paint(&v);
+            if op.operator == "k" {
+              state.fill = p;
+              fill_sep = false;
+              fill_n = 4;
+            } else {
+              state.stroke = p;
+              stroke_sep = false;
+              stroke_n = 4;
+            }
+          }
+        }
+        "cs" | "CS" => {
+          if let Some(space) = o.first() {
+            let n = self.colour_components(resources, space);
+            let sep = match space {
+              Object::Name(name) => self
+                .resource(resources, b"ColorSpace", name)
+                .is_some_and(|cs| {
+                  matches!(
+                    cs.as_array()
+                      .ok()
+                      .and_then(|a| a.first())
+                      .and_then(|f| f.as_name().ok()),
+                    Some(b"Separation" | b"Indexed" | b"DeviceN")
+                  )
+                }),
+              _ => false,
+            };
+            // A new colour space starts out black.
+            let black = paint(&vec![0.0; n.max(1)]);
+            if op.operator == "cs" {
+              fill_n = n;
+              fill_sep = sep;
+              state.fill = if sep { paint(&[1.0]) } else { black };
+            } else {
+              stroke_n = n;
+              stroke_sep = sep;
+              state.stroke = if sep { paint(&[1.0]) } else { black };
+            }
+          }
+        }
+        "sc" | "scn" | "SC" | "SCN" => {
+          let v = numbers(o);
+          // A pattern paint (`/P1 scn`) has no components; it draws as
+          // mid-gray so the shape it fills still shows.
+          let is_fill = op.operator.starts_with('s');
+          let (n, sep) = if is_fill {
+            (fill_n, fill_sep)
+          } else {
+            (stroke_n, stroke_sep)
+          };
+          let p = if v.is_empty() {
+            "rgb(128,128,128)".to_string()
+          } else if v.len() == n || n == 0 {
+            Self::paint_for(&v, sep)
+          } else {
+            paint(&v)
+          };
+          if is_fill {
+            state.fill = p;
+          } else {
+            state.stroke = p;
+          }
+        }
+
+        // Path construction — points go straight to page space.
+        "m" => {
+          let v = numbers(o);
+          if v.len() == 2 {
+            let p = apply(&state.ctm, v[0], v[1]);
+            let _ = write!(pb.d, "M{} {}", fmt(p.0), fmt(p.1));
+            pb.current = p;
+            pb.start = p;
+          }
+        }
+        "l" => {
+          let v = numbers(o);
+          if v.len() == 2 {
+            let p = apply(&state.ctm, v[0], v[1]);
+            let _ = write!(pb.d, "L{} {}", fmt(p.0), fmt(p.1));
+            pb.current = p;
+          }
+        }
+        "c" => {
+          let v = numbers(o);
+          if v.len() == 6 {
+            let p1 = apply(&state.ctm, v[0], v[1]);
+            let p2 = apply(&state.ctm, v[2], v[3]);
+            let p3 = apply(&state.ctm, v[4], v[5]);
+            let _ = write!(
+              pb.d,
+              "C{} {} {} {} {} {}",
+              fmt(p1.0),
+              fmt(p1.1),
+              fmt(p2.0),
+              fmt(p2.1),
+              fmt(p3.0),
+              fmt(p3.1)
+            );
+            pb.current = p3;
+          }
+        }
+        "v" => {
+          let v = numbers(o);
+          if v.len() == 4 {
+            let p1 = pb.current;
+            let p2 = apply(&state.ctm, v[0], v[1]);
+            let p3 = apply(&state.ctm, v[2], v[3]);
+            let _ = write!(
+              pb.d,
+              "C{} {} {} {} {} {}",
+              fmt(p1.0),
+              fmt(p1.1),
+              fmt(p2.0),
+              fmt(p2.1),
+              fmt(p3.0),
+              fmt(p3.1)
+            );
+            pb.current = p3;
+          }
+        }
+        "y" => {
+          let v = numbers(o);
+          if v.len() == 4 {
+            let p1 = apply(&state.ctm, v[0], v[1]);
+            let p3 = apply(&state.ctm, v[2], v[3]);
+            let _ = write!(
+              pb.d,
+              "C{} {} {} {} {} {}",
+              fmt(p1.0),
+              fmt(p1.1),
+              fmt(p3.0),
+              fmt(p3.1),
+              fmt(p3.0),
+              fmt(p3.1)
+            );
+            pb.current = p3;
+          }
+        }
+        "h" => {
+          if !pb.d.is_empty() {
+            pb.d.push('Z');
+            pb.current = pb.start;
+          }
+        }
+        "re" => {
+          let v = numbers(o);
+          if v.len() == 4 {
+            let corners = [
+              apply(&state.ctm, v[0], v[1]),
+              apply(&state.ctm, v[0] + v[2], v[1]),
+              apply(&state.ctm, v[0] + v[2], v[1] + v[3]),
+              apply(&state.ctm, v[0], v[1] + v[3]),
+            ];
+            let _ = write!(
+              pb.d,
+              "M{} {}L{} {}L{} {}L{} {}Z",
+              fmt(corners[0].0),
+              fmt(corners[0].1),
+              fmt(corners[1].0),
+              fmt(corners[1].1),
+              fmt(corners[2].0),
+              fmt(corners[2].1),
+              fmt(corners[3].0),
+              fmt(corners[3].1)
+            );
+            pb.current = corners[0];
+            pb.start = corners[0];
+          }
+        }
+
+        // Path painting
+        "S" => self.paint_path(&mut pb, &mut state, false, false, true),
+        "s" => {
+          if !pb.d.is_empty() {
+            pb.d.push('Z');
+          }
+          self.paint_path(&mut pb, &mut state, false, false, true);
+        }
+        "f" | "F" => self.paint_path(&mut pb, &mut state, true, false, false),
+        "f*" => self.paint_path(&mut pb, &mut state, true, true, false),
+        "B" => self.paint_path(&mut pb, &mut state, true, false, true),
+        "B*" => self.paint_path(&mut pb, &mut state, true, true, true),
+        "b" => {
+          if !pb.d.is_empty() {
+            pb.d.push('Z');
+          }
+          self.paint_path(&mut pb, &mut state, true, false, true);
+        }
+        "b*" => {
+          if !pb.d.is_empty() {
+            pb.d.push('Z');
+          }
+          self.paint_path(&mut pb, &mut state, true, true, true);
+        }
+        "n" => self.paint_path(&mut pb, &mut state, false, false, false),
+        "W" => pb.pending_clip = Some("nonzero"),
+        "W*" => pb.pending_clip = Some("evenodd"),
+
+        // XObjects
+        "Do" => {
+          if let Some(name) = o.first().and_then(|n| n.as_name().ok()) {
+            self.draw_xobject(resources, name, &state);
+          }
+        }
+
+        // Text
+        "BT" => {
+          text.tm = IDENTITY;
+          text.tlm = IDENTITY;
+        }
+        "ET" => {}
+        "Tc" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.char_spacing = v;
+          }
+        }
+        "Tw" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.word_spacing = v;
+          }
+        }
+        "Tz" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.hscale = v / 100.0;
+          }
+        }
+        "TL" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.leading = v;
+          }
+        }
+        "Ts" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.rise = v;
+          }
+        }
+        "Tr" => {
+          if let Some(v) = o.first().and_then(number) {
+            state.render_mode = v as i64;
+          }
+        }
+        "Tf" => {
+          if let Some(name) = o.first().and_then(|n| n.as_name().ok()) {
+            state.font = self.font(resources, name);
+          }
+          if let Some(size) = o.get(1).and_then(number) {
+            state.font_size = size;
+          }
+        }
+        "Td" => {
+          let v = numbers(o);
+          if v.len() == 2 {
+            text.tlm = mul(&[1.0, 0.0, 0.0, 1.0, v[0], v[1]], &text.tlm);
+            text.tm = text.tlm;
+          }
+        }
+        "TD" => {
+          let v = numbers(o);
+          if v.len() == 2 {
+            state.leading = -v[1];
+            text.tlm = mul(&[1.0, 0.0, 0.0, 1.0, v[0], v[1]], &text.tlm);
+            text.tm = text.tlm;
+          }
+        }
+        "Tm" => {
+          let v = numbers(o);
+          if v.len() == 6 {
+            text.tlm = [v[0], v[1], v[2], v[3], v[4], v[5]];
+            text.tm = text.tlm;
+          }
+        }
+        "T*" => {
+          text.tlm = mul(&[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading], &text.tlm);
+          text.tm = text.tlm;
+        }
+        "Tj" => {
+          if let Some(Object::String(bytes, _)) = o.first() {
+            self.show_text(bytes, &state, &mut text);
+          }
+        }
+        "'" => {
+          text.tlm = mul(&[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading], &text.tlm);
+          text.tm = text.tlm;
+          if let Some(Object::String(bytes, _)) = o.first() {
+            self.show_text(bytes, &state, &mut text);
+          }
+        }
+        "\"" => {
+          if let Some(aw) = o.first().and_then(number) {
+            state.word_spacing = aw;
+          }
+          if let Some(ac) = o.get(1).and_then(number) {
+            state.char_spacing = ac;
+          }
+          text.tlm = mul(&[1.0, 0.0, 0.0, 1.0, 0.0, -state.leading], &text.tlm);
+          text.tm = text.tlm;
+          if let Some(Object::String(bytes, _)) = o.get(2) {
+            self.show_text(bytes, &state, &mut text);
+          }
+        }
+        "TJ" => {
+          if let Some(Object::Array(items)) = o.first() {
+            for item in items {
+              match item {
+                Object::String(bytes, _) => {
+                  self.show_text(bytes, &state, &mut text);
+                }
+                other => {
+                  if let Some(adj) = number(other) {
+                    let tx = -adj / 1000.0 * state.font_size * state.hscale;
+                    text.tm = mul(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &text.tm);
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // Shadings, inline images, marked content, type 3 glyph metrics
+        // and compatibility sections draw nothing here.
+        _ => {}
+      }
+    }
+  }
+
+  /// The font resource `name` names, with what is needed to place its text.
+  fn font(&self, resources: &Dictionary, name: &[u8]) -> Option<Font> {
+    let Object::Dictionary(dict) = self.resource(resources, b"Font", name)?
+    else {
+      return None;
+    };
+    let subtype = dict
+      .get(b"Subtype")
+      .ok()
+      .and_then(|s| s.as_name().ok())
+      .unwrap_or(b"");
+    let two_byte = subtype == b"Type0";
+    let base = dict
+      .get(b"BaseFont")
+      .ok()
+      .and_then(|b| b.as_name().ok())
+      .map(|b| String::from_utf8_lossy(b).into_owned())
+      .unwrap_or_default();
+    // `ABCDEF+Times-BoldItalic` → family `Times`, bold, italic.
+    let name = base.split_once('+').map_or(base.as_str(), |(_, n)| n);
+    let lower = name.to_ascii_lowercase();
+    let weight = if lower.contains("bold")
+      || lower.contains("black")
+      || lower.contains("heavy")
+    {
+      "bold"
+    } else {
+      "normal"
+    };
+    let style = if lower.contains("italic") || lower.contains("oblique") {
+      "italic"
+    } else {
+      "normal"
+    };
+    let stem = name.split(['-', ',']).next().unwrap_or(name).to_string();
+    let family = if lower.starts_with("times")
+      || lower.contains("serif") && !lower.contains("sans")
+    {
+      "'Times New Roman', Times, serif".to_string()
+    } else if lower.starts_with("courier") || lower.contains("mono") {
+      "'Courier New', Courier, monospace".to_string()
+    } else if lower.starts_with("helvetica") || lower.starts_with("arial") {
+      "Helvetica, Arial, sans-serif".to_string()
+    } else if lower.starts_with("symbol") {
+      "Symbol".to_string()
+    } else {
+      format!("'{stem}', sans-serif")
+    };
+
+    // Simple fonts list their glyph widths; a CID font's come from its
+    // descendant's W array, which is read as a default here.
+    let first_char = dict
+      .get(b"FirstChar")
+      .ok()
+      .and_then(number)
+      .map_or(0, |n| n as u32);
+    let widths = dict
+      .get(b"Widths")
+      .ok()
+      .and_then(|w| self.doc.dereference(w).ok())
+      .and_then(|(_, w)| w.as_array().ok())
+      .map(|w| {
+        w.iter()
+          .map(|x| {
+            self
+              .doc
+              .dereference(x)
+              .ok()
+              .and_then(|(_, x)| number(x))
+              .unwrap_or(0.0)
+          })
+          .collect()
+      })
+      .unwrap_or_default();
+    Some(Font {
+      family,
+      weight,
+      style,
+      first_char,
+      widths,
+      two_byte,
+      encoding: Some(dict),
+    })
+  }
+
+  /// Draw a string at the text matrix and advance it.
+  fn show_text(&mut self, bytes: &[u8], state: &State, text: &mut TextState) {
+    let Some(font) = &state.font else {
+      return;
+    };
+    let fs = state.font_size;
+    // Decode the codes to text through the font's encoding; a font whose
+    // encoding cannot be resolved shows its bytes as Latin-1.
+    let decoded = font
+      .encoding
+      .as_ref()
+      .and_then(|dict| dict.get_font_encoding(self.doc).ok())
+      .and_then(|enc| enc.bytes_to_string(bytes).ok())
+      .unwrap_or_else(|| bytes.iter().map(|&b| b as char).collect());
+
+    // Where the run starts, in page space. The glyphs are drawn in SVG's
+    // y-down text space, so the text matrix takes a flip.
+    let trm = mul(
+      &[fs * state.hscale, 0.0, 0.0, fs, 0.0, state.rise],
+      &mul(&text.tm, &state.ctm),
+    );
+    let placed = mul(&[1.0, 0.0, 0.0, -1.0, 0.0, 0.0], &trm);
+    if state.render_mode != 3
+      && state.render_mode != 7
+      && !decoded.trim().is_empty()
+    {
+      let fill = if state.render_mode == 1 || state.render_mode == 5 {
+        "none".to_string()
+      } else {
+        state.fill.clone()
+      };
+      let mut attrs = format!(
+        " font-family=\"{}\" font-size=\"1\" fill=\"{}\"",
+        font.family, fill
+      );
+      if font.weight != "normal" {
+        let _ = write!(attrs, " font-weight=\"{}\"", font.weight);
+      }
+      if font.style != "normal" {
+        let _ = write!(attrs, " font-style=\"{}\"", font.style);
+      }
+      if state.fill_alpha < 1.0 {
+        let _ = write!(attrs, " fill-opacity=\"{}\"", fmt(state.fill_alpha));
+      }
+      if matches!(state.render_mode, 1 | 2 | 5 | 6) {
+        let _ = write!(
+          attrs,
+          " stroke=\"{}\" stroke-width=\"{}\"",
+          state.stroke,
+          fmt(state.line_width / fs.max(1e-6))
+        );
+      }
+      let escaped = decoded
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+      let _ = writeln!(
+        self.body,
+        "<text transform=\"{}\"{attrs} xml:space=\"preserve\"{}>{escaped}</text>",
+        matrix_attr(&placed),
+        Self::clip_attr(state)
+      );
+    }
+
+    // Advance: each glyph's width, plus character and word spacing.
+    let mut tx = 0.0;
+    let codes: Vec<u32> = if font.two_byte {
+      bytes
+        .chunks(2)
+        .map(|c| (u32::from(c[0]) << 8) | u32::from(*c.get(1).unwrap_or(&0)))
+        .collect()
+    } else {
+      bytes.iter().map(|&b| u32::from(b)).collect()
+    };
+    for code in codes {
+      let w = code
+        .checked_sub(font.first_char)
+        .and_then(|i| font.widths.get(i as usize))
+        .copied()
+        .unwrap_or(if font.two_byte { 1000.0 } else { 500.0 });
+      let mut advance = w / 1000.0 * fs + state.char_spacing;
+      if code == 32 && !font.two_byte {
+        advance += state.word_spacing;
+      }
+      tx += advance * state.hscale;
+    }
+    text.tm = mul(&[1.0, 0.0, 0.0, 1.0, tx, 0.0], &text.tm);
+  }
+
+  /// Draw a form or image XObject at the current transform.
+  fn draw_xobject(
+    &mut self,
+    resources: &Dictionary,
+    name: &[u8],
+    state: &State,
+  ) {
+    let Some(entry) = resources
+      .get(b"XObject")
+      .ok()
+      .and_then(|x| self.doc.dereference(x).ok())
+      .and_then(|(_, x)| x.as_dict().ok())
+      .and_then(|x| x.get(name).ok())
+    else {
+      return;
+    };
+    let id = entry.as_reference().ok();
+    let Ok((_, obj)) = self.doc.dereference(entry) else {
+      return;
+    };
+    let Ok(stream) = obj.as_stream() else {
+      return;
+    };
+    let subtype = stream
+      .dict
+      .get(b"Subtype")
+      .ok()
+      .and_then(|s| s.as_name().ok())
+      .unwrap_or(b"");
+    match subtype {
+      b"Form" => {
+        if let Some(id) = id {
+          if self.active_forms.contains(&id) || self.active_forms.len() > 32 {
+            return;
+          }
+          self.active_forms.insert(id);
+        }
+        let mut inner = state.clone();
+        if let Ok(Object::Array(m)) = stream.dict.get(b"Matrix") {
+          let v = numbers(m);
+          if v.len() == 6 {
+            inner.ctm = mul(&[v[0], v[1], v[2], v[3], v[4], v[5]], &inner.ctm);
+          }
+        }
+        // The form is clipped to its bounding box.
+        if let Some(b) = rect(stream.dict.get(b"BBox").ok()) {
+          let corners = [
+            apply(&inner.ctm, b[0], b[1]),
+            apply(&inner.ctm, b[2], b[1]),
+            apply(&inner.ctm, b[2], b[3]),
+            apply(&inner.ctm, b[0], b[3]),
+          ];
+          self.clip_count += 1;
+          let clip_id = self.clip_count;
+          let parent = Self::clip_attr(&inner);
+          let _ = writeln!(
+            self.defs,
+            "<clipPath id=\"clip{clip_id}\"{parent}><path d=\"M{} {}L{} {}L{} {}L{} {}Z\"/></clipPath>",
+            fmt(corners[0].0),
+            fmt(corners[0].1),
+            fmt(corners[1].0),
+            fmt(corners[1].1),
+            fmt(corners[2].0),
+            fmt(corners[2].1),
+            fmt(corners[3].0),
+            fmt(corners[3].1)
+          );
+          inner.clip = Some(clip_id);
+        }
+        let own_resources = stream
+          .dict
+          .get(b"Resources")
+          .ok()
+          .and_then(|r| self.doc.dereference(r).ok())
+          .and_then(|(_, r)| r.as_dict().ok())
+          .cloned();
+        let content = stream
+          .decompressed_content()
+          .unwrap_or_else(|_| stream.content.clone());
+        self.run(&content, own_resources.as_ref().unwrap_or(resources), inner);
+        if let Some(id) = id {
+          self.active_forms.remove(&id);
+        }
+      }
+      b"Image" => {
+        if let Some(href) = image_data_uri(stream) {
+          self.image_count += 1;
+          // The image fills the unit square of user space, its first row
+          // at the top (y = 1).
+          let placed = mul(&[1.0, 0.0, 0.0, -1.0, 0.0, 1.0], &state.ctm);
+          let mut attrs = String::new();
+          if state.fill_alpha < 1.0 {
+            let _ = write!(attrs, " opacity=\"{}\"", fmt(state.fill_alpha));
+          }
+          let _ = writeln!(
+            self.body,
+            "<image x=\"0\" y=\"0\" width=\"1\" height=\"1\" preserveAspectRatio=\"none\" transform=\"{}\"{attrs}{} xlink:href=\"{href}\"/>",
+            matrix_attr(&placed),
+            Self::clip_attr(state)
+          );
+        }
+      }
+      _ => {}
+    }
+  }
+}
+
+/// An image XObject's pixels as a data URI: JPEG data passes through, and
+/// 8-bit gray/RGB samples are packed into a PNG. Other encodings (JPX,
+/// CCITT, JBIG2, deep or indexed samples) are not decoded.
+fn image_data_uri(stream: &lopdf::Stream) -> Option<String> {
+  use base64::Engine as _;
+  let filters = stream.filters().unwrap_or_default();
+  let width = stream.dict.get(b"Width").ok().and_then(number)? as u32;
+  let height = stream.dict.get(b"Height").ok().and_then(number)? as u32;
+  if filters.iter().any(|f| *f == b"DCTDecode") {
+    let encoded =
+      base64::engine::general_purpose::STANDARD.encode(&stream.content);
+    return Some(format!("data:image/jpeg;base64,{encoded}"));
+  }
+  let bpc = stream
+    .dict
+    .get(b"BitsPerComponent")
+    .ok()
+    .and_then(number)
+    .unwrap_or(8.0) as u32;
+  if bpc != 8 {
+    return None;
+  }
+  let data = stream.decompressed_content().ok()?;
+  let space = stream
+    .dict
+    .get(b"ColorSpace")
+    .ok()
+    .and_then(|c| c.as_name().ok())
+    .unwrap_or(b"DeviceRGB");
+  let mut png = Vec::new();
+  let cursor = &mut std::io::Cursor::new(&mut png);
+  match space {
+    b"DeviceGray" | b"CalGray" | b"G" => {
+      let img = image::GrayImage::from_raw(width, height, data)?;
+      img.write_to(cursor, image::ImageFormat::Png).ok()?;
+    }
+    b"DeviceRGB" | b"CalRGB" | b"RGB" => {
+      let img = image::RgbImage::from_raw(width, height, data)?;
+      img.write_to(cursor, image::ImageFormat::Png).ok()?;
+    }
+    _ => return None,
+  }
+  let encoded = base64::engine::general_purpose::STANDARD.encode(&png);
+  Some(format!("data:image/png;base64,{encoded}"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn matrices_compose_in_pdf_order() {
+    let scale = [2.0, 0.0, 0.0, 2.0, 0.0, 0.0];
+    let shift = [1.0, 0.0, 0.0, 1.0, 5.0, 7.0];
+    // Scale first, then shift.
+    let m = mul(&scale, &shift);
+    assert_eq!(apply(&m, 1.0, 1.0), (7.0, 9.0));
+    // Shift first, then scale.
+    let m = mul(&shift, &scale);
+    assert_eq!(apply(&m, 1.0, 1.0), (12.0, 16.0));
+  }
+
+  #[test]
+  fn paints_by_component_count() {
+    assert_eq!(paint(&[1.0]), "rgb(255,255,255)");
+    assert_eq!(paint(&[1.0, 0.0, 0.0]), "rgb(255,0,0)");
+    assert_eq!(paint(&[0.0, 0.0, 0.0, 1.0]), "rgb(0,0,0)");
+  }
+
+  #[test]
+  fn numbers_format_compactly() {
+    assert_eq!(fmt(1.0), "1");
+    assert_eq!(fmt(-0.0004), "0");
+    assert_eq!(fmt(12.3456), "12.346");
+  }
+}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2795,7 +2795,13 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       // has to be decided at read time by the context resolver (which maps
       // it back to the plain `x` that Woxi stores a Global symbol under).
       let s = pair.as_str();
-      let name = s.strip_prefix('`').unwrap_or(s).to_string();
+      // A leading backtick followed by a sub-context (`` `Info`$Version ``)
+      // stays relative: it names a symbol in a sub-context of `$Context`,
+      // and only the context resolver knows which context that is.
+      let name = match s.strip_prefix('`') {
+        Some(rest) if !rest.contains('`') => rest.to_string(),
+        _ => s.to_string(),
+      };
       // Expand any embedded `\[Name]` segments to their Unicode chars so
       // `Z\[Infinity]` becomes the single identifier `Z∞`, matching
       // wolframscript's identifier-character semantics.

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1114,6 +1114,7 @@
     - [`RayleighDistribution`](functions/RayleighDistribution.md)
     - [`Return`](functions/Return.md)
     - [`Run`](functions/Run.md)
+    - [`RunProcess`](functions/RunProcess.md)
     - [`StudentTDistribution`](functions/StudentTDistribution.md)
     - [`SubtractFrom`](functions/SubtractFrom.md)
     - [`Switch`](functions/Switch.md)

--- a/tests/cli/functions.md
+++ b/tests/cli/functions.md
@@ -74,6 +74,7 @@ icon: lucide/square-function
 - [`RayleighDistribution`](functions/RayleighDistribution.md)
 - [`Return`](functions/Return.md)
 - [`Run`](functions/Run.md)
+- [`RunProcess`](functions/RunProcess.md)
 - [`StudentTDistribution`](functions/StudentTDistribution.md)
 - [`SubtractFrom`](functions/SubtractFrom.md)
 - [`Switch`](functions/Switch.md)

--- a/tests/cli/functions/RunProcess.md
+++ b/tests/cli/functions/RunProcess.md
@@ -1,0 +1,55 @@
+# `RunProcess`
+
+Runs a program to completion and reports its exit code and output.
+A string names the program; a list gives the program and its arguments.
+The program is started directly, not through a shell.
+
+```scrut
+$ wo 'RunProcess[{"echo", "hello"}]'
+<|ExitCode -> 0, StandardOutput -> hello
+, StandardError -> |>
+```
+
+A property name picks one of the results:
+
+```scrut
+$ wo 'RunProcess[{"sh", "-c", "exit 3"}, "ExitCode"]'
+3
+```
+
+```scrut
+$ wo 'RunProcess[{"sh", "-c", "echo oops >&2"}, "StandardError"]'
+oops
+
+```
+
+A third argument is fed to the program's standard input:
+
+```scrut
+$ wo 'RunProcess[{"tr", "a-z", "A-Z"}, "StandardOutput", "shout"]'
+SHOUT
+```
+
+`ProcessDirectory` runs the program in a directory, and `ProcessEnvironment`
+gives it its environment variables:
+
+```scrut
+$ wo 'RunProcess[{"sh", "-c", "pwd"}, "StandardOutput", ProcessDirectory -> "/"]'
+/
+
+```
+
+```scrut
+$ wo 'RunProcess[{"sh", "-c", "echo $GREETING"}, "StandardOutput", ProcessEnvironment -> <|"GREETING" -> "hi"|>]'
+hi
+
+```
+
+A program that cannot be found gives `$Failed`:
+
+```scrut
+$ wo 'RunProcess["no-such-program-anywhere"]'
+
+RunProcess::pnfd: Program no-such-program-anywhere not found. Check the path and file permissions.
+$Failed
+```

--- a/tests/interpreter_tests/association.rs
+++ b/tests/interpreter_tests/association.rs
@@ -2341,3 +2341,58 @@ mod association_lookup_chains {
     );
   }
 }
+
+mod lookup_with_list_keys {
+  use super::*;
+
+  // A key that is itself a list is one key: `Lookup[assoc, {key1, key2}]`
+  // looks each of them up once and does not thread into them.
+  #[test]
+  fn list_valued_keys_are_looked_up_whole() {
+    assert_eq!(
+      interpret("Lookup[<|{1, 2} -> x, 3 -> y|>, {{1, 2}, 3}]").unwrap(),
+      "{x, y}"
+    );
+    assert_eq!(
+      interpret("Lookup[<|{1, 2} -> x|>, {1, 2}]").unwrap(),
+      "{Missing[KeyAbsent, 1], Missing[KeyAbsent, 2]}"
+    );
+    assert_eq!(
+      interpret("Lookup[<|{1, 2} -> x|>, {{1, 2}, {3}}, 0]").unwrap(),
+      "{x, 0}"
+    );
+  }
+}
+
+mod append_to_association {
+  use super::*;
+
+  #[test]
+  fn append_to_adds_an_entry() {
+    clear_state();
+    assert_eq!(
+      interpret("ata = <|\"a\" -> 1|>; AppendTo[ata, \"b\" -> 2]; ata")
+        .unwrap(),
+      "<|a -> 1, b -> 2|>"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("atb = <|\"a\" -> 1|>; PrependTo[atb, \"b\" -> 2]; atb")
+        .unwrap(),
+      "<|b -> 2, a -> 1|>"
+    );
+  }
+
+  #[test]
+  fn append_to_inside_a_scanned_pure_function() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "atc = <|\"a\" -> 1|>; \
+         Scan[If[True, AppendTo[atc, #]]&, {\"b\" -> 2, \"c\" -> 3}]; atc"
+      )
+      .unwrap(),
+      "<|a -> 1, b -> 2, c -> 3|>"
+    );
+  }
+}

--- a/tests/interpreter_tests/contexts.rs
+++ b/tests/interpreter_tests/contexts.rs
@@ -565,3 +565,38 @@ mod head_patterns_in_a_package {
     );
   }
 }
+
+mod relative_sub_contexts {
+  use super::*;
+
+  // `` `Info`$Version `` inside a package names a symbol in a sub-context
+  // of the package (MaTeX declares its version this way); a short name
+  // that is a system variable does not make it the system variable.
+  #[test]
+  fn relative_name_with_sub_context_resolves_under_the_package() {
+    clear_state();
+    interpret(
+      "BeginPackage[\"RelCtx`\"]\n`Info`$Version = \"1.0\"\n`Info`build = 7\nEndPackage[]\n",
+    )
+    .unwrap();
+    assert_eq!(interpret("RelCtx`Info`$Version").unwrap(), "1.0");
+    assert_eq!(interpret("RelCtx`Info`build").unwrap(), "7");
+    assert_eq!(interpret("Names[\"RelCtx`*\"]").unwrap(), "{}");
+    assert_eq!(
+      interpret("MemberQ[Names[\"RelCtx`Info`*\"], \"RelCtx`Info`$Version\"]")
+        .unwrap(),
+      "True"
+    );
+    assert_eq!(interpret("Length[Names[\"RelCtx`Info`*\"]]").unwrap(), "2");
+  }
+
+  #[test]
+  fn relative_name_outside_a_package_lives_under_global() {
+    clear_state();
+    assert_eq!(interpret("Context[`relA`relB]").unwrap(), "Global`relA`");
+    assert_eq!(
+      interpret("`relA`relB === Global`relA`relB").unwrap(),
+      "True"
+    );
+  }
+}

--- a/tests/interpreter_tests/control_flow.rs
+++ b/tests/interpreter_tests/control_flow.rs
@@ -4486,3 +4486,29 @@ mod return_propagation {
     );
   }
 }
+
+mod compound_assignment_on_a_list {
+  use super::*;
+
+  // `{w, h} *= k` is `{w, h} = {w, h} k`: every target is updated.
+  #[test]
+  fn times_by_on_a_list_of_symbols() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "{cw, ch, cd} = {{1.5}, {2}, {3}}; {cw, ch, cd} *= 2; {cw, ch, cd}"
+      )
+      .unwrap(),
+      "{{3.}, {4}, {6}}"
+    );
+  }
+
+  #[test]
+  fn add_to_on_a_list_of_symbols() {
+    clear_state();
+    assert_eq!(
+      interpret("{ca, cb} = {1, 2}; {ca, cb} += 10; {ca, cb}").unwrap(),
+      "{11, 12}"
+    );
+  }
+}

--- a/tests/interpreter_tests/entity.rs
+++ b/tests/interpreter_tests/entity.rs
@@ -492,3 +492,16 @@ mod interpreter_scalar_tests {
     assert_eq!(interpret(r#"Interpreter["Integer"][42]"#).unwrap(), "42");
   }
 }
+
+mod interpreter_over_lists {
+  use super::*;
+
+  #[test]
+  fn number_interpreter_threads_over_a_list() {
+    assert_eq!(
+      interpret("Interpreter[\"Number\"][{\"12.5\", \"3\"}]").unwrap(),
+      "{12.5, 3}"
+    );
+    assert_eq!(interpret("Interpreter[\"Number\"][{}]").unwrap(), "{}");
+  }
+}

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -5259,3 +5259,149 @@ mod a_guard_inside_a_scoping_construct_keeps_the_definition {
     );
   }
 }
+
+mod sequence_pattern_slots {
+  use super::*;
+
+  // A named sequence body (`r : _Rule..`) claims as many arguments as its
+  // run takes — MaTeX's `ConfigureMaTeX[rules : (_Rule | _RuleDelayed)...]`
+  // relies on it. Outputs verified against wolframscript.
+  #[test]
+  fn named_repeated_takes_the_whole_run() {
+    clear_state();
+    assert_eq!(
+      interpret("sq1[r:_Rule..] := {r}; {sq1[a->1], sq1[a->1, b->2], sq1[]}")
+        .unwrap(),
+      "{{a -> 1}, {a -> 1, b -> 2}, sq1[]}"
+    );
+  }
+
+  #[test]
+  fn named_repeated_null_admits_no_arguments() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "sq2[rules : (_Rule|_RuleDelayed)...] := {rules}; \
+         {sq2[], sq2[a->1], sq2[a->1, b:>2], sq2[1]}"
+      )
+      .unwrap(),
+      "{{}, {a -> 1}, {a -> 1, b :> 2}, sq2[1]}"
+    );
+  }
+
+  #[test]
+  fn sequence_slot_between_single_slots() {
+    clear_state();
+    assert_eq!(
+      interpret("sq3[x_, r:_Rule.., y_] := {x, {r}, y}; sq3[1, a->1, b->2, 3]")
+        .unwrap(),
+      "{1, {a -> 1, b -> 2}, 3}"
+    );
+  }
+
+  #[test]
+  fn named_pattern_sequence() {
+    clear_state();
+    assert_eq!(
+      interpret("sq4[r:PatternSequence[_,_]] := {r}; {sq4[1,2], sq4[1]}")
+        .unwrap(),
+      "{{1, 2}, sq4[1]}"
+    );
+  }
+
+  // The immediate assignment keeps the constraint too.
+  #[test]
+  fn set_keeps_a_sequence_body() {
+    clear_state();
+    assert_eq!(
+      interpret("sq5[r:_Rule..] = 7; {sq5[a->1, b->2], sq5[1]}").unwrap(),
+      "{7, sq5[1]}"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("sq6[r:Except[_Integer]] = 7; {sq6[1], sq6[a]}").unwrap(),
+      "{sq6[1], 7}"
+    );
+  }
+}
+
+mod constrained_trailing_sequence_in_list_pattern {
+  use super::*;
+
+  // `{__String}` only takes a list of strings; previously the trailing
+  // sequence's head was never checked, so `{x}` matched too.
+  #[test]
+  fn head_of_trailing_sequence_is_enforced() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "ts1[tex:{__String}] := 1; ts1[tex_List] := 2; \
+         {ts1[{\"a\"}], ts1[{x}], ts1[{}], ts1[{\"a\", 1}], ts1[{\"a\", \"b\"}]}"
+      )
+      .unwrap(),
+      "{1, 2, 2, 2, 1}"
+    );
+    clear_state();
+    assert_eq!(
+      interpret(
+        "ts2[{x_, r__Integer}] := {x, r}; {ts2[{1, 2, 3}], ts2[{1, a}]}"
+      )
+      .unwrap(),
+      "{{1, 2, 3}, ts2[{1, a}]}"
+    );
+  }
+
+  #[test]
+  fn test_of_trailing_sequence_is_enforced() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "ts3[{r___?StringQ}] := {r}; {ts3[{\"a\"}], ts3[{}], ts3[{1}]}"
+      )
+      .unwrap(),
+      "{{a}, {}, ts3[{1}]}"
+    );
+  }
+}
+
+mod delayed_own_values {
+  use super::*;
+
+  // `line := lines[[i]]` reads the part afresh on every access.
+  #[test]
+  fn part_body_is_reevaluated() {
+    clear_state();
+    assert_eq!(interpret("dl = {1, 2}; dp := dl[[1]]; dp").unwrap(), "1");
+    assert_eq!(interpret("dl = {5}; dp").unwrap(), "5");
+  }
+
+  #[test]
+  fn part_body_inside_module() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "Module[{lines = {\"a\", \"b\"}, i = 1, line}, \
+         line := lines[[i]]; {line, StringMatchQ[line, \"a\"]}]"
+      )
+      .unwrap(),
+      "{a, True}"
+    );
+  }
+
+  // The memoization idiom `tpl := tpl = expr` used as a head: the head is
+  // evaluated (which computes and stores the value) before being applied.
+  #[test]
+  fn memoized_head_is_evaluated_before_application() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "tpl := tpl = StringTemplate[\"a `x`\"]; \
+         {tpl[<|\"x\" -> 1|>], tpl[<|\"x\" -> 2|>]}"
+      )
+      .unwrap(),
+      "{a 1, a 2}"
+    );
+    clear_state();
+    assert_eq!(interpret("dh := dh = df[]; dh[3]").unwrap(), "df[][3]");
+  }
+}

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -28185,3 +28185,68 @@ fn test_highlight_graph_draws_the_highlighted_parts_red() {
   .unwrap();
   assert_eq!(subgraph, "3");
 }
+
+mod options_of_a_graphic {
+  use super::*;
+
+  // `Options[g, opt]` reads the options a graphic was drawn with.
+  #[test]
+  fn options_of_a_graphics_expression() {
+    assert_eq!(
+      interpret("Options[Graphics[{Disk[]}, ImageSize -> 20], ImageSize]")
+        .unwrap(),
+      "{ImageSize -> 20}"
+    );
+    assert_eq!(
+      interpret("Options[Graphics[{Disk[]}], ImageSize]").unwrap(),
+      "{}"
+    );
+    assert_eq!(
+      interpret("Options[Graphics[{Disk[]}, ImageSize -> 20, Axes -> True]]")
+        .unwrap(),
+      "{ImageSize -> 20, Axes -> True}"
+    );
+  }
+
+  #[test]
+  fn options_of_a_shown_graphic() {
+    assert_eq!(
+      interpret(
+        "Options[Show[Graphics[{Disk[]}], ImageSize -> {30, 15}], ImageSize]"
+      )
+      .unwrap(),
+      "{ImageSize -> {30, 15}}"
+    );
+  }
+
+  // A picture with no primitives to redraw (an imported SVG) is resized
+  // by `Show[…, ImageSize -> …]`.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn show_resizes_an_imported_svg() {
+    let dir = std::env::temp_dir()
+      .join(format!("woxi_show_resize_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("box.svg");
+    std::fs::write(
+      &path,
+      r#"<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20"><rect width="40" height="20" fill="red"/></svg>"#,
+    )
+    .unwrap();
+    let p = path.display().to_string().replace('\\', "/");
+    assert_eq!(
+      interpret(&format!(
+        r#"Options[Show[Import["{p}"], ImageSize -> {{30, 15}}], ImageSize]"#
+      ))
+      .unwrap(),
+      "{ImageSize -> {30, 15}}"
+    );
+    let svg = interpret(&format!(
+      r#"ExportString[Show[Import["{p}"], ImageSize -> {{30, 15}}], "SVG"]"#
+    ))
+    .unwrap();
+    assert!(svg.contains(r#"width="30" height="15""#), "{svg}");
+    assert!(svg.contains(r#"viewBox="0 0 40 20""#), "{svg}");
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+}

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -10740,3 +10740,285 @@ mod import_named_format {
     std::fs::remove_file(path).ok();
   }
 }
+
+mod import_options {
+  use super::*;
+
+  // Options such as CharacterEncoding ride along after the element.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn text_import_accepts_character_encoding() {
+    let dir = std::env::temp_dir()
+      .join(format!("woxi_import_options_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("greeting.txt");
+    std::fs::write(&path, "héllo\n").unwrap();
+    let p = unixify(&path.display().to_string());
+    assert_eq!(
+      interpret(&format!(
+        r#"Import["{p}", "Text", CharacterEncoding -> "UTF-8"]"#
+      ))
+      .unwrap(),
+      "héllo"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+}
+
+mod run_process {
+  use super::*;
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn reports_exit_code_and_both_streams() {
+    let result = interpret(
+      r#"ToString[RunProcess[{"sh", "-c", "printf out; printf err >&2; exit 3"}], InputForm]"#,
+    )
+    .unwrap();
+    assert_eq!(
+      result,
+      r#"<|"ExitCode" -> 3, "StandardOutput" -> "out", "StandardError" -> "err"|>"#
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn a_property_picks_one_result() {
+    assert_eq!(
+      interpret(
+        r#"RunProcess[{"sh", "-c", "printf hello"}, "StandardOutput"]"#
+      )
+      .unwrap(),
+      "hello"
+    );
+    assert_eq!(
+      interpret(r#"RunProcess[{"sh", "-c", "exit 4"}, "ExitCode"]"#).unwrap(),
+      "4"
+    );
+    assert_eq!(
+      interpret(r#"Keys[RunProcess[{"true"}, All]]"#).unwrap(),
+      "{ExitCode, StandardOutput, StandardError}"
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn input_is_fed_to_standard_input() {
+    assert_eq!(
+      interpret(r#"RunProcess[{"cat"}, "StandardOutput", "fed input"]"#)
+        .unwrap(),
+      "fed input"
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn process_directory_and_environment_options() {
+    assert_eq!(
+      interpret(
+        r#"StringTrim@RunProcess[{"sh", "-c", "pwd"}, "StandardOutput", ProcessDirectory -> "/"]"#
+      )
+      .unwrap(),
+      "/"
+    );
+    assert_eq!(
+      interpret(
+        r#"StringTrim@RunProcess[{"sh", "-c", "echo $WOXI_RP"}, "StandardOutput", ProcessEnvironment -> <|"WOXI_RP" -> "bar"|>]"#
+      )
+      .unwrap(),
+      "bar"
+    );
+    assert_eq!(
+      interpret(
+        r#"StringTrim@RunProcess[{"sh", "-c", "echo $WOXI_RP"}, "StandardOutput", ProcessEnvironment -> {"WOXI_RP" -> "baz"}]"#
+      )
+      .unwrap(),
+      "baz"
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn a_missing_program_or_bad_property_fails() {
+    let result =
+      interpret_with_stdout(r#"RunProcess["woxi-no-such-program"]"#).unwrap();
+    assert_eq!(result.result, "$Failed");
+    assert!(
+      result
+        .warnings
+        .iter()
+        .any(|w| w.contains("RunProcess::pnfd"))
+    );
+    let result =
+      interpret_with_stdout(r#"RunProcess[{"true"}, "Bogus"]"#).unwrap();
+    assert_eq!(result.result, "$Failed");
+    assert!(
+      result
+        .warnings
+        .iter()
+        .any(|w| w.contains("RunProcess::pbad"))
+    );
+  }
+}
+
+mod import_pdf {
+  use super::*;
+
+  /// A one-page PDF drawn from `content`, with the given page resources.
+  #[cfg(not(target_arch = "wasm32"))]
+  fn pdf_bytes(content: &str, resources: &str) -> Vec<u8> {
+    let objects = [
+      "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+      "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+      format!(
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 50 40] /Contents 4 0 R {resources} >>"
+      ),
+      format!(
+        "<< /Length {} >>\nstream\n{content}\nendstream",
+        content.len()
+      ),
+    ];
+    let mut out = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::new();
+    for (i, object) in objects.iter().enumerate() {
+      offsets.push(out.len());
+      out.extend_from_slice(
+        format!("{} 0 obj\n{object}\nendobj\n", i + 1).as_bytes(),
+      );
+    }
+    let xref = out.len();
+    out.extend_from_slice(
+      format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1)
+        .as_bytes(),
+    );
+    for offset in offsets {
+      out.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+      format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+        objects.len() + 1
+      )
+      .as_bytes(),
+    );
+    out
+  }
+
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_pdf(name: &str, content: &str, resources: &str) -> String {
+    let dir = std::env::temp_dir()
+      .join(format!("woxi_import_pdf_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, pdf_bytes(content, resources)).unwrap();
+    unixify(&path.display().to_string())
+  }
+
+  const SHAPES: &str = "1 0 0 rg 10 10 30 20 re f 0 0 1 RG 2 w 5 5 m 45 35 l S";
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn pages_import_as_graphics_of_the_page_size() {
+    let p = write_pdf("shapes.pdf", SHAPES, "");
+    assert_eq!(
+      interpret(&format!(
+        r#"pg = Import["{p}"]; {{Head[pg], Length[pg], Head[First[pg]], Options[First[pg], ImageSize]}}"#
+      ))
+      .unwrap(),
+      "{List, 1, Graphics, {ImageSize -> {50, 40}}}"
+    );
+    assert_eq!(
+      interpret(&format!(r#"Import["{p}", "PageCount"]"#)).unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret(&format!(r#"Import["{p}", {{"PDF", "Pages", 1}}]"#)).unwrap(),
+      "-Graphics-"
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn vector_content_becomes_paths() {
+    let p = write_pdf("paths.pdf", SHAPES, "");
+    let svg = interpret(&format!(
+      r#"ExportString[First@Import["{p}", "Pages"], "SVG"]"#
+    ))
+    .unwrap();
+    assert!(svg.contains(r#"width="50" height="40""#), "{svg}");
+    assert!(
+      svg.contains(
+        r#"<path d="M10 10L40 10L40 30L10 30Z" fill="rgb(255,0,0)"/>"#
+      ),
+      "{svg}"
+    );
+    assert!(
+      svg.contains(
+        r#"<path d="M5 5L45 35" fill="none" stroke="rgb(0,0,255)" stroke-width="2"/>"#
+      ),
+      "{svg}"
+    );
+    // PDF's y axis points up; the page group flips it.
+    assert!(svg.contains(r#"matrix(1 0 0 -1 0 40)"#), "{svg}");
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn text_is_drawn_and_extracted() {
+    let p = write_pdf(
+      "text.pdf",
+      "BT /F1 12 Tf 10 20 Td (Hi there) Tj ET",
+      "/Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> >> >>",
+    );
+    let svg =
+      interpret(&format!(r#"ExportString[First@Import["{p}"], "SVG"]"#))
+        .unwrap();
+    assert!(svg.contains("<text "), "{svg}");
+    assert!(svg.contains(">Hi there</text>"), "{svg}");
+    assert!(svg.contains("Helvetica"), "{svg}");
+    assert!(svg.contains(r#"font-weight="bold""#), "{svg}");
+    assert_eq!(
+      interpret(&format!(r#"Import["{p}", "Plaintext"]"#)).unwrap(),
+      "Hi there"
+    );
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn show_resizes_an_imported_page() {
+    let p = write_pdf("resize.pdf", SHAPES, "");
+    assert_eq!(
+      interpret(&format!(
+        r#"Options[Show[First@Import["{p}"], ImageSize -> {{25, 20}}, BaselinePosition -> Scaled[0.3]], ImageSize]"#
+      ))
+      .unwrap(),
+      "{ImageSize -> {25, 20}}"
+    );
+    let svg = interpret(&format!(
+      r#"ExportString[Show[First@Import["{p}"], ImageSize -> {{25, 20}}], "SVG"]"#
+    ))
+    .unwrap();
+    assert!(svg.contains(r#"width="25" height="20""#), "{svg}");
+    assert!(svg.contains(r#"viewBox="0 0 50 40""#), "{svg}");
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn missing_elements_and_pages_fail() {
+    let p = write_pdf("elements.pdf", SHAPES, "");
+    let result = interpret_with_stdout(&format!(
+      r#"Import["{p}", {{"PDF", "Pages", 2}}]"#
+    ))
+    .unwrap();
+    assert_eq!(result.result, "$Failed");
+    assert!(result.warnings.iter().any(|w| w.contains("Import::noelem")));
+    let result =
+      interpret_with_stdout(&format!(r#"Import["{p}", "Bogus"]"#)).unwrap();
+    assert_eq!(result.result, "$Failed");
+    assert!(result.warnings.iter().any(|w| w.contains("Import::noelem")));
+    assert_eq!(
+      interpret(&format!(r#"Import["{p}", "Elements"]"#)).unwrap(),
+      "{PageCount, Pages, Plaintext}"
+    );
+  }
+}

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -5490,3 +5490,36 @@ mod free_q_sees_operator_forms {
     );
   }
 }
+
+mod standalone_sequence_patterns {
+  use super::*;
+
+  // A sequence pattern on its own matches an expression as a one-element
+  // sequence, the way wolframscript does.
+  #[test]
+  fn repeated_matches_a_single_expression() {
+    assert_eq!(interpret("MatchQ[a -> 1, _Rule..]").unwrap(), "True");
+    assert_eq!(interpret("MatchQ[a -> 1, r:(_Rule)..]").unwrap(), "True");
+    assert_eq!(interpret("MatchQ[1, RepeatedNull[_]]").unwrap(), "True");
+    assert_eq!(interpret("MatchQ[{1, 2}, _List..]").unwrap(), "True");
+    assert_eq!(interpret("MatchQ[a, _Rule..]").unwrap(), "False");
+    assert_eq!(interpret("MatchQ[1, Repeated[_, {2}]]").unwrap(), "False");
+  }
+
+  #[test]
+  fn pattern_sequence_needs_its_element_count() {
+    assert_eq!(interpret("MatchQ[1, PatternSequence[_]]").unwrap(), "True");
+    assert_eq!(
+      interpret("MatchQ[1, PatternSequence[_, _]]").unwrap(),
+      "False"
+    );
+  }
+
+  #[test]
+  fn cases_with_a_repeated_pattern() {
+    assert_eq!(
+      interpret("Cases[{a -> 1, 2, b :> 3}, _Rule..]").unwrap(),
+      "{a -> 1}"
+    );
+  }
+}


### PR DESCRIPTION
This PR adds two major features to Woxi:

## PDF Import Support

Implements `Import` for PDF files, converting each page's content stream into an SVG graphic. The implementation:

- Adds a new `pdf_import` module that interprets PDF content streams into SVG, covering vector graphics (paths, transforms, colours, clipping, transparency, form and image XObjects)
- Renders text through SVG text elements using PDF-named font families
- Supports multiple import elements: `"Pages"` (default), `"PageCount"`, `"Plaintext"`, and `"Elements"`
- Handles page rotation via the `/Rotate` attribute
- Properly manages graphics state (line width, dash patterns, fill/stroke colors, alpha transparency)
- Includes comprehensive path construction and clipping support

The PDF parsing uses the `lopdf` crate for document loading and stream decompression.

## RunProcess Function

Implements `RunProcess[cmd, (property, (input,)) opts…]` to execute external programs:

- Accepts a program name as a string or a list of `{program, arg1, arg2, …}`
- Returns an association with `ExitCode`, `StandardOutput`, and `StandardError`
- Supports property selection to return just one result
- Accepts optional standard input as a third argument
- Supports `ProcessDirectory` and `ProcessEnvironment` options
- Properly handles missing programs and invalid properties with appropriate error messages

## Supporting Changes

- Enhanced `Show` to resize imported graphics via `ImageSize` option
- Added `graphics_options` function to extract options from rendered graphics
- Fixed pattern matching for sequence patterns (`Repeated`, `RepeatedNull`, `PatternSequence`) to work as standalone patterns
- Fixed compound assignment operators (`*=`, `+=`, etc.) to work on lists of targets
- Improved `Lookup` to handle list-valued keys correctly
- Added support for relative sub-contexts in package symbols
- Enhanced `Options` function to work with rendered graphics
- Fixed `needs_reevaluation` to properly handle `Part`, `Comparison`, and `Rule` expressions
- Added `Interpreter` support for threading over lists

All changes include comprehensive test coverage following the project's testing conventions.

https://claude.ai/code/session_01Ft1MfZmwGrC4kzX1FznEJa