### PR TITLE
Introduce const_expr helper.

### DIFF
--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1044,7 +1044,7 @@ fn laplace_unit_step(arg: &Expr, t: &str, s: &Expr) -> Option<Expr> {
   // Exp[-t0*s] / s.
   Some(make_times(vec![
     make_power(
-      Expr::Constant("E".to_string()),
+      const_expr("E"),
       make_times(vec![Expr::Integer(-1), t0, s.clone()]),
     ),
     inv_s,
@@ -1717,10 +1717,7 @@ fn inverse_laplace_2d(
     };
     let cosh_arg = call("Times", vec![Expr::Integer(2), call1("Sqrt", neg_xy)]);
     let cosh = call1("Cosh", cosh_arg);
-    let pi_sqrt_xy = call(
-      "Times",
-      vec![Expr::Constant("Pi".to_string()), sqrt_x(), sqrt_y()],
-    );
+    let pi_sqrt_xy = call("Times", vec![const_expr("Pi"), sqrt_x(), sqrt_y()]);
     return Some(div2(cosh, pi_sqrt_xy));
   }
 
@@ -1855,10 +1852,7 @@ fn inverse_laplace_inner(expr: &Expr, s: &str, t: &str) -> Option<Expr> {
             ]
             .into(),
           };
-          return Some(call(
-            "Power",
-            vec![Expr::Constant("E".to_string()), exponent],
-          ));
+          return Some(call("Power", vec![const_expr("E"), exponent]));
         }
       }
     }
@@ -2123,10 +2117,7 @@ fn inverse_laplace_exact_term(term: &Expr, s: &str, t: &str) -> Option<Expr> {
         ),
         call(
           "Power",
-          vec![
-            Expr::Constant("E".to_string()),
-            call("Times", vec![root, t_id.clone()]),
-          ],
+          vec![const_expr("E"), call("Times", vec![root, t_id.clone()])],
         ),
       ];
       if k > 1 {
@@ -2202,13 +2193,7 @@ fn inverse_laplace_exact_term(term: &Expr, s: &str, t: &str) -> Option<Expr> {
         vec![
           coeff,
           inv_c2,
-          call(
-            "Power",
-            vec![
-              Expr::Constant("E".to_string()),
-              call("Times", vec![a, t_id]),
-            ],
-          ),
+          call("Power", vec![const_expr("E"), call("Times", vec![a, t_id])]),
           oscillation,
         ],
       ))
@@ -2334,7 +2319,7 @@ fn inverse_laplace_partial_fractions(
     .map(|k| den_coeffs[k] * k as f64)
     .collect();
 
-  let e_const = || Expr::Constant("E".to_string());
+  let e_const = || const_expr("E");
   let t_id = || Expr::Identifier(t.to_string());
 
   let mut terms: Vec<Expr> = quotient
@@ -3111,10 +3096,10 @@ fn inverse_mellin_inner(
     {
       let result = Expr::BinaryOp {
         op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
+        left: Box::new(const_expr("Pi")),
         right: Box::new(make_plus(vec![
-          Expr::Constant("Pi".to_string()),
-          make_times(vec![Expr::Constant("Pi".to_string()), x.clone()]),
+          const_expr("Pi"),
+          make_times(vec![const_expr("Pi"), x.clone()]),
         ])),
       };
       return Some((result, false));
@@ -3836,7 +3821,7 @@ fn fourier_lorentzian(expr: &Expr, var: &str, out: &Expr) -> Option<Expr> {
   }
   let (p, q) = match_inv_quadratic(args[0], var)?;
   let sqrt_pi_2 = make_sqrt(make_times(vec![
-    Expr::Constant("Pi".to_string()),
+    const_expr("Pi"),
     make_power(Expr::Integer(2), Expr::Integer(-1)),
   ]));
   let inv_sqrt_pq = make_power(
@@ -3845,7 +3830,7 @@ fn fourier_lorentzian(expr: &Expr, var: &str, out: &Expr) -> Option<Expr> {
   );
   let b = make_sqrt(make_times(vec![p, make_power(q, Expr::Integer(-1))]));
   let exp_part = make_power(
-    Expr::Constant("E".to_string()),
+    const_expr("E"),
     make_times(vec![Expr::Integer(-1), b, call1("Abs", out.clone())]),
   );
   Some(make_times(vec![sqrt_pi_2, inv_sqrt_pq, exp_part]))
@@ -3861,10 +3846,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
   if !depends_on(expr, t) {
     return Some(make_times(vec![
       expr.clone(),
-      make_sqrt(make_times(vec![
-        Expr::Integer(2),
-        Expr::Constant("Pi".to_string()),
-      ])),
+      make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")])),
       make_dirac_delta(w.clone()),
     ]));
   }
@@ -3878,7 +3860,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
       && v == t
     {
       return Some(make_power(
-        make_times(vec![Expr::Integer(2), Expr::Constant("Pi".to_string())]),
+        make_times(vec![Expr::Integer(2), const_expr("Pi")]),
         call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
       ));
     }
@@ -3888,15 +3870,15 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
       // F = E^(i*(-neg_a)*w) / Sqrt[2*Pi]
       return Some(make_times(vec![
         make_power(
-          Expr::Constant("E".to_string()),
+          const_expr("E"),
           make_times(vec![
-            Expr::Constant("I".to_string()),
+            const_expr("I"),
             make_times(vec![Expr::Integer(-1), neg_a]),
             w.clone(),
           ]),
         ),
         make_power(
-          make_times(vec![Expr::Integer(2), Expr::Constant("Pi".to_string())]),
+          make_times(vec![Expr::Integer(2), const_expr("Pi")]),
           call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
         ),
       ]));
@@ -3955,7 +3937,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
         let k = av / 2;
         let sqrt_two_over_pi = make_sqrt(make_times(vec![
           Expr::Integer(2),
-          make_power(Expr::Constant("Pi".to_string()), Expr::Integer(-1)),
+          make_power(const_expr("Pi"), Expr::Integer(-1)),
         ]));
         if k == 1 {
           sqrt_two_over_pi
@@ -3964,10 +3946,8 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
         }
       } else {
         // av/Sqrt[2π]
-        let sqrt_2pi = make_sqrt(make_times(vec![
-          Expr::Integer(2),
-          Expr::Constant("Pi".to_string()),
-        ]));
+        let sqrt_2pi =
+          make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")]));
         let inv_sqrt = make_power(sqrt_2pi, Expr::Integer(-1));
         if av == 1 {
           inv_sqrt
@@ -3993,10 +3973,8 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
         ])
       };
       let sinc = call1("Sinc", arg);
-      let sqrt_2pi = make_sqrt(make_times(vec![
-        Expr::Integer(2),
-        Expr::Constant("Pi".to_string()),
-      ]));
+      let sqrt_2pi =
+        make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")]));
       let inv_sqrt = make_power(sqrt_2pi, Expr::Integer(-1));
       let prefactor = if c_val == 1 {
         inv_sqrt
@@ -4020,7 +3998,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
           // F[E^(-a*t^2)] = E^(-w^2/(4a)) / Sqrt[2a]
           return Some(make_times(vec![
             make_power(
-              Expr::Constant("E".to_string()),
+              const_expr("E"),
               make_times(vec![
                 Expr::Integer(-1),
                 make_power(w.clone(), Expr::Integer(2)),
@@ -4041,7 +4019,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
           return Some(make_times(vec![
             make_sqrt(make_times(vec![
               Expr::Integer(2),
-              make_power(Expr::Constant("Pi".to_string()), Expr::Integer(-1)),
+              make_power(const_expr("Pi"), Expr::Integer(-1)),
             ])),
             a.clone(),
             make_power(
@@ -4063,9 +4041,9 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
       && let Some(a) = extract_linear_coeff(fargs[0], t)
     {
       let coeff = make_times(vec![
-        Expr::Constant("I".to_string()),
+        const_expr("I"),
         make_sqrt(make_times(vec![
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           make_power(Expr::Integer(2), Expr::Integer(-1)),
         ])),
       ]);
@@ -4091,7 +4069,7 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
       && let Some(a) = extract_linear_coeff(fargs[0], t)
     {
       let coeff = make_sqrt(make_times(vec![
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         make_power(Expr::Integer(2), Expr::Integer(-1)),
       ]));
       return Some(make_plus(vec![
@@ -4118,11 +4096,11 @@ fn fourier_transform_inner(expr: &Expr, t: &str, w: &Expr) -> Option<Expr> {
       && matches!(fargs[1], Expr::Integer(-1))
     {
       return Some(make_times(vec![
-        Expr::Constant("I".to_string()),
-        Expr::Constant("Pi".to_string()),
+        const_expr("I"),
+        const_expr("Pi"),
         call1("Sign", w.clone()),
         make_power(
-          make_times(vec![Expr::Integer(2), Expr::Constant("Pi".to_string())]),
+          make_times(vec![Expr::Integer(2), const_expr("Pi")]),
           call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
         ),
       ]));
@@ -4306,10 +4284,7 @@ fn inverse_fourier_inner(expr: &Expr, w: &str, t: &Expr) -> Option<Expr> {
   if !depends_on(expr, w) {
     return Some(make_times(vec![
       expr.clone(),
-      make_sqrt(make_times(vec![
-        Expr::Integer(2),
-        Expr::Constant("Pi".to_string()),
-      ])),
+      make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")])),
       make_dirac_delta(t.clone()),
     ]));
   }
@@ -4322,7 +4297,7 @@ fn inverse_fourier_inner(expr: &Expr, w: &str, t: &Expr) -> Option<Expr> {
     && v == w
   {
     return Some(make_power(
-      make_times(vec![Expr::Integer(2), Expr::Constant("Pi".to_string())]),
+      make_times(vec![Expr::Integer(2), const_expr("Pi")]),
       call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
     ));
   }
@@ -4337,7 +4312,7 @@ fn inverse_fourier_inner(expr: &Expr, w: &str, t: &Expr) -> Option<Expr> {
       && v == w
     {
       let sqrt_pi_half = make_sqrt(make_times(vec![
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         make_power(Expr::Integer(2), Expr::Integer(-1)),
       ]));
       let sign_1_minus_t = Expr::FunctionCall {
@@ -4366,7 +4341,7 @@ fn inverse_fourier_inner(expr: &Expr, w: &str, t: &Expr) -> Option<Expr> {
         // F^-1[E^(-a*w^2)] = E^(-t^2/(4a)) / Sqrt[2a]
         return Some(make_times(vec![
           make_power(
-            Expr::Constant("E".to_string()),
+            const_expr("E"),
             make_times(vec![
               Expr::Integer(-1),
               make_power(t.clone(), Expr::Integer(2)),
@@ -5321,7 +5296,7 @@ fn gf_power(
     && args.len() == 1
     && matches!(&args[0], Expr::Identifier(var) if var == n)
   {
-    return Some(pow2(Expr::Constant("E".to_string()), x.clone()));
+    return Some(pow2(const_expr("E"), x.clone()));
   }
 
   // Case: Power[Factorial[n], -2] => 1/(n!)^2 => BesselI[0, 2*Sqrt[x]]
@@ -5656,7 +5631,7 @@ fn gf_divide(
       && args.len() == 1
       && matches!(&args[0], Expr::Identifier(var) if var == n)
     {
-      return Ok(Some(pow2(Expr::Constant("E".to_string()), x.clone())));
+      return Ok(Some(pow2(const_expr("E"), x.clone())));
     }
   }
 
@@ -5853,10 +5828,7 @@ fn egf_inner(
   // First try the polynomial approach: EGF = E^x * P(x)
   // This produces properly factored results like E^x*(1+x) instead of E^x + E^x*x
   if let Some(poly) = egf_poly_part(expr, n, x)? {
-    return Ok(Some(times2(
-      pow2(Expr::Constant("E".to_string()), x.clone()),
-      poly,
-    )));
+    return Ok(Some(times2(pow2(const_expr("E"), x.clone()), poly)));
   }
 
   // Handle Minus: a - b => a + (-b)
@@ -6038,10 +6010,7 @@ fn egf_power(
   // Case: c^n where c doesn't depend on n => e^(c*x)
   if !depends_on(base, n) && matches!(exp, Expr::Identifier(name) if name == n)
   {
-    return Some(pow2(
-      Expr::Constant("E".to_string()),
-      times2(base.clone(), x.clone()),
-    ));
+    return Some(pow2(const_expr("E"), times2(base.clone(), x.clone())));
   }
 
   // Case: n^k where k is a non-negative integer
@@ -6050,10 +6019,7 @@ fn egf_power(
     && let Some(k) = egf_expr_to_nonneg_int(exp)
   {
     let poly = egf_stirling_polynomial(k, x);
-    return Some(times2(
-      pow2(Expr::Constant("E".to_string()), x.clone()),
-      poly,
-    ));
+    return Some(times2(pow2(const_expr("E"), x.clone()), poly));
   }
 
   None
@@ -6298,7 +6264,7 @@ fn fourier_sin_cos_transform_inner(
   // sqrt(2/Pi) prefactor
   let prefactor = make_sqrt(make_times(vec![
     Expr::Integer(2),
-    make_power(Expr::Constant("Pi".to_string()), Expr::Integer(-1)),
+    make_power(const_expr("Pi"), Expr::Integer(-1)),
   ]));
 
   // Handle linearity: c * f(t) where c doesn't depend on t
@@ -6413,7 +6379,7 @@ fn fourier_sin_cos_transform_inner(
   {
     return Some(make_times(vec![
       make_sqrt(make_times(vec![
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
       ])),
       call1("Sign", w.clone()),
@@ -6470,14 +6436,11 @@ fn fourier_sin_cos_transform_inner(
       if (cv - wv).abs() < 1e-15 * cv.abs().max(1.0) {
         // Pi/(2*Sqrt[2*Pi])
         return Some(make_times(vec![
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           make_power(
             make_times(vec![
               Expr::Integer(2),
-              make_sqrt(make_times(vec![
-                Expr::Integer(2),
-                Expr::Constant("Pi".to_string()),
-              ])),
+              make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")])),
             ]),
             Expr::Integer(-1),
           ),
@@ -6485,12 +6448,9 @@ fn fourier_sin_cos_transform_inner(
       } else if wv > cv {
         // Pi/Sqrt[2*Pi]
         return Some(make_times(vec![
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           make_power(
-            make_sqrt(make_times(vec![
-              Expr::Integer(2),
-              Expr::Constant("Pi".to_string()),
-            ])),
+            make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")])),
             Expr::Integer(-1),
           ),
         ]));
@@ -6500,19 +6460,12 @@ fn fourier_sin_cos_transform_inner(
     // Symbolic path: (Pi - Pi*Sign[c-w]) / (2*Sqrt[2*Pi]).
     let sign = call1("Sign", c_minus_w);
     let numer = make_plus(vec![
-      Expr::Constant("Pi".to_string()),
-      make_times(vec![
-        Expr::Integer(-1),
-        Expr::Constant("Pi".to_string()),
-        sign,
-      ]),
+      const_expr("Pi"),
+      make_times(vec![Expr::Integer(-1), const_expr("Pi"), sign]),
     ]);
     let denom = make_times(vec![
       Expr::Integer(2),
-      make_sqrt(make_times(vec![
-        Expr::Integer(2),
-        Expr::Constant("Pi".to_string()),
-      ])),
+      make_sqrt(make_times(vec![Expr::Integer(2), const_expr("Pi")])),
     ]);
     return Some(make_times(vec![
       numer,
@@ -6564,7 +6517,7 @@ fn fourier_sin_cos_transform_inner(
       if tsq_ok && !depends_on(c, t) {
         let inv_amp = make_sqrt(make_power((*c).clone(), Expr::Integer(-1)));
         let decay = make_power(
-          Expr::Constant("E".to_string()),
+          const_expr("E"),
           make_times(vec![
             Expr::Integer(-1),
             w.clone(),
@@ -6572,7 +6525,7 @@ fn fourier_sin_cos_transform_inner(
           ]),
         );
         let sqrt_pi_half = make_sqrt(make_times(vec![
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
         ]));
         let mut factors = vec![sqrt_pi_half, decay];
@@ -6603,7 +6556,7 @@ fn fourier_sin_cos_transform_inner(
       && let Some(a) = extract_neg_quadratic_coeff(exp_arg, t)
     {
       let decay = make_power(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         make_times(vec![
           Expr::Integer(-1),
           make_power(w.clone(), Expr::Integer(2)),
@@ -6642,8 +6595,7 @@ fn fourier_sin_cos_transform_inner(
       w_sq,
       make_power(four_a, Expr::Integer(-1)),
     ]);
-    let numerator =
-      make_power(Expr::Constant("E".to_string()), neg_w_sq_over_4a);
+    let numerator = make_power(const_expr("E"), neg_w_sq_over_4a);
     let two_a = make_times(vec![Expr::Integer(2), a]);
     let denom = make_sqrt(two_a);
     return Some(make_times(vec![

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -7296,13 +7296,7 @@ fn compute_find_shortest_curve(
         // larger angle and end at the smaller one shifted by a full turn.
         let shifted = evaluate_expr_to_expr(&call(
           "Plus",
-          vec![
-            lo,
-            call(
-              "Times",
-              vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-            ),
-          ],
+          vec![lo, call("Times", vec![Expr::Integer(2), const_expr("Pi")])],
         ))?;
         vec![hi, shifted]
       };
@@ -7574,15 +7568,10 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
   {
     match radii.len() {
       2 => {
-        let area = Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
-            Expr::Constant("Pi".to_string()),
-            radii[0].clone(),
-            radii[1].clone(),
-          ]
-          .into(),
-        };
+        let area = call(
+          "Times",
+          vec![const_expr("Pi"), radii[0].clone(), radii[1].clone()],
+        );
         return crate::evaluator::evaluate_expr_to_expr(&area);
       }
       3 => {
@@ -7590,7 +7579,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           name: "Times".to_string(),
           args: vec![
             Expr::Integer(4),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
             radii[0].clone(),
             radii[1].clone(),
             radii[2].clone(),
@@ -7684,10 +7673,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
         let half = |e: Expr| div2(e, Expr::Integer(2));
         let tube = half(call("Subtract", vec![r2.clone(), r1.clone()]));
         let ring = half(call("Plus", vec![r1, r2]));
-        let pi_sq = call(
-          "Power",
-          vec![Expr::Constant("Pi".to_string()), Expr::Integer(2)],
-        );
+        let pi_sq = call("Power", vec![const_expr("Pi"), Expr::Integer(2)]);
         let measure = if name == "Torus" {
           call("Times", vec![Expr::Integer(4), pi_sq, tube, ring])
         } else {
@@ -7788,10 +7774,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           _ => return unevaluated(),
         };
         let half_n = div2(Expr::Integer(n as i128), Expr::Integer(2));
-        let pi_pow = call(
-          "Power",
-          vec![Expr::Constant("Pi".to_string()), half_n.clone()],
-        );
+        let pi_pow = call("Power", vec![const_expr("Pi"), half_n.clone()]);
         let r_pow = call("Power", vec![radius, Expr::Integer(n as i128)]);
         let gamma =
           call("Gamma", vec![call("Plus", vec![half_n, Expr::Integer(1)])]);
@@ -9471,22 +9454,15 @@ fn stadium_area(
       name: "Times".to_string(),
       args: vec![
         Expr::Integer(*b),
-        call(
-          "Plus",
-          vec![Expr::Integer(*a / *b), Expr::Constant("Pi".to_string())],
-        ),
+        call("Plus", vec![Expr::Integer(*a / *b), const_expr("Pi")]),
       ]
       .into(),
     });
   }
-  ev(&Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![
-      rect,
-      call("Times", vec![Expr::Constant("Pi".to_string()), cap_coeff]),
-    ]
-    .into(),
-  })
+  ev(&call(
+    "Plus",
+    vec![rect, call("Times", vec![const_expr("Pi"), cap_coeff])],
+  ))
 }
 
 fn capsule_height_sq_radius(args: &[Expr]) -> Option<(Expr, Expr)> {
@@ -9542,10 +9518,7 @@ fn spherical_shell_measure(
     ]
     .into(),
   };
-  let product = call(
-    "Times",
-    vec![Expr::Integer(4), Expr::Constant("Pi".to_string()), diff],
-  );
+  let product = call("Times", vec![Expr::Integer(4), const_expr("Pi"), diff]);
   let measure = if den == 1 {
     product
   } else {
@@ -9562,23 +9535,14 @@ fn capsule_volume(
   let pow =
     |b: &Expr, e: i128| call("Power", vec![b.clone(), Expr::Integer(e)]);
   let height = call1("Sqrt", height_sq.clone());
-  let cylinder = call(
-    "Times",
-    vec![Expr::Constant("Pi".to_string()), pow(radius, 2), height],
+  let cylinder = call("Times", vec![const_expr("Pi"), pow(radius, 2), height]);
+  let sphere = div2(
+    call(
+      "Times",
+      vec![Expr::Integer(4), const_expr("Pi"), pow(radius, 3)],
+    ),
+    Expr::Integer(3),
   );
-  let sphere = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![
-        Expr::Integer(4),
-        Expr::Constant("Pi".to_string()),
-        pow(radius, 3),
-      ]
-      .into(),
-    }),
-    right: Box::new(Expr::Integer(3)),
-  };
   crate::evaluator::evaluate_expr_to_expr(&call("Plus", vec![cylinder, sphere]))
 }
 
@@ -9766,7 +9730,7 @@ fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           Expr::Integer(4),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           call("Power", vec![radius, Expr::Integer(2)]),
         ]
         .into(),
@@ -9850,7 +9814,7 @@ fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
       if name == "Cylinder" {
         factors.push(Expr::Integer(2));
       }
-      factors.push(Expr::Constant("Pi".to_string()));
+      factors.push(const_expr("Pi"));
       factors.push(radius);
       factors.push(r_plus);
       crate::evaluator::evaluate_expr_to_expr(&call("Times", factors))
@@ -9871,7 +9835,7 @@ fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           Expr::Integer(4),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           call("Plus", vec![sq(&r1), sq(&r2)]),
         ]
         .into(),
@@ -9891,7 +9855,7 @@ fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           Expr::Integer(2),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           r.clone(),
           call1("Sqrt", h_sq),
         ]
@@ -9901,7 +9865,7 @@ fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           Expr::Integer(4),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
           call("Power", vec![r, Expr::Integer(2)]),
         ]
         .into(),
@@ -10043,10 +10007,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
     };
     let length = call1("Sqrt", sum_sq);
     let r_squared = call("Power", vec![radius, Expr::Integer(2)]);
-    let mut volume = call(
-      "Times",
-      vec![Expr::Constant("Pi".to_string()), r_squared, length],
-    );
+    let mut volume = call("Times", vec![const_expr("Pi"), r_squared, length]);
     if name == "Cone" {
       volume = div2(volume, Expr::Integer(3));
     }
@@ -10148,7 +10109,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
             name: "Times".to_string(),
             args: vec![
               Expr::Integer(4),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
               call("Power", vec![radius, Expr::Integer(3)]),
             ]
             .into(),
@@ -10176,7 +10137,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
             name: "Times".to_string(),
             args: vec![
               Expr::Integer(4),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
               radii[0].clone(),
               radii[1].clone(),
               radii[2].clone(),
@@ -10304,7 +10265,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
       "Disk" => {
         if args.is_empty() || (args.len() == 1) {
           // Unit disk
-          Ok(Expr::Constant("Pi".to_string()))
+          Ok(const_expr("Pi"))
         } else if args.len() == 2 {
           match &args[1] {
             Expr::List(radii) if radii.len() == 2 => {
@@ -10312,7 +10273,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
               let area = Expr::FunctionCall {
                 name: "Times".to_string(),
                 args: vec![
-                  Expr::Constant("Pi".to_string()),
+                  const_expr("Pi"),
                   radii[0].clone(),
                   radii[1].clone(),
                 ]
@@ -10325,7 +10286,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
               let area = Expr::FunctionCall {
                 name: "Times".to_string(),
                 args: vec![
-                  Expr::Constant("Pi".to_string()),
+                  const_expr("Pi"),
                   call("Power", vec![r.clone(), Expr::Integer(2)]),
                 ]
                 .into(),
@@ -10374,7 +10335,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         let radial = call("Subtract", vec![sq(r2), sq(r1)]);
         // Angular factor: Pi for the full ring, (t2 - t1)/2 for a sector.
         let angular = match angles {
-          None => Expr::Constant("Pi".to_string()),
+          None => const_expr("Pi"),
           Some((t1, t2)) => Expr::FunctionCall {
             name: "Times".to_string(),
             args: vec![
@@ -10398,15 +10359,10 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         let Expr::List(radii) = &args[1] else {
           unreachable!()
         };
-        let area = Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
-            Expr::Constant("Pi".to_string()),
-            radii[0].clone(),
-            radii[1].clone(),
-          ]
-          .into(),
-        };
+        let area = call(
+          "Times",
+          vec![const_expr("Pi"), radii[0].clone(), radii[1].clone()],
+        );
         crate::evaluator::evaluate_expr_to_expr(&area)
       }
       "Ellipsoid"
@@ -10656,17 +10612,9 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         let factor = call("Times", vec![rx, ry]);
         const TWO_PI: f64 = std::f64::consts::TAU;
         let area = if (d - TWO_PI).abs() < 1e-12 {
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              Expr::Integer(2),
-              Expr::Constant("Pi".to_string()),
-              factor,
-            ]
-            .into(),
-          }
+          call("Times", vec![Expr::Integer(2), const_expr("Pi"), factor])
         } else if d > TWO_PI {
-          call("Times", vec![Expr::Constant("Pi".to_string()), factor])
+          call("Times", vec![const_expr("Pi"), factor])
         } else {
           let dt = disk_segment_dtheta(&th1, &th2)?;
           // Together hoists the rational content of Δθ - Sin[Δθ] so the
@@ -10777,7 +10725,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           name: "Times".to_string(),
           args: vec![
             Expr::Integer(4),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
             call("Power", vec![radius, Expr::Integer(2)]),
           ]
           .into(),
@@ -10825,7 +10773,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           name: "Times".to_string(),
           args: vec![
             Expr::Integer(2),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
             call("Power", vec![n_expr, Expr::Integer(-1)]),
           ]
           .into(),
@@ -12069,22 +12017,14 @@ fn compute_arc_length(expr: &Expr) -> Result<Expr, InterpreterError> {
       "Circle" => {
         if args.is_empty() || args.len() == 1 {
           // Unit circle: 2*Pi
-          let result = call(
-            "Times",
-            vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-          );
+          let result = call("Times", vec![Expr::Integer(2), const_expr("Pi")]);
           crate::evaluator::evaluate_expr_to_expr(&result)
         } else if args.len() == 2 {
           // Circle[center, r] -> 2*Pi*r
-          let result = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              Expr::Integer(2),
-              Expr::Constant("Pi".to_string()),
-              args[1].clone(),
-            ]
-            .into(),
-          };
+          let result = call(
+            "Times",
+            vec![Expr::Integer(2), const_expr("Pi"), args[1].clone()],
+          );
           crate::evaluator::evaluate_expr_to_expr(&result)
         } else if args.len() == 3
           && !matches!(&args[1], Expr::List(_))
@@ -12167,10 +12107,7 @@ fn compute_perimeter(expr: &Expr) -> Result<Expr, InterpreterError> {
           name: "Plus".to_string(),
           args: vec![
             call("Times", vec![Expr::Integer(2), length]),
-            call(
-              "Times",
-              vec![Expr::Integer(2), Expr::Constant("Pi".to_string()), r],
-            ),
+            call("Times", vec![Expr::Integer(2), const_expr("Pi"), r]),
           ]
           .into(),
         })
@@ -12198,21 +12135,13 @@ fn compute_perimeter(expr: &Expr) -> Result<Expr, InterpreterError> {
       // Disk[{x, y}, r] -> 2*Pi*r, Disk[] -> 2*Pi
       "Disk" => {
         if args.is_empty() || args.len() == 1 {
-          let result = call(
-            "Times",
-            vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-          );
+          let result = call("Times", vec![Expr::Integer(2), const_expr("Pi")]);
           crate::evaluator::evaluate_expr_to_expr(&result)
         } else if args.len() == 2 {
-          let result = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              Expr::Integer(2),
-              Expr::Constant("Pi".to_string()),
-              args[1].clone(),
-            ]
-            .into(),
-          };
+          let result = call(
+            "Times",
+            vec![Expr::Integer(2), const_expr("Pi"), args[1].clone()],
+          );
           crate::evaluator::evaluate_expr_to_expr(&result)
         } else {
           unevaluated()
@@ -12753,10 +12682,7 @@ fn compute_polygon_angle(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let reflex = Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![
-            call(
-              "Times",
-              vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-            ),
+            call("Times", vec![Expr::Integer(2), const_expr("Pi")]),
             call("Times", vec![Expr::Integer(-1), base]),
           ]
           .into(),

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1473,7 +1473,7 @@ pub fn dispatch_math_functions(
         let exp_neg = |z: &Expr| Expr::FunctionCall {
           name: "Power".to_string(),
           args: vec![
-            Expr::Constant("E".to_string()),
+            const_expr("E"),
             call("Times", vec![Expr::Integer(-1), z.clone()]),
           ]
           .into(),
@@ -6572,7 +6572,7 @@ fn trig_to_exp_recursive(expr: &Expr) -> Expr {
     Expr::FunctionCall { name, args } if args.len() == 1 => {
       let arg = trig_to_exp_recursive(&args[0]);
       let i = Expr::Identifier("I".to_string());
-      let e = Expr::Constant("E".to_string());
+      let e = const_expr("E");
       let half = call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
       match name.as_str() {
         // Cos[x] = E^(I*x)/2 + E^(-I*x)/2
@@ -6723,7 +6723,7 @@ fn trig_to_exp_recursive(expr: &Expr) -> Expr {
             times(&[i.clone(), power(arg.clone(), Expr::Integer(-1))]),
           ]);
           plus(&[
-            times(&[Expr::Constant("Pi".to_string()), half.clone()]),
+            times(&[const_expr("Pi"), half.clone()]),
             times(&[i.clone(), log_of(inner)]),
           ])
         }

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-  binop, bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2,
-  times2, unevaluated,
+  binop, bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2,
+  pow2, times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -1154,8 +1154,8 @@ fn try_definite_integral(
     && let Some(coeff) = match_gaussian(integrand, var)
   {
     let result = match coeff {
-      Expr::Integer(1) => make_sqrt(Expr::Constant("Pi".to_string())),
-      _ => make_sqrt(div2(Expr::Constant("Pi".to_string()), coeff)),
+      Expr::Integer(1) => make_sqrt(const_expr("Pi")),
+      _ => make_sqrt(div2(const_expr("Pi"), coeff)),
     };
     // Re-evaluate so e.g. `Sqrt[Pi/(1/4)]` collapses to `2*Sqrt[Pi]`.
     return Some(
@@ -1183,8 +1183,8 @@ fn try_definite_integral(
     && let Some(coeff) = match_gaussian(integrand, var)
   {
     let sqrt_part = match coeff {
-      Expr::Integer(1) => make_sqrt(Expr::Constant("Pi".to_string())),
-      _ => make_sqrt(div2(Expr::Constant("Pi".to_string()), coeff)),
+      Expr::Integer(1) => make_sqrt(const_expr("Pi")),
+      _ => make_sqrt(div2(const_expr("Pi"), coeff)),
     };
     let result = div2(sqrt_part, Expr::Integer(2));
     return Some(
@@ -1223,7 +1223,7 @@ fn try_definite_integral(
     && !expr_depends_on_var(&n, var)
   {
     let bessel = call("BesselJ", vec![Expr::Integer(0), n]);
-    return Some(times2(Expr::Constant("Pi".to_string()), bessel));
+    return Some(times2(const_expr("Pi"), bessel));
   }
 
   // Euler's log-trig integrals:
@@ -1244,14 +1244,10 @@ fn try_definite_integral(
     && trig_args.len() == 1
     && matches!(&trig_args[0], Expr::Identifier(n) if n == var)
   {
-    let pi_log2 = Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![
-        Expr::Constant("Pi".to_string()),
-        call1("Log", Expr::Integer(2)),
-      ]
-      .into(),
-    };
+    let pi_log2 = call(
+      "Times",
+      vec![const_expr("Pi"), call1("Log", Expr::Integer(2))],
+    );
     if is_pi_over_two(hi) {
       match trig_name.as_str() {
         "Sin" | "Cos" => {
@@ -1611,8 +1607,8 @@ fn gaussian_moment_result(
     |base: Expr, exp: i128| call("Power", vec![base, Expr::Integer(exp)]);
   let half = || call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
   let sqrt_pi_over_a = || match coeff {
-    Expr::Integer(1) => make_sqrt(Expr::Constant("Pi".to_string())),
-    _ => make_sqrt(div2(Expr::Constant("Pi".to_string()), coeff.clone())),
+    Expr::Integer(1) => make_sqrt(const_expr("Pi")),
+    _ => make_sqrt(div2(const_expr("Pi"), coeff.clone())),
   };
 
   let mut factors: Vec<Expr> = Vec::new();
@@ -3177,7 +3173,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(0)) {
             return Ok(Expr::Integer(0));
           }
-          let exp_z = pow2(Expr::Constant("E".to_string()), args[0].clone());
+          let exp_z = pow2(const_expr("E"), args[0].clone());
           let result = simplify(div2(exp_z, args[0].clone()));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
@@ -3348,10 +3344,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           }
           // (Pi * z^2) / 2, evaluated so a compound argument's square expands.
           let inner = crate::evaluator::evaluate_expr_to_expr(&div2(
-            times2(
-              Expr::Constant("Pi".to_string()),
-              pow2(args[0].clone(), Expr::Integer(2)),
-            ),
+            times2(const_expr("Pi"), pow2(args[0].clone(), Expr::Integer(2))),
             Expr::Integer(2),
           ))
           .unwrap_or_else(|_| args[0].clone());
@@ -3570,8 +3563,8 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             left: Box::new(Expr::FunctionCall {
               name: "Times".to_string(),
               args: vec![
-                pow2(Expr::Constant("E".to_string()), f_sq),
-                call1("Sqrt", Expr::Constant("Pi".to_string())),
+                pow2(const_expr("E"), f_sq),
+                call1("Sqrt", const_expr("Pi")),
               ]
               .into(),
             }),
@@ -3650,8 +3643,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // z^(a-1)
           let z_pow = pow2(z.clone(), minus2(a.clone(), Expr::Integer(1)));
           // E^(-z)
-          let exp_neg_z =
-            pow2(Expr::Constant("E".to_string()), neg1(z.clone()));
+          let exp_neg_z = pow2(const_expr("E"), neg1(z.clone()));
           // -z^(a-1) E^(-z), times z' (chain rule).
           let core = neg1(times2(z_pow, exp_neg_z));
           let full = if matches!(dz, Expr::Integer(1)) {
@@ -3851,11 +3843,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = pow2(args[0].clone(), Expr::Integer(2));
-          let exp_neg_z2 = pow2(Expr::Constant("E".to_string()), neg1(z_sq));
-          let two_over_sqrt_pi = div2(
-            Expr::Integer(2),
-            make_sqrt(Expr::Constant("Pi".to_string())),
-          );
+          let exp_neg_z2 = pow2(const_expr("E"), neg1(z_sq));
+          let two_over_sqrt_pi =
+            div2(Expr::Integer(2), make_sqrt(const_expr("Pi")));
           let result = simplify(times2(two_over_sqrt_pi, exp_neg_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
@@ -3870,12 +3860,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = pow2(args[0].clone(), Expr::Integer(2));
-          let neg_exp_neg_z2 =
-            neg1(pow2(Expr::Constant("E".to_string()), neg1(z_sq)));
-          let two_over_sqrt_pi = div2(
-            Expr::Integer(2),
-            make_sqrt(Expr::Constant("Pi".to_string())),
-          );
+          let neg_exp_neg_z2 = neg1(pow2(const_expr("E"), neg1(z_sq)));
+          let two_over_sqrt_pi =
+            div2(Expr::Integer(2), make_sqrt(const_expr("Pi")));
           let result = simplify(times2(two_over_sqrt_pi, neg_exp_neg_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
@@ -3890,11 +3877,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = pow2(args[0].clone(), Expr::Integer(2));
-          let exp_z2 = pow2(Expr::Constant("E".to_string()), z_sq);
-          let two_over_sqrt_pi = div2(
-            Expr::Integer(2),
-            make_sqrt(Expr::Constant("Pi".to_string())),
-          );
+          let exp_z2 = pow2(const_expr("E"), z_sq);
+          let two_over_sqrt_pi =
+            div2(Expr::Integer(2), make_sqrt(const_expr("Pi")));
           let result = simplify(times2(two_over_sqrt_pi, exp_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
@@ -4905,21 +4890,20 @@ fn make_gaussian_antiderivative(
   let (erf_arg, prefix) = match coeff {
     Expr::Integer(1) => {
       // a=1: Erf[x], prefix = Sqrt[Pi]
-      (var_expr, make_sqrt(Expr::Constant("Pi".to_string())))
+      (var_expr, make_sqrt(const_expr("Pi")))
     }
     Expr::Integer(n) if *n != 1 => {
       // concrete integer a: (Sqrt[Pi/a]*Erf[Sqrt[a]*x])/2 — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
       let erf_arg = times2(sqrt_a, var_expr);
-      let prefix =
-        make_sqrt(div2(Expr::Constant("Pi".to_string()), coeff.clone()));
+      let prefix = make_sqrt(div2(const_expr("Pi"), coeff.clone()));
       (erf_arg, prefix)
     }
     _ => {
       // symbolic a: (Sqrt[Pi]*Erf[Sqrt[a]*x])/(2*Sqrt[a]) — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
       let erf_arg = times2(sqrt_a.clone(), var_expr);
-      let prefix = make_sqrt(Expr::Constant("Pi".to_string()));
+      let prefix = make_sqrt(const_expr("Pi"));
       let erf_expr = call(erf_name, vec![erf_arg]);
       // (Sqrt[Pi] * Erf[Sqrt[a]*x]) / (2 * Sqrt[a])
       return div2(times2(prefix, erf_expr), times2(Expr::Integer(2), sqrt_a));
@@ -4955,7 +4939,7 @@ fn make_fresnel_antiderivative(
   fresnel_name: &str,
 ) -> Expr {
   let x = Expr::Identifier(var.to_string());
-  let pi = Expr::Constant("Pi".to_string());
+  let pi = const_expr("Pi");
   let sqrt_pi_2 = make_sqrt(div2(pi.clone(), Expr::Integer(2)));
   let sqrt_2_pi = make_sqrt(div2(Expr::Integer(2), pi));
   let sqrt_a = make_sqrt(coeff.clone());
@@ -7958,10 +7942,8 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               let var_expr = Expr::Identifier(var.to_string());
               let inv_x = pow2(var_expr.clone(), Expr::Integer(-1));
               let term1 = times2(var_expr, expr.clone());
-              let term2 = times2(
-                make_sqrt(Expr::Constant("Pi".to_string())),
-                call("Erf", vec![inv_x]),
-              );
+              let term2 =
+                times2(make_sqrt(const_expr("Pi")), call("Erf", vec![inv_x]));
               return Some(plus2(term1, term2));
             }
           }
@@ -8248,7 +8230,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               "CosIntegral" => neg(call1("Sin", x.clone())),
               "SinhIntegral" => neg(call1("Cosh", x.clone())),
               "CoshIntegral" => neg(call1("Sinh", x.clone())),
-              _ => neg(pow2(Expr::Constant("E".to_string()), x.clone())),
+              _ => neg(pow2(const_expr("E"), x.clone())),
             };
             let x_f = Expr::BinaryOp {
               op: BinaryOperator::Times,
@@ -8322,40 +8304,26 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
           {
             let x = Expr::Identifier(var.to_string());
             let x_sq = pow2(x.clone(), Expr::Integer(2));
-            let sqrt_pi = call1("Sqrt", Expr::Constant("Pi".to_string()));
+            let sqrt_pi = call1("Sqrt", const_expr("Pi"));
             let neg = |e: Expr| times2(Expr::Integer(-1), e);
             // exp(-x^2)/Sqrt[Pi] used by Erf/Erfc.
             let gauss = || {
               div2(
                 Expr::Integer(1),
-                times2(
-                  pow2(Expr::Constant("E".to_string()), x_sq.clone()),
-                  sqrt_pi.clone(),
-                ),
+                times2(pow2(const_expr("E"), x_sq.clone()), sqrt_pi.clone()),
               )
             };
             // (Pi x^2)/2 argument for the Fresnel corrections.
-            let fresnel_arg = || {
-              div2(
-                times2(Expr::Constant("Pi".to_string()), x_sq.clone()),
-                Expr::Integer(2),
-              )
-            };
+            let fresnel_arg =
+              || div2(times2(const_expr("Pi"), x_sq.clone()), Expr::Integer(2));
             let correction = match name.as_str() {
               "Erf" => gauss(),
               "Erfc" => neg(gauss()),
-              "Erfi" => neg(div2(
-                pow2(Expr::Constant("E".to_string()), x_sq.clone()),
-                sqrt_pi.clone(),
-              )),
-              "FresnelS" => div2(
-                call1("Cos", fresnel_arg()),
-                Expr::Constant("Pi".to_string()),
-              ),
-              _ => neg(div2(
-                call1("Sin", fresnel_arg()),
-                Expr::Constant("Pi".to_string()),
-              )),
+              "Erfi" => {
+                neg(div2(pow2(const_expr("E"), x_sq.clone()), sqrt_pi.clone()))
+              }
+              "FresnelS" => div2(call1("Cos", fresnel_arg()), const_expr("Pi")),
+              _ => neg(div2(call1("Sin", fresnel_arg()), const_expr("Pi"))),
             };
             let x_f = times2(
               x,
@@ -9016,10 +8984,8 @@ pub fn simplify(mut expr: Expr) -> Expr {
       // Convert Exp[x] → E^x
       if name == "Exp"
         && args.len() == 1
-        && let Ok(result) = crate::functions::math_ast::power_two(
-          &Expr::Constant("E".to_string()),
-          &args[0],
-        )
+        && let Ok(result) =
+          crate::functions::math_ast::power_two(&const_expr("E"), &args[0])
       {
         return result;
       }
@@ -10203,8 +10169,7 @@ fn limit_at_infinity(
         Expr::FunctionCall { name, .. } if name == "Limit")
         && is_constant_wrt(&exponent_limit, var_name);
       if is_clean_value(&exponent_limit) || resolved {
-        let result =
-          simplify(pow2(Expr::Constant("E".to_string()), exponent_limit));
+        let result = simplify(pow2(const_expr("E"), exponent_limit));
         return crate::evaluator::evaluate_expr_to_expr(&result);
       }
     }
@@ -10301,10 +10266,10 @@ fn limit_at_infinity(
       }
       // Check for known constants
       if (f2 - std::f64::consts::E).abs() < 1e-3 {
-        return Ok(Expr::Constant("E".to_string()));
+        return Ok(const_expr("E"));
       }
       if (f2 - std::f64::consts::PI).abs() < 1e-3 {
-        return Ok(Expr::Constant("Pi".to_string()));
+        return Ok(const_expr("Pi"));
       }
       // Check for common multiples/fractions of Pi
       let pi = std::f64::consts::PI;
@@ -10331,12 +10296,9 @@ fn limit_at_infinity(
         if (f2 - val).abs() < 1e-3 {
           if denom == 1 {
             if numer == -1 {
-              return Ok(neg1(Expr::Constant("Pi".to_string())));
+              return Ok(neg1(const_expr("Pi")));
             }
-            return Ok(times2(
-              Expr::Integer(numer),
-              Expr::Constant("Pi".to_string()),
-            ));
+            return Ok(times2(Expr::Integer(numer), const_expr("Pi")));
           }
           return Ok(Expr::FunctionCall {
             name: "Times".to_string(),
@@ -10345,7 +10307,7 @@ fn limit_at_infinity(
                 "Rational",
                 vec![Expr::Integer(numer), Expr::Integer(denom)],
               ),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
             ]
             .into(),
           });
@@ -11334,10 +11296,10 @@ fn numerical_one_sided_limit(
     }
     // Check for known constants
     if (last - std::f64::consts::E).abs() < 1e-4 {
-      return Some(Expr::Constant("E".to_string()));
+      return Some(const_expr("E"));
     }
     if (last - std::f64::consts::PI).abs() < 1e-4 {
-      return Some(Expr::Constant("Pi".to_string()));
+      return Some(const_expr("Pi"));
     }
     return Some(Expr::Real(last));
   }
@@ -14912,14 +14874,10 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       exp_terms.reverse();
 
       // E^x * (sum of terms)
-      let exp_x = Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![
-          Expr::Constant("E".to_string()),
-          Expr::Identifier(var_name.clone()),
-        ]
-        .into(),
-      };
+      let exp_x = call(
+        "Power",
+        vec![const_expr("E"), Expr::Identifier(var_name.clone())],
+      );
       let exp_part = Expr::FunctionCall {
         name: "Times".to_string(),
         args: {
@@ -15256,8 +15214,7 @@ fn gaussian_closed_form_integral(
   let neg_alpha = call("Times", vec![Expr::Integer(-1), alpha.clone()]);
   let neg_alpha_eval = crate::evaluator::evaluate_expr_to_expr(&neg_alpha)?;
   let sqrt_neg_alpha = call1("Sqrt", neg_alpha_eval.clone());
-  let pi_over_neg_alpha =
-    div2(Expr::Constant("Pi".to_string()), neg_alpha_eval.clone());
+  let pi_over_neg_alpha = div2(const_expr("Pi"), neg_alpha_eval.clone());
   let sqrt_pi_over = call1("Sqrt", pi_over_neg_alpha);
 
   let bound_expr = |v: f64| -> Expr {
@@ -17966,7 +17923,7 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   let const_part = div2(
     plus2(
       times2(Expr::Integer(2), half_delta.clone()),
-      Expr::Constant("Pi".to_string()),
+      const_expr("Pi"),
     ),
     Expr::Integer(2),
   );
@@ -18879,11 +18836,7 @@ fn limit_resolved(e: &Expr) -> bool {
 /// (`Sqrt[x]/x` resolves only once it has folded to `1/Sqrt[x]`), so the
 /// division is put through the evaluator before the limit is taken.
 fn ratio(f: &Expr, g: &Expr) -> Expr {
-  let quotient = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(f.clone()),
-    right: Box::new(g.clone()),
-  };
+  let quotient = div2(f.clone(), g.clone());
   crate::evaluator::evaluate_expr_to_expr(&quotient).unwrap_or(quotient)
 }
 

--- a/src/functions/convolve_ast.rs
+++ b/src/functions/convolve_ast.rs
@@ -78,10 +78,7 @@ pub fn convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   ) {
     let s = frac(a.0 * b.1 + b.0 * a.1, a.1 * b.1); // a + b
     let q = frac(a.0 * b.0 * s.1, a.1 * b.1 * s.0); // a*b/(a + b)
-    let sqrt_part = call1(
-      "Sqrt",
-      div2(Expr::Constant("Pi".to_string()), frac_to_expr(s)),
-    );
+    let sqrt_part = call1("Sqrt", div2(const_expr("Pi"), frac_to_expr(s)));
     let y_sq = pow2(y.clone(), Expr::Integer(2));
     let exponent = match q {
       (1, 1) => y_sq,

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -430,7 +430,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               "Rational",
               vec![Expr::Integer(a as i128 + 1), Expr::Integer(k)],
             ),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
           ]
           .into(),
         }]
@@ -447,7 +447,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Times".to_string(),
       args: vec![
         call("Rational", vec![Expr::Integer(1), Expr::Integer(2 * k)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         sum,
       ]
       .into(),

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -404,10 +404,7 @@ fn eval_add_many(terms: Vec<Expr>) -> Expr {
     1 => terms.into_iter().next().unwrap(),
     _ => match crate::functions::math_ast::plus_ast(&terms) {
       Ok(r) => r,
-      Err(_) => Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      },
+      Err(_) => call("Plus", terms),
     },
   }
 }
@@ -3145,7 +3142,7 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
       if coeff != 1 {
         factors.push(Expr::Integer(coeff));
       }
-      factors.push(Expr::Constant("I".to_string()));
+      factors.push(const_expr("I"));
       if inner != 1 {
         factors.push(call1("Sqrt", Expr::Integer(inner as i128)));
       }

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -515,7 +515,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
     }
     "LogNormalDistribution" if dargs.len() == 2 => {
       // Median[LogNormalDistribution[mu, sigma]] = E^mu
-      let med = pow2(Expr::Constant("E".to_string()), dargs[0].clone());
+      let med = pow2(const_expr("E"), dargs[0].clone());
       crate::evaluator::evaluate_expr_to_expr(&med).ok()
     }
     "ExponentialDistribution" if dargs.len() == 1 => {

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::InterpreterError;
 use crate::helpers::{
-  bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2, times2,
-  unevaluated,
+  bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2, pow2,
+  times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -1329,10 +1329,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(max_expr, Expr::Identifier(s) if s == "Infinity")
             && body_is_one_plus_one_over_var_squared(body, &var_name)
           {
-            return Ok(div2(
-              call1("Sinh", Expr::Constant("Pi".to_string())),
-              Expr::Constant("Pi".to_string()),
-            ));
+            return Ok(div2(call1("Sinh", const_expr("Pi")), const_expr("Pi")));
           }
 
           // Closed form for ∏_{k=2}^∞ (1 - 1/k⁴) = Sinh[π] / (4 π).
@@ -1345,8 +1342,8 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && body_is_one_minus_one_over_var_quartic(body, &var_name)
           {
             return Ok(div2(
-              call1("Sinh", Expr::Constant("Pi".to_string())),
-              times2(Expr::Integer(4), Expr::Constant("Pi".to_string())),
+              call1("Sinh", const_expr("Pi")),
+              times2(Expr::Integer(4), const_expr("Pi")),
             ));
           }
 
@@ -4361,7 +4358,7 @@ fn try_infinite_sum(
   // wolframscript canonicalizes those results to a different (though
   // equivalent) form.
   if let Some((coeff, base)) = match_exponential_base(body, var_name) {
-    let e_to_base = call("Power", vec![Expr::Constant("E".to_string()), base]);
+    let e_to_base = call("Power", vec![const_expr("E"), base]);
     if min == 0 {
       let result = call("Times", vec![coeff, e_to_base]);
       return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
@@ -4536,10 +4533,7 @@ fn try_infinite_sum(
 
   // Try Leibniz formula: Sum[(-1)^k / (2k+1), {k, 0, Infinity}] = Pi/4
   if min == 0 && is_leibniz_body(body, var_name) {
-    return Ok(Some(div2(
-      Expr::Constant("Pi".to_string()),
-      Expr::Integer(4),
-    )));
+    return Ok(Some(div2(const_expr("Pi"), Expr::Integer(4))));
   }
 
   // Sums over the odd positive integers 1, 3, 5, …:

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -10518,10 +10518,7 @@ fn try_power_overflow(base: &Expr, exp: &Expr) -> Option<Expr> {
     )
   };
   crate::emit_message(message);
-  Some(Expr::FunctionCall {
-    name: head.to_string(),
-    args: Vec::new().into(),
-  })
+  Some(call0(head))
 }
 
 /// Helper for Power of two arguments
@@ -10844,7 +10841,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     if let Some(terms) = terms
       && terms.iter().any(|t| term_has_log(t))
     {
-      let e = Expr::Constant("E".to_string());
+      let e = const_expr("E");
       let mut factors: Vec<Expr> = Vec::new();
       let mut rest: Vec<Expr> = Vec::new();
       for t in &terms {

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -796,7 +796,7 @@ fn wrap_bessel_k_factor(
       call(
         "Power",
         vec![
-          Expr::Constant("E".to_string()),
+          const_expr("E"),
           call("Times", vec![Expr::Integer(-1), z_expr.clone()]),
         ],
       ),
@@ -1256,7 +1256,7 @@ fn coulomb_hplus_expr(l: i128, eta: &Expr, rho: &Expr) -> Expr {
       "Times",
       vec![
         call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         eta.clone(),
       ],
     ),
@@ -1322,7 +1322,7 @@ fn coulomb_f_numeric(
       "Times",
       vec![
         call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
         eta.clone(),
       ],
     ),

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -297,7 +297,7 @@ fn sqrt_of(x: &Expr) -> Expr {
 }
 
 fn pi() -> Expr {
-  Expr::Constant("Pi".to_string())
+  const_expr("Pi")
 }
 
 fn cinf() -> Expr {

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1023,14 +1023,7 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           name: "Plus".to_string(),
           args: vec![
             imz,
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![
-                Expr::Integer(-2 * k),
-                Expr::Constant("Pi".to_string()),
-              ]
-              .into(),
-            },
+            call("Times", vec![Expr::Integer(-2 * k), const_expr("Pi")]),
           ]
           .into(),
         };

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -15,11 +15,11 @@ fn gamma(z: Expr) -> Expr {
 }
 
 fn e() -> Expr {
-  Expr::Constant("E".to_string())
+  const_expr("E")
 }
 
 fn pi() -> Expr {
-  Expr::Constant("Pi".to_string())
+  const_expr("Pi")
 }
 
 fn infinity() -> Expr {
@@ -5362,10 +5362,7 @@ pub fn distribution_mean_variance(
         }
       };
       // Mean = a + b * EulerGamma
-      let mean = plus2(
-        a,
-        times2(b.clone(), Expr::Constant("EulerGamma".to_string())),
-      );
+      let mean = plus2(a, times2(b.clone(), const_expr("EulerGamma")));
       // Variance = b^2 * Pi^2 / 6
       let var = div2(times2(pow2(b, int(2)), pow2(pi(), int(2))), int(6));
       Ok((mean, var))

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -111,11 +111,8 @@ pub fn elliptic_nome_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(call(
             "Power",
             vec![
-              Expr::Constant("E".to_string()),
-              call(
-                "Times",
-                vec![Expr::Integer(-1), Expr::Constant("Pi".to_string())],
-              ),
+              const_expr("E"),
+              call("Times", vec![Expr::Integer(-1), const_expr("Pi")]),
             ],
           ));
         }

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -393,7 +393,7 @@ fn gamma_half_expr(numer: &BigInt, denom: &BigInt, is_neg: bool) -> Expr {
       // `Constant`, not `Identifier`: only the former counts as numeric-like
       // when `Times` merges radicals, so `Gamma[-1/2] Sqrt[2]` folds to
       // `-2 Sqrt[2 Pi]` the way wolframscript prints it.
-      Expr::Constant("Pi".to_string()),
+      const_expr("Pi"),
       call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
     ]
     .into(),
@@ -1601,7 +1601,7 @@ pub fn gamma_regularized_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Power".to_string(),
       args: vec![
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         call("Times", vec![Expr::Integer(-1), z_expr.clone()]),
       ]
       .into(),
@@ -1635,7 +1635,7 @@ pub fn gamma_regularized_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let e_pow = Expr::FunctionCall {
       name: "Power".to_string(),
       args: vec![
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         call("Times", vec![Expr::Integer(-1), z_expr.clone()]),
       ]
       .into(),
@@ -1713,7 +1713,7 @@ pub fn marcum_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               Expr::FunctionCall {
                 name: "Power".to_string(),
                 args: vec![
-                  Expr::Constant("E".to_string()),
+                  const_expr("E"),
                   Expr::FunctionCall {
                     name: "Times".to_string(),
                     args: vec![

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1105,7 +1105,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if is_half(&args[0]) && matches!(&args[1], Expr::Integer(1)) {
     let z = &args[2];
     let half_z = div2(z.clone(), Expr::Integer(2));
-    let exp_part = pow2(Expr::Constant("E".to_string()), half_z.clone());
+    let exp_part = pow2(const_expr("E"), half_z.clone());
     let bessel = call("BesselI", vec![Expr::Integer(0), half_z]);
     return crate::evaluator::evaluate_function_call_ast(
       "Times",
@@ -1121,8 +1121,8 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && !matches!(&args[2], Expr::Real(_) | Expr::BigFloat(_, _))
   {
     let z = &args[2];
-    let exp_z = pow2(Expr::Constant("E".to_string()), z.clone());
-    let sqrt_pi = call1("Sqrt", Expr::Constant("Pi".to_string()));
+    let exp_z = pow2(const_expr("E"), z.clone());
+    let sqrt_pi = call1("Sqrt", const_expr("Pi"));
     let sqrt_z = call1("Sqrt", z.clone());
     let erf = call1("Erf", sqrt_z.clone());
     let product = crate::evaluator::evaluate_function_call_ast(

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -99,14 +99,10 @@ pub fn cos_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => {
       if is_neg_infinity(other) {
         // CosIntegral[-Infinity] = I*Pi
-        return Ok(Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
-            Expr::Identifier("I".to_string()),
-            Expr::Constant("Pi".to_string()),
-          ]
-          .into(),
-        });
+        return Ok(call(
+          "Times",
+          vec![Expr::Identifier("I".to_string()), const_expr("Pi")],
+        ));
       }
       // Unevaluated
       Ok(unevaluated("CosIntegral", args))
@@ -575,20 +571,16 @@ pub fn sin_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // SinIntegral[0] = 0
     Expr::Integer(0) => Ok(Expr::Integer(0)),
     // SinIntegral[Infinity] = Pi/2
-    Expr::Identifier(s) if s == "Infinity" => Ok(call(
-      "Times",
-      vec![make_rational(1, 2), Expr::Constant("Pi".to_string())],
-    )),
+    Expr::Identifier(s) if s == "Infinity" => {
+      Ok(call("Times", vec![make_rational(1, 2), const_expr("Pi")]))
+    }
     // Numeric evaluation
     Expr::Real(x) => Ok(Expr::Real(sin_integral_numeric(*x))),
     // Check for -Infinity
     other => {
       if is_neg_infinity(other) {
         // SinIntegral[-Infinity] = -Pi/2
-        return Ok(call(
-          "Times",
-          vec![make_rational(-1, 2), Expr::Constant("Pi".to_string())],
-        ));
+        return Ok(call("Times", vec![make_rational(-1, 2), const_expr("Pi")]));
       }
       // Unevaluated
       Ok(unevaluated("SinIntegral", args))

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1030,7 +1030,7 @@ fn struve_half_integer_closed_form(
 ) -> Option<Result<Expr, InterpreterError>> {
   let int = Expr::Integer;
   let neg = |a: Expr| times2(int(-1), a);
-  let pi = || Expr::Constant("Pi".to_string());
+  let pi = || const_expr("Pi");
   let sqrt = |e: Expr| call1("Sqrt", e);
   let z = || z.clone();
   let sqrt_z = || sqrt(z());
@@ -1704,7 +1704,7 @@ fn weber_e_integer_closed_form(
   z: &Expr,
 ) -> Result<Expr, InterpreterError> {
   let m = n.unsigned_abs() as i128; // |n|
-  let pi = Expr::Constant("Pi".to_string());
+  let pi = const_expr("Pi");
   let pi_inv = pow2(pi, Expr::Integer(-1));
 
   // Polynomial terms: c_k * z^(m-2k-1) / Pi with
@@ -1742,7 +1742,7 @@ fn weber_e_integer_closed_form(
 
 /// AngerJ[ν, 0] closed form: Sin[ν*Pi] / (ν*Pi).
 fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
-  let pi = Expr::Constant("Pi".to_string());
+  let pi = const_expr("Pi");
   let nu_pi = times2(nu.clone(), pi.clone());
   let sin_nu_pi = call1("Sin", nu_pi.clone());
   div2(sin_nu_pi, nu_pi)
@@ -1750,7 +1750,7 @@ fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
 
 /// WeberE[ν, 0] closed form: (1 - Cos[ν*Pi]) / (ν*Pi).
 fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
-  let pi = Expr::Constant("Pi".to_string());
+  let pi = const_expr("Pi");
   let nu_pi = times2(nu.clone(), pi.clone());
   let cos_nu_pi = call1("Cos", nu_pi.clone());
   let one_minus_cos = minus2(Expr::Integer(1), cos_nu_pi);
@@ -1915,10 +1915,7 @@ fn wigner_d_symbolic(
       "Times",
       vec![Expr::Identifier("I".to_string()), coef_expr, ang.clone()],
     );
-    Some(call(
-      "Power",
-      vec![Expr::Constant("E".to_string()), exponent],
-    ))
+    Some(call("Power", vec![const_expr("E"), exponent]))
   };
   let e1 = exp_factor(m1, phi)?;
   let e2 = exp_factor(m2, psi)?;

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -4,8 +4,8 @@
 
 use crate::InterpreterError;
 use crate::helpers::{
-  binop, bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2,
-  times2, unevaluated,
+  binop, bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2,
+  pow2, times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -991,10 +991,7 @@ pub fn spherical_harmonic_y_ast(
     name: "Times".to_string(),
     args: vec![
       norm_inner,
-      call(
-        "Power",
-        vec![Expr::Constant("Pi".to_string()), Expr::Integer(-1)],
-      ),
+      call("Power", vec![const_expr("Pi"), Expr::Integer(-1)]),
     ]
     .into(),
   };
@@ -1030,7 +1027,7 @@ pub fn spherical_harmonic_y_ast(
     Expr::FunctionCall {
       name: "Power".to_string(),
       args: vec![
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![
@@ -1194,10 +1191,7 @@ fn simplify_spherical_harmonic_form(expr: &Expr) -> Expr {
       name: "Times".to_string(),
       args: vec![
         new_radicand_rat,
-        call(
-          "Power",
-          vec![Expr::Constant("Pi".to_string()), Expr::Integer(-1)],
-        ),
+        call("Power", vec![const_expr("Pi"), Expr::Integer(-1)]),
       ]
       .into(),
     };

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -6574,15 +6574,12 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
             .into(),
           },
           // Sqrt[2*Pi]
-          make_sqrt(call(
-            "Times",
-            vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-          )),
+          make_sqrt(call("Times", vec![Expr::Integer(2), const_expr("Pi")])),
           // E^(-n)
           Expr::FunctionCall {
             name: "Power".to_string(),
             args: vec![
-              Expr::Constant("E".to_string()),
+              const_expr("E"),
               call("Times", vec![Expr::Integer(-1), n]),
             ]
             .into(),
@@ -6752,19 +6749,12 @@ fn stirling_approx(var: &str) -> Expr {
         .into(),
       },
       // Sqrt[2*Pi]
-      make_sqrt(call(
-        "Times",
-        vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
-      )),
+      make_sqrt(call("Times", vec![Expr::Integer(2), const_expr("Pi")])),
       // E^(-n)
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![
-          Expr::Constant("E".to_string()),
-          call("Times", vec![Expr::Integer(-1), n]),
-        ]
-        .into(),
-      },
+      call(
+        "Power",
+        vec![const_expr("E"), call("Times", vec![Expr::Integer(-1), n])],
+      ),
     ]
     .into(),
   }
@@ -6928,14 +6918,7 @@ fn asymptotic_binomial(
       Expr::FunctionCall {
         name: "Power".to_string(),
         args: vec![
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              make_sqrt(n),
-              make_sqrt(Expr::Constant("Pi".to_string())),
-            ]
-            .into(),
-          },
+          call("Times", vec![make_sqrt(n), make_sqrt(const_expr("Pi"))]),
           Expr::Integer(-1),
         ]
         .into(),
@@ -7130,7 +7113,7 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     // Stationary Ornstein-Uhlenbeck: s^2 E^(-th |t1 - t2|) / (2 th).
     ("OrnsteinUhlenbeckProcess", [_, sp, th]) => {
       let decay = pow2(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         times2(th.clone(), call1("Abs", plus2(t1.clone(), neg(t2.clone())))),
       );
       Some(div2(
@@ -7155,12 +7138,12 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     // x0^2 E^(m (t1 + t2)) (E^(s^2 Min) - 1).
     ("GeometricBrownianMotionProcess", [m, sp, x0]) => {
       let growth = pow2(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         times2(m.clone(), plus2(t1.clone(), t2.clone())),
       );
       let bump = plus2(
         Expr::Integer(-1),
-        pow2(Expr::Constant("E".to_string()), times2(sq(sp), min)),
+        pow2(const_expr("E"), times2(sq(sp), min)),
       );
       Some(times2(times2(growth, bump), sq(x0)))
     }
@@ -7252,7 +7235,7 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
       Some(div2(min, call1("Sqrt", times2(t1.clone(), t2.clone()))))
     }
     ("OrnsteinUhlenbeckProcess", [_, _, th]) => Some(pow2(
-      Expr::Constant("E".to_string()),
+      const_expr("E"),
       neg(times2(
         th.clone(),
         call1("Abs", plus2(t1.clone(), neg(t2.clone()))),
@@ -7296,7 +7279,7 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
       let bump = |arg: Expr| {
         plus2(
           Expr::Integer(-1),
-          pow2(Expr::Constant("E".to_string()), times2(sq(sp), arg)),
+          pow2(const_expr("E"), times2(sq(sp), arg)),
         )
       };
       Some(div2(
@@ -7342,7 +7325,7 @@ pub fn process_absolute_correlation(
     )),
     ("OrnsteinUhlenbeckProcess", [m, sp, th]) => {
       let decay = pow2(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         times2(th.clone(), call1("Abs", plus2(t1.clone(), neg(t2.clone())))),
       );
       Some(plus2(
@@ -7387,7 +7370,7 @@ pub fn process_absolute_correlation(
     }
     ("GeometricBrownianMotionProcess", [m, sp, x0]) => Some(times2(
       pow2(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         plus2(
           times2(m.clone(), plus2(t1.clone(), t2.clone())),
           times2(sq(sp), min),
@@ -9482,7 +9465,7 @@ fn erlang_b_symbolic(
       call(
         "Power",
         vec![
-          Expr::Constant("E".to_string()),
+          const_expr("E"),
           call("Times", vec![Expr::Integer(-1), a.clone()]),
         ],
       ),

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -2298,7 +2298,7 @@ pub fn exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   match &args[0] {
     Expr::Integer(0) => Ok(Expr::Integer(1)),
-    Expr::Integer(1) => Ok(Expr::Constant("E".to_string())),
+    Expr::Integer(1) => Ok(const_expr("E")),
     Expr::Real(f) => {
       // Wolfram only emits General::ovfl + Overflow[] for *truly* huge
       // arguments (around |x| >= 10^15) — its big-exponent reals can
@@ -2318,9 +2318,9 @@ pub fn exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(result) = bigfloat_exp(digits, *prec) {
         return result;
       }
-      power_two(&Expr::Constant("E".to_string()), &args[0])
+      power_two(&const_expr("E"), &args[0])
     }
-    _ => power_two(&Expr::Constant("E".to_string()), &args[0]),
+    _ => power_two(&const_expr("E"), &args[0]),
   }
 }
 
@@ -2896,7 +2896,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               name: "Times".to_string(),
               args: vec![
                 Expr::Integer(-2 * k),
-                Expr::Constant("Pi".to_string()),
+                const_expr("Pi"),
                 Expr::Identifier("I".to_string()),
               ]
               .into(),
@@ -2956,7 +2956,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           &[
             Expr::Identifier("I".to_string()),
             make_rational(1, 2),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
           ],
         );
       }
@@ -2995,7 +2995,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               Expr::Integer(-1),
               Expr::Identifier("I".to_string()),
               make_rational(1, 2),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
             ],
           );
         }
@@ -3021,7 +3021,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                   call1("Sign", coeff.clone()),
                   make_rational(1, 2),
                   Expr::Identifier("I".to_string()),
-                  Expr::Constant("Pi".to_string()),
+                  const_expr("Pi"),
                 ]
                 .into(),
               },
@@ -3041,10 +3041,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let result = Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![
-            times2(
-              Expr::Identifier("I".to_string()),
-              Expr::Constant("Pi".to_string()),
-            ),
+            times2(Expr::Identifier("I".to_string()), const_expr("Pi")),
             call1("Log", make_rational(p.abs(), q.abs())),
           ]
           .into(),
@@ -3057,10 +3054,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         let abs_n = -*n;
         // I*Pi
-        let i_pi = times2(
-          Expr::Identifier("I".to_string()),
-          Expr::Constant("Pi".to_string()),
-        );
+        let i_pi = times2(Expr::Identifier("I".to_string()), const_expr("Pi"));
         if abs_n == 1 {
           return Ok(i_pi);
         }
@@ -3102,10 +3096,8 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             )
         });
         if let Some(inner_expr) = inner {
-          let i_pi = times2(
-            Expr::Identifier("I".to_string()),
-            Expr::Constant("Pi".to_string()),
-          );
+          let i_pi =
+            times2(Expr::Identifier("I".to_string()), const_expr("Pi"));
           let log_x =
             crate::evaluator::evaluate_function_call_ast("Log", &[inner_expr])?;
           return crate::evaluator::evaluate_function_call_ast(
@@ -3414,7 +3406,7 @@ fn fold_inverse_of_forward(name: &str, arg: &Expr) -> Option<Expr> {
     return None;
   }
 
-  let pi = || Expr::Constant("Pi".to_string());
+  let pi = || const_expr("Pi");
   let half = || call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
   // How many half turns to take off `u`, as an exact integer. Each range
   // wants its own half-open period:
@@ -3514,13 +3506,13 @@ pub fn arcsin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(2)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(2)));
     }
     Expr::Integer(-1) => {
       // -1/2*Pi = Times[Rational[-1, 2], Pi]
       return Ok(times2(
         call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
       ));
     }
     Expr::Real(f) if (-1.0..=1.0).contains(f) => {
@@ -3652,9 +3644,9 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(1) => return Ok(Expr::Integer(0)),
     Expr::Integer(0) => {
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(2)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(2)));
     }
-    Expr::Integer(-1) => return Ok(Expr::Constant("Pi".to_string())),
+    Expr::Integer(-1) => return Ok(const_expr("Pi")),
     Expr::Real(f) if (-1.0..=1.0).contains(f) => {
       return Ok(Expr::Real(f.acos()));
     }
@@ -3698,15 +3690,15 @@ fn arccos_special_value(v: f64) -> Option<Expr> {
   let pi_frac = |num: i128, den: i128| -> Expr {
     if den == 1 {
       if num == 1 {
-        Expr::Constant("Pi".to_string())
+        const_expr("Pi")
       } else {
-        times2(Expr::Integer(num), Expr::Constant("Pi".to_string()))
+        times2(Expr::Integer(num), const_expr("Pi"))
       }
     } else {
       let numerator = if num == 1 {
-        Expr::Constant("Pi".to_string())
+        const_expr("Pi")
       } else {
-        times2(Expr::Integer(num), Expr::Constant("Pi".to_string()))
+        times2(Expr::Integer(num), const_expr("Pi"))
       };
       div2(numerator, Expr::Integer(den))
     }
@@ -3749,12 +3741,12 @@ fn arcsin_special_value(v: f64) -> Option<Expr> {
         // Negative: build Times[Rational[-1, den], Pi] to display as -1/den*Pi
         return Some(times2(
           call("Rational", vec![Expr::Integer(-1), Expr::Integer(den)]),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
         ));
       } else if den == 1 {
-        return Some(Expr::Constant("Pi".to_string()));
+        return Some(const_expr("Pi"));
       }
-      return Some(div2(Expr::Constant("Pi".to_string()), Expr::Integer(den)));
+      return Some(div2(const_expr("Pi"), Expr::Integer(den)));
     }
   }
   None
@@ -3801,18 +3793,18 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(4)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(4)));
     }
     Expr::Integer(-1) => {
       // -1/4*Pi = Times[Rational[-1, 4], Pi]
       return Ok(times2(
         call("Rational", vec![Expr::Integer(-1), Expr::Integer(4)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
       ));
     }
     Expr::Identifier(s) if s == "Infinity" => {
       // ArcTan[Infinity] = Pi/2
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(2)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(2)));
     }
     Expr::Real(f) => return Ok(Expr::Real(f.atan())),
     _ => {}
@@ -3823,7 +3815,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Times".to_string(),
       args: vec![
         call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
       ]
       .into(),
     });
@@ -3836,7 +3828,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let eps = 1e-12;
     if (val - sqrt3).abs() < eps {
       // ArcTan[Sqrt[3]] = Pi/3
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(3)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(3)));
     }
     if (val + sqrt3).abs() < eps {
       // ArcTan[-Sqrt[3]] = -Pi/3
@@ -3844,7 +3836,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           call("Rational", vec![Expr::Integer(-1), Expr::Integer(3)]),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
         ]
         .into(),
       });
@@ -3852,7 +3844,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inv_sqrt3 = 1.0 / sqrt3;
     if (val - inv_sqrt3).abs() < eps {
       // ArcTan[1/Sqrt[3]] = Pi/6
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(6)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(6)));
     }
     if (val + inv_sqrt3).abs() < eps {
       // ArcTan[-1/Sqrt[3]] = -Pi/6
@@ -3860,7 +3852,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           call("Rational", vec![Expr::Integer(-1), Expr::Integer(6)]),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
         ]
         .into(),
       });
@@ -3869,13 +3861,13 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Tan[5 Pi/12] = 2 + Sqrt[3]). `k_over_12_pi(k)` builds k*Pi/12.
     let k_over_12_pi = |k: i128| -> Expr {
       if k == 1 {
-        div2(Expr::Constant("Pi".to_string()), Expr::Integer(12))
+        div2(const_expr("Pi"), Expr::Integer(12))
       } else {
         Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![
             call("Rational", vec![Expr::Integer(k), Expr::Integer(12)]),
-            Expr::Constant("Pi".to_string()),
+            const_expr("Pi"),
           ]
           .into(),
         }
@@ -3943,14 +3935,14 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let rational_pi = |num: i128, den: i128| -> Expr {
     if den == 1 {
       if num == 1 {
-        Expr::Constant("Pi".to_string())
+        const_expr("Pi")
       } else {
-        times2(Expr::Integer(num), Expr::Constant("Pi".to_string()))
+        times2(Expr::Integer(num), const_expr("Pi"))
       }
     } else {
       times2(
         call("Rational", vec![Expr::Integer(num), Expr::Integer(den)]),
-        Expr::Constant("Pi".to_string()),
+        const_expr("Pi"),
       )
     }
   };
@@ -3999,9 +3991,9 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // x < 0: shift by +Pi (y >= 0) or -Pi (y < 0).
     let pi_term = if yf >= 0.0 {
-      Expr::Constant("Pi".to_string())
+      const_expr("Pi")
     } else {
-      times2(Expr::Integer(-1), Expr::Constant("Pi".to_string()))
+      times2(Expr::Integer(-1), const_expr("Pi"))
     };
     return crate::evaluator::evaluate_function_call_ast(
       "Plus",
@@ -4738,7 +4730,7 @@ pub fn arccosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         &[
           call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
           Expr::Identifier("I".to_string()),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
         ],
       );
     }
@@ -4763,7 +4755,7 @@ pub fn arccosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             name: "Times".to_string(),
             args: vec![
               call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
             ]
             .into(),
           },
@@ -4881,7 +4873,7 @@ pub fn arccoth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         &[
           call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
           Expr::Identifier("I".to_string()),
-          Expr::Constant("Pi".to_string()),
+          const_expr("Pi"),
         ],
       );
     }
@@ -4930,7 +4922,7 @@ pub fn arccoth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             name: "Times".to_string(),
             args: vec![
               call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
-              Expr::Constant("Pi".to_string()),
+              const_expr("Pi"),
             ]
             .into(),
           },
@@ -5169,14 +5161,11 @@ pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Helper to construct -Pi/2 matching wolframscript output format
 /// Construct Pi/n as an AST expression
 fn pi_over_n(n: i128) -> Expr {
-  div2(Expr::Constant("Pi".to_string()), Expr::Integer(n))
+  div2(const_expr("Pi"), Expr::Integer(n))
 }
 
 fn negative_pi_over_2() -> Expr {
-  times2(
-    div2(Expr::Integer(-1), Expr::Integer(2)),
-    Expr::Constant("Pi".to_string()),
-  )
+  times2(div2(Expr::Integer(-1), Expr::Integer(2)), const_expr("Pi"))
 }
 
 /// Gudermannian[x] - the Gudermannian function: 2 ArcTan[Tanh[x/2]]
@@ -5341,7 +5330,7 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Identifier(name) if name == "Infinity" => {
       // Gudermannian[Infinity] = Pi/2
-      return Ok(div2(Expr::Constant("Pi".to_string()), Expr::Integer(2)));
+      return Ok(div2(const_expr("Pi"), Expr::Integer(2)));
     }
     Expr::Identifier(name) if name == "ComplexInfinity" => {
       // Gudermannian[ComplexInfinity] is unevaluated in Wolfram
@@ -5505,7 +5494,7 @@ fn trig_degrees_ast(
   // Convert degrees to radians: x * Degree
   let radians = crate::evaluator::evaluate_function_call_ast(
     "Times",
-    &[args[0].clone(), Expr::Constant("Degree".to_string())],
+    &[args[0].clone(), const_expr("Degree")],
   )?;
   let result =
     crate::evaluator::evaluate_function_call_ast(func_name, &[radians])?;
@@ -5549,10 +5538,7 @@ fn arc_trig_degrees_ast(
     &[
       radians,
       call("Rational", vec![Expr::Integer(180), Expr::Integer(1)]),
-      call(
-        "Power",
-        vec![Expr::Constant("Pi".to_string()), Expr::Integer(-1)],
-      ),
+      call("Power", vec![const_expr("Pi"), Expr::Integer(-1)]),
     ],
   )
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,7 +1,7 @@
 use crate::InterpreterError;
 use crate::helpers::{
-  binop, bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2,
-  times2, unevaluated,
+  binop, bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2,
+  pow2, times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -1013,27 +1013,16 @@ fn try_solve_pde_system(
       if is_zero_literal(&e) {
         return e;
       }
-      Expr::UnaryOp {
-        op: UnaryOperator::Minus,
-        operand: Box::new(e),
-      }
+      neg1(e)
     }
     fn add_expr(a: Expr, b: Expr) -> Expr {
-      Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(a),
-        right: Box::new(b),
-      }
+      plus2(a, b)
     }
     fn mul_expr(coeff: Expr, e: Expr) -> Expr {
       if is_one_literal(&coeff) {
         return e;
       }
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(coeff),
-        right: Box::new(e),
-      }
+      times2(coeff, e)
     }
     fn flatten_additive_signed(
       expr: &Expr,
@@ -1098,10 +1087,7 @@ fn try_solve_pde_system(
       let coeff = match coeff_factors.len() {
         0 => Expr::Integer(1),
         1 => coeff_factors.into_iter().next().unwrap(),
-        _ => Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: coeff_factors.into(),
-        },
+        _ => call("Times", coeff_factors),
       };
       Some((coeff, t_arg, x_arg))
     }
@@ -1168,11 +1154,7 @@ fn try_solve_pde_system(
     let derived = if is_one_literal(&self_coeff) {
       negated
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(negated),
-        right: Box::new(self_coeff),
-      }
+      div2(negated, self_coeff)
     };
     Some(PdeBc::Neumann(derived))
   }
@@ -2657,10 +2639,7 @@ fn ndsolve_system(
     // Mirrors the parser's own shape for `Derivative[k][f]` (nested
     // `CurriedCall`s) so `/.` matches the same expression the user wrote.
     let deriv_pattern = Expr::CurriedCall {
-      func: Box::new(Expr::FunctionCall {
-        name: "Derivative".to_string(),
-        args: vec![Expr::Integer(*order as i128)].into(),
-      }),
+      func: Box::new(call("Derivative", vec![Expr::Integer(*order as i128)])),
       args: vec![Expr::Identifier(name.clone())],
     };
     rules.push(if *function_form {
@@ -4770,7 +4749,7 @@ fn make_exp_term(r: f64, x_name: &str) -> Expr {
   } else {
     times2(r_expr, x)
   };
-  pow2(Expr::Constant("E".to_string()), exponent)
+  pow2(const_expr("E"), exponent)
 }
 
 /// Create Cos[β*x] or Sin[β*x] expression
@@ -4897,7 +4876,7 @@ fn solve_first_order_linear(
     Expr::Identifier(x_name.to_string()),
   ])?;
 
-  let mu = pow2(Expr::Constant("E".to_string()), p_integral.clone());
+  let mu = pow2(const_expr("E"), p_integral.clone());
 
   let mu_q =
     crate::functions::calculus_ast::simplify(times2(mu.clone(), q_expr));
@@ -4909,7 +4888,7 @@ fn solve_first_order_linear(
 
   // y = E^(-∫P dx) * (∫(μ*Q)dx + C[1])
   let neg_p_integral = negate_expr(&p_integral);
-  let inv_mu = pow2(Expr::Constant("E".to_string()), neg_p_integral);
+  let inv_mu = pow2(const_expr("E"), neg_p_integral);
 
   // Distribute the integrating factor over the particular part and the
   // constant separately, matching wolframscript's form, e.g.
@@ -5167,7 +5146,7 @@ fn make_exp_term_expr(coeff: &Expr, x_name: &str) -> Expr {
     Expr::Integer(-1) => neg1(x),
     _ => times2(coeff.clone(), x),
   };
-  pow2(Expr::Constant("E".to_string()), exponent)
+  pow2(const_expr("E"), exponent)
 }
 
 // ─── Particular Solution (Undetermined Coefficients) ───────────────────
@@ -6779,11 +6758,7 @@ fn lagrange_polynomial(
     let mut factors: Vec<Expr> = vec![ys[i].clone()];
     for j in 0..m {
       if j != i {
-        factors.push(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(minus(var, &xs[j])),
-          right: Box::new(minus(&xs[i], &xs[j])),
-        });
+        factors.push(div2(minus(var, &xs[j]), minus(&xs[i], &xs[j])));
       }
     }
     factors.retain(|f| !matches!(f, Expr::Integer(1)));
@@ -6996,7 +6971,7 @@ fn try_linear_first_order_pde_body(
     } else {
       times2(Expr::Integer(c_eff), n_var(xn))
     };
-    pow2(Expr::Constant("E".to_string()), exponent)
+    pow2(const_expr("E"), exponent)
   };
   // Argument to C[1]: y - b*x  (or just y when b == 0).
   let c1_arg = if b == 0 {

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -7,8 +7,8 @@ use crate::functions::math_ast::{
   gcd_i128, is_sqrt, lcm_i128, make_sqrt, rat_reduce, rat_reduce_bigint,
 };
 use crate::helpers::{
-  bool_expr, call, call0, call1, div2, minus2, neg1, plus2, pow2, times2,
-  unevaluated,
+  bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2, pow2,
+  times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -1242,7 +1242,7 @@ fn refine_expr(expr: &Expr, info: &AssumptionInfo, assumption: &Expr) -> Expr {
           return Expr::Integer(0);
         }
         if info.negative_vars.contains(var_name) {
-          return Expr::Constant("Pi".to_string());
+          return const_expr("Pi");
         }
       }
       let refined_arg = refine_expr(&args[0], info, assumption);
@@ -2649,14 +2649,10 @@ fn refine_log(
     return Some(Expr::FunctionCall {
       name: "Plus".to_string(),
       args: vec![
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
-            Expr::Identifier("I".to_string()),
-            Expr::Constant("Pi".to_string()),
-          ]
-          .into(),
-        },
+        call(
+          "Times",
+          vec![Expr::Identifier("I".to_string()), const_expr("Pi")],
+        ),
         call1("Log", neg1(arg.clone())),
       ]
       .into(),
@@ -5605,7 +5601,7 @@ pub(crate) fn factor_exponential_sum(expr: &Expr) -> Option<Expr> {
   // Substitute x back and multiply the pulled-out E^(k_min u) in.
   let step_rate = make_ratio(step, common_den);
   let x_value = pow2(
-    Expr::Constant("E".to_string()),
+    const_expr("E"),
     match &step_rate {
       Expr::Integer(1) => var.clone(),
       other => times2(other.clone(), var.clone()),
@@ -5622,7 +5618,7 @@ pub(crate) fn factor_exponential_sum(expr: &Expr) -> Option<Expr> {
   } else {
     times2(
       pow2(
-        Expr::Constant("E".to_string()),
+        const_expr("E"),
         crate::evaluator::evaluate_expr_to_expr(&times2(min_rate, var)).ok()?,
       ),
       substituted,
@@ -6100,10 +6096,8 @@ fn try_complementary_inverse_trig(expr: &Expr) -> Option<Expr> {
     return None;
   }
   // c * Pi / 2
-  let result = div2(
-    call("Times", vec![c0, Expr::Constant("Pi".to_string())]),
-    Expr::Integer(2),
-  );
+  let result =
+    div2(call("Times", vec![c0, const_expr("Pi")]), Expr::Integer(2));
   crate::evaluator::evaluate_expr_to_expr(&result).ok()
 }
 

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -4472,7 +4472,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
   }
 
   let var_expr = Expr::Identifier(var.to_string());
-  let pi = Expr::Constant("Pi".to_string());
+  let pi = const_expr("Pi");
   let c1 = call1("C", Expr::Integer(1));
   let element_c1_integers = call(
     "Element",
@@ -4758,7 +4758,7 @@ fn try_solve_inverse_function(
     let inverse_rhs = match name.as_str() {
       "Log" => {
         // Log[inner] == val → inner == E^val
-        pow2(Expr::Constant("E".to_string()), val.clone())
+        pow2(const_expr("E"), val.clone())
       }
       "Sqrt" => {
         // Sqrt[inner] == val → inner == val^2
@@ -4794,7 +4794,7 @@ fn try_solve_inverse_function(
           "ArcCscDegrees" => "Csc",
           _ => unreachable!(),
         };
-        let val_deg = times2(val.clone(), Expr::Constant("Degree".to_string()));
+        let val_deg = times2(val.clone(), const_expr("Degree"));
         call1(inverse_name, val_deg)
       }
       "Log10" => {

--- a/src/functions/trig_factor_ast.rs
+++ b/src/functions/trig_factor_ast.rs
@@ -55,7 +55,7 @@ fn sqrt2() -> Expr {
 }
 
 fn pi_quarter() -> Expr {
-  div(Expr::Constant("Pi".to_string()), 4)
+  div(const_expr("Pi"), 4)
 }
 
 /// First symbol of `v` in canonical term order, lowercased; decides

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -1052,7 +1052,7 @@ pub fn fourier_coefficient_ast(
   let times = |fs: Vec<Expr>| call("Times", fs);
   let pow = |b: Expr, e: i128| pow2(b, Expr::Integer(e));
   let i_unit = || Expr::Identifier("I".to_string());
-  let pi = || Expr::Constant("Pi".to_string());
+  let pi = || const_expr("Pi");
 
   let (c0, c1, c2, c3) = (coeff(0), coeff(1), coeff(2), coeff(3));
 
@@ -1210,7 +1210,7 @@ pub fn fourier_sin_cos_coefficient_ast(
   let times = |fs: Vec<Expr>| call("Times", fs);
   let plus = |ts: Vec<Expr>| call("Plus", ts);
   let pow = |b: Expr, e: i128| pow2(b, Expr::Integer(e));
-  let pi = || Expr::Constant("Pi".to_string());
+  let pi = || const_expr("Pi");
   let n_e = || n_arg.clone();
   let m1 = || pow2(Expr::Integer(-1), n_arg.clone());
   let scaled = |base: i128| -> Expr {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -62,3 +62,7 @@ pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
 pub fn bool_expr(b: bool) -> Expr {
   Expr::Identifier(if b { "True" } else { "False" }.to_string())
 }
+
+pub fn const_expr(name: &str) -> Expr {
+  Expr::Constant(name.to_string())
+}


### PR DESCRIPTION
This PR adds a const_expr helper, which replaces Expr::Constant("Foo".to_string()) with const_expr("Foo"). It also applies the call helpers where the const_expr changes exposed more opportunities to use them.