### PR TITLE
Introduce fn id_expr helper

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -495,10 +495,7 @@ fn structural_subsumes(a: &[Expr], b: &[Expr]) -> Option<bool> {
   }
   let frozen_a = freeze_patterns(a)?;
   let frozen_b = freeze_patterns(b)?;
-  let as_call = |args: &[Expr]| Expr::FunctionCall {
-    name: "Woxi`RuleShape".to_string(),
-    args: args.to_vec().into(),
-  };
+  let as_call = |args: &[Expr]| call("Woxi`RuleShape", args.to_vec());
   let b_covers_a = crate::evaluator::pattern_matching::match_pattern(
     &as_call(&frozen_a),
     &as_call(b),
@@ -1461,7 +1458,7 @@ fn set_attributes_from_value(sym_name: &str, rhs_value: &Expr) -> Expr {
   }
 
   let Some(valid_attrs) = get_attributes(rhs_value) else {
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   };
 
   // Replace all user-defined attributes for this symbol
@@ -1524,10 +1521,7 @@ fn set_extended_full_definition(
         if !matches!(&**pattern, Expr::Identifier(n) if n == head) {
           continue;
         }
-        let section_lhs = Expr::FunctionCall {
-          name: (*head).to_string(),
-          args: vec![Expr::Identifier(target.clone())].into(),
-        };
+        let section_lhs = call1(head, Expr::Identifier(target.clone()));
         set_ast(&section_lhs, replacement)?;
       }
     }
@@ -1611,7 +1605,7 @@ fn set_upvalues_from_rules(
     };
     tag_set_delayed_ast(&tag, &pattern_lhs, &body, false)?;
   }
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Install `rules` as the own value of `sym` — the single
@@ -1635,7 +1629,7 @@ fn set_ownvalues_from_rules(
     };
     set_ast(&Expr::Identifier(sym.to_string()), &replacement)?;
   }
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Helper for `DownValues[f] = rules` / `DownValues[f] := rules` (and the
@@ -1997,10 +1991,7 @@ fn try_assignment_upvalue(
   if tags.is_empty() {
     return None;
   }
-  let actual = Expr::FunctionCall {
-    name: head.to_string(),
-    args: vec![lhs.clone(), rhs.clone()].into(),
-  };
+  let actual = call(head, vec![lhs.clone(), rhs.clone()]);
   for tag in tags {
     let Some(entries) = crate::UPVALUES.with(|m| m.borrow().get(&tag).cloned())
     else {
@@ -2448,9 +2439,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         _ => None,
       };
       if let Some(prec_real) = as_real {
-        Expr::List(
-          vec![prec_real, Expr::Identifier("Infinity".to_string())].into(),
-        )
+        Expr::List(vec![prec_real, id_expr("Infinity")].into())
       } else {
         // Non-numeric precision (`N[a, p_?test] := …` style) — keep
         // the user's spec verbatim, mirroring Wolfram's HoldPattern
@@ -2459,11 +2448,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       }
     } else {
       Expr::List(
-        vec![
-          Expr::Identifier("MachinePrecision".to_string()),
-          Expr::Identifier("MachinePrecision".to_string()),
-        ]
-        .into(),
+        vec![id_expr("MachinePrecision"), id_expr("MachinePrecision")].into(),
       )
     };
     let canonical_lhs =
@@ -3173,7 +3158,7 @@ pub fn set_delayed_ast(
           }
         }
       });
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
   }
 
@@ -3199,7 +3184,7 @@ pub fn set_delayed_ast(
         t,
         expr_to_string(lhs)
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
   }
 
@@ -3264,7 +3249,7 @@ pub fn set_delayed_ast(
     if matches!(&result, Expr::Identifier(s) if s == "$Failed") {
       return Ok(result);
     }
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Handle `NValues[sym] := rules` — same store as the Set form,
@@ -3310,7 +3295,7 @@ pub fn set_delayed_ast(
       let mut map = m.borrow_mut();
       map.insert(sym_name.clone(), entries);
     });
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // `Format[expr, FORM] := …` (or its UpSet/UpSetDelayed cousins) registers
@@ -3348,7 +3333,7 @@ pub fn set_delayed_ast(
           ));
         });
       }
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
   }
 
@@ -3365,7 +3350,7 @@ pub fn set_delayed_ast(
     let rhs_value = evaluate_expr_to_expr(body)?;
     let clear_head = clear_replaced_values(func_name, sym_name);
     set_downvalues_from_rules(&rhs_value, clear_head)?;
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Handle Options[f] := rules — same as Options[f] = rules (SetDelayed
@@ -3384,7 +3369,7 @@ pub fn set_delayed_ast(
     crate::FUNC_OPTIONS_DELAYED.with(|m| {
       m.borrow_mut().insert(sym_name.clone());
     });
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Handle UpValues[sym] := rules — same as `UpValues[sym] = rules`.
@@ -3432,7 +3417,7 @@ pub fn set_delayed_ast(
       crate::emit_message(&format!(
         "SetDelayed::write: Tag {func_name} in {lhs_str} is Protected."
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
 
     let mut params = Vec::new();
@@ -3928,7 +3913,7 @@ pub fn set_delayed_ast(
       });
     });
 
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Handle simple identifier assignment: a := expr (OwnValues)
@@ -3941,7 +3926,7 @@ pub fn set_delayed_ast(
       ));
       // wolframscript returns `$Failed` (not `Null`) from a rejected
       // `SetDelayed`, unlike `Set`, which returns its right-hand side.
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     // If a `/; cond` clause was stripped from the LHS (or RHS), wrap the
     // body in `Condition[body, cond]` so the lookup can re-check the
@@ -3956,7 +3941,7 @@ pub fn set_delayed_ast(
       e.borrow_mut()
         .insert(var_name.clone(), StoredValue::ExprVal(stored_body))
     });
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // SubValue form: f[a][b] := rhs (also deeper nestings like f[a][b][c])
@@ -3997,7 +3982,7 @@ pub fn set_delayed_ast(
           None => rules.push((evaluated_lhs, body.clone())),
         }
       });
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
   }
 
@@ -4030,7 +4015,7 @@ fn list_element_accessor(
     Expr::FunctionCall {
       name: "Apply".to_string(),
       args: vec![
-        Expr::Identifier("Sequence".to_string()),
+        id_expr("Sequence"),
         call("Drop", vec![base.clone(), Expr::Integer(idx as i128)]),
       ]
       .into(),
@@ -4151,7 +4136,7 @@ fn collect_element_bindings(
                   Expr::FunctionCall {
                     name: "Apply".to_string(),
                     args: vec![
-                      Expr::Identifier("Sequence".to_string()),
+                      id_expr("Sequence"),
                       call(
                         "Drop",
                         vec![accessor.clone(), Expr::Integer(k as i128)],
@@ -4584,7 +4569,7 @@ pub fn downvalue_param_pattern(
   if name.starts_with("__opts") {
     return call(
       "Pattern",
-      vec![Expr::Identifier(name), call("OptionsPattern", Vec::new())],
+      vec![Expr::Identifier(name), call0("OptionsPattern")],
     );
   }
   Expr::Pattern {
@@ -4895,11 +4880,7 @@ pub fn tag_set_delayed_ast(
       },
       expr_to_string(lhs)
     ));
-    return Ok(if evaluate_rhs {
-      body
-    } else {
-      Expr::Identifier("$Failed".to_string())
-    });
+    return Ok(if evaluate_rhs { body } else { fail_expr() });
   }
 
   // Extract Condition from body: Condition[actual_body, test] → (actual_body, Some(test))
@@ -5275,7 +5256,7 @@ pub fn tag_set_delayed_ast(
   if evaluate_rhs {
     Ok(body)
   } else {
-    Ok(Expr::Identifier("Null".to_string()))
+    Ok(null_expr())
   }
 }
 
@@ -5297,10 +5278,10 @@ pub fn tag_unset_ast(tag: &Expr, lhs: &Expr) -> Result<Expr, InterpreterError> {
       if let Expr::FunctionCall { name, .. } = func.as_ref() {
         name.clone()
       } else {
-        return Ok(Expr::Identifier("Null".to_string()));
+        return Ok(null_expr());
       }
     }
-    _ => return Ok(Expr::Identifier("Null".to_string())),
+    _ => return Ok(null_expr()),
   };
 
   let lhs_str = expr_to_string(lhs);
@@ -5350,7 +5331,7 @@ pub fn tag_unset_ast(tag: &Expr, lhs: &Expr) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Convert parser-level BinaryOp/UnaryOp/Comparison nodes that may appear on
@@ -5429,19 +5410,13 @@ pub fn upset_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         _ => None,
       };
       if let Some(prec_real) = as_real {
-        Expr::List(
-          vec![prec_real, Expr::Identifier("Infinity".to_string())].into(),
-        )
+        Expr::List(vec![prec_real, id_expr("Infinity")].into())
       } else {
         prec_eval
       }
     } else {
       Expr::List(
-        vec![
-          Expr::Identifier("MachinePrecision".to_string()),
-          Expr::Identifier("MachinePrecision".to_string()),
-        ]
-        .into(),
+        vec![id_expr("MachinePrecision"), id_expr("MachinePrecision")].into(),
       )
     };
     let canonical_lhs =
@@ -5537,7 +5512,7 @@ pub fn upset_delayed_ast(
   }
 
   // UpSetDelayed returns Null
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Drop every message (`sym::tag = "…"`) declared on `sym`. Messages live as

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -990,7 +990,7 @@ pub fn dispatch_attributes(
         _ => symbol_name(&args[0]).map(|n| vec![n]).unwrap_or_default(),
       };
       let Some(attr) = get_attributes(&args[1]) else {
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       };
 
       if !func_names.is_empty() {
@@ -1026,9 +1026,9 @@ pub fn dispatch_attributes(
           }
         });
         if locked {
-          return Some(Ok(Expr::Identifier("Null".to_string())));
+          return Some(Ok(null_expr()));
         }
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
     }
     "ClearAttributes" if args.len() == 2 => {
@@ -1085,7 +1085,7 @@ pub fn dispatch_attributes(
             }
           }
         });
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
     }
     "Protect" => {
@@ -1201,7 +1201,7 @@ pub fn dispatch_attributes(
           _ => {}
         }
       }
-      return Some(Ok(Expr::Identifier("Null".to_string())));
+      return Some(Ok(null_expr()));
     }
     "ClearAll" => {
       // `ClearAll` is `Block`'s localization without the putting-back: take
@@ -1230,7 +1230,7 @@ pub fn dispatch_attributes(
           _ => {}
         }
       }
-      return Some(Ok(Expr::Identifier("Null".to_string())));
+      return Some(Ok(null_expr()));
     }
     _ => {}
   }

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -494,7 +494,7 @@ pub fn named_color_expr(name: &str) -> Option<Expr> {
 pub fn style_directive_expr(name: &str) -> Option<Expr> {
   let thickness =
     |size: &str| call1("Thickness", Expr::Identifier(size.to_string()));
-  let small = || Expr::Identifier("Small".to_string());
+  let small = || id_expr("Small");
   let dashing =
     |segments: Vec<Expr>| call1("Dashing", Expr::List(segments.into()));
   Some(match name {
@@ -584,9 +584,9 @@ fn evaluate_expr_to_expr_early_dispatch(
     }
     "CompoundExpression" => {
       if args.is_empty() {
-        return Ok(Some(Expr::Identifier("Null".to_string())));
+        return Ok(Some(null_expr()));
       }
-      let mut result = Expr::Identifier("Null".to_string());
+      let mut result = null_expr();
       let mut start_index = 0;
       'goto_loop: loop {
         // `start_index` is reassigned on a Goto and only takes effect on the
@@ -628,10 +628,7 @@ fn evaluate_expr_to_expr_early_dispatch(
       } = &result
         && n == "Sequence"
       {
-        result = seq_args
-          .last()
-          .cloned()
-          .unwrap_or_else(|| Expr::Identifier("Null".to_string()));
+        result = seq_args.last().cloned().unwrap_or_else(null_expr);
       }
       return Ok(Some(result));
     }
@@ -649,7 +646,7 @@ fn evaluate_expr_to_expr_early_dispatch(
     }
     "RepeatedTiming" if args.len() == 1 => {
       let mut times = Vec::new();
-      let mut last_result = Expr::Identifier("Null".to_string());
+      let mut last_result = null_expr();
       let overall_start = web_time::Instant::now();
       for _ in 0..100 {
         let start = web_time::Instant::now();
@@ -1167,7 +1164,7 @@ pub fn evaluate_expr_to_expr_inner(
                 args[2].clone(),
               )));
             }
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // Condition didn't evaluate to True/False - return unevaluated
           let mut new_args = vec![cond];
@@ -1339,9 +1336,9 @@ pub fn evaluate_expr_to_expr_inner(
             if had_value.is_none() {
               // No OwnValue was set. Mathematica still returns Null for
               // 'foo =.' even if foo was never defined, so do the same.
-              return Ok(Expr::Identifier("Null".to_string()));
+              return Ok(null_expr());
             }
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // OwnValues[sym] =. clears the OwnValue for sym (equivalent to
           // sym =.). Wolfram returns Null whether or not the value was set.
@@ -1354,7 +1351,7 @@ pub fn evaluate_expr_to_expr_inner(
             && let Expr::Identifier(var_name) = &lhs_args[0]
           {
             ENV.with(|e| e.borrow_mut().remove(var_name));
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // SubValues[sym] =. and DownValues[sym] =. clear the corresponding
           // function definitions for sym. A SubValue rule (from `f[a][b] =
@@ -1377,7 +1374,7 @@ pub fn evaluate_expr_to_expr_inner(
                 m.borrow_mut().remove(sym_name);
               });
             }
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // UpValues[sym] =. removes every upvalue rule attached to
           // `sym`. Each rule lives in two places: `UPVALUES[sym]` (for
@@ -1393,7 +1390,7 @@ pub fn evaluate_expr_to_expr_inner(
             && let Expr::Identifier(sym_name) = &lhs_args[0]
           {
             crate::evaluator::assignment::clear_upvalues_of(sym_name);
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // Messages[sym] =. — Woxi has no per-symbol message storage
           // yet; treat as a no-op success.
@@ -1405,7 +1402,7 @@ pub fn evaluate_expr_to_expr_inner(
             && lhs_args.len() == 1
             && matches!(&lhs_args[0], Expr::Identifier(_))
           {
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // Pattern-based unset: f[args] =.
           // Requires a matching DownValue in FUNC_DEFS; otherwise Mathematica
@@ -1423,7 +1420,7 @@ pub fn evaluate_expr_to_expr_inner(
               crate::emit_message(&format!(
                 "Unset::norep: Assignment on {head} for {lhs_str} not found."
               ));
-              return Ok(Expr::Identifier("$Failed".to_string()));
+              return Ok(fail_expr());
             }
             // Reconstruct each entry's LHS pattern and remove only the entry
             // whose LHS matches the unset pattern. Two entries with the same
@@ -1491,12 +1488,12 @@ pub fn evaluate_expr_to_expr_inner(
               crate::emit_message(&format!(
                 "Unset::norep: Assignment on {head} for {lhs_str} not found."
               ));
-              return Ok(Expr::Identifier("$Failed".to_string()));
+              return Ok(fail_expr());
             }
             let _ = lhs_args;
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
-          return Ok(Expr::Identifier("Null".to_string()));
+          return Ok(null_expr());
         }
         // Definition and FullDefinition have HoldAll in Wolfram, so their
         // argument stays unevaluated. Information has no Hold attribute —
@@ -2063,7 +2060,7 @@ pub fn evaluate_expr_to_expr_inner(
         // Special handling for Return - raises ReturnValue to short-circuit evaluation
         if name == "Return" {
           let val = if args.is_empty() {
-            Expr::Identifier("Null".to_string())
+            null_expr()
           } else {
             evaluate_expr_to_expr(&args[0])?
           };
@@ -2129,8 +2126,7 @@ pub fn evaluate_expr_to_expr_inner(
               // Caught. With a third argument, apply f to value and tag.
               if args.len() == 3 {
                 let f = evaluate_expr_to_expr(&args[2])?;
-                let tag_expr = thrown_tag
-                  .map_or_else(|| Expr::Identifier("Null".to_string()), |t| *t);
+                let tag_expr = thrown_tag.map_or_else(null_expr, |t| *t);
                 let application = if let Expr::Identifier(fname) = &f {
                   Expr::FunctionCall {
                     name: fname.clone(),
@@ -2231,7 +2227,7 @@ pub fn evaluate_expr_to_expr_inner(
           } else if args.len() >= 3 {
             evaluate_expr_to_expr(&args[2])?
           } else {
-            Expr::Identifier("Null".to_string())
+            null_expr()
           };
           let value = evaluate_expr_to_expr(&args[0])?;
           let failure = match name.as_str() {
@@ -2335,7 +2331,7 @@ pub fn evaluate_expr_to_expr_inner(
               // this thread, so it can only fire where evaluation stops to
               // wait. wolframscript behaves the same way.
               crate::functions::socket_ast::pump_socket_events();
-              return Ok(Expr::Identifier("Null".to_string()));
+              return Ok(null_expr());
             }
             _ => {
               let shown = evaluated.as_ref().unwrap_or(&args[0]);
@@ -3717,7 +3713,7 @@ pub fn evaluate_expr_to_expr_inner(
       Ok(bool_expr(true))
     }
     Expr::CompoundExpr(exprs) => {
-      let mut result = Expr::Identifier("Null".to_string());
+      let mut result = null_expr();
       let mut start_index = 0;
       'goto_loop: loop {
         // `start_index` is reassigned on a Goto and only takes effect on the
@@ -3758,10 +3754,7 @@ pub fn evaluate_expr_to_expr_inner(
       } = &result
         && n == "Sequence"
       {
-        result = seq_args
-          .last()
-          .cloned()
-          .unwrap_or_else(|| Expr::Identifier("Null".to_string()));
+        result = seq_args.last().cloned().unwrap_or_else(null_expr);
       }
       Ok(result)
     }

--- a/src/evaluator/dispatch/audio_functions.rs
+++ b/src/evaluator/dispatch/audio_functions.rs
@@ -51,14 +51,10 @@ pub(super) fn dispatch_audio_functions(
     }
     // AudioCapture[] records from a microphone; this environment has no
     // audio input device, so it fails like wolframscript does headless.
-    "AudioCapture" if args.is_empty() => {
-      Some(Ok(Expr::Identifier("$Failed".to_string())))
-    }
+    "AudioCapture" if args.is_empty() => Some(Ok(fail_expr())),
     // WebAudioSearch requires the paid web audio search service; without
     // service credentials it fails.
-    "WebAudioSearch" if !args.is_empty() => {
-      Some(Ok(Expr::Identifier("$Failed".to_string())))
-    }
+    "WebAudioSearch" if !args.is_empty() => Some(Ok(fail_expr())),
     _ => None,
   }
 }

--- a/src/evaluator/dispatch/boolean_functions.rs
+++ b/src/evaluator/dispatch/boolean_functions.rs
@@ -68,7 +68,7 @@ pub fn dispatch_boolean_functions(
     }
     "Return" => {
       let val = if args.is_empty() {
-        Expr::Identifier("Null".to_string())
+        null_expr()
       } else {
         args[0].clone()
       };

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -647,7 +647,7 @@ pub fn dispatch_calculus_functions(
         if idx_u < coeffs.len() {
           return Some(Ok(coeffs[idx_u].clone()));
         }
-        return Some(Ok(Expr::Identifier("Indeterminate".to_string())));
+        return Some(Ok(id_expr("Indeterminate")));
       }
       // SeriesCoefficient[f, {x, x0, n}]
       if let Expr::List(spec) = &args[1]
@@ -2212,7 +2212,7 @@ fn dirac_delta_derivative(k: i128, t: &str) -> Expr {
   Expr::CurriedCall {
     func: Box::new(Expr::CurriedCall {
       func: Box::new(call("Derivative", vec![Expr::Integer(k)])),
-      args: vec![Expr::Identifier("DiracDelta".to_string())],
+      args: vec![id_expr("DiracDelta")],
     }),
     args: vec![t_id],
   }
@@ -2815,15 +2815,11 @@ fn mellin_transform(
     let result = make_times(vec![
       expr.clone(),
       Expr::Integer(2),
-      Expr::Identifier("Pi".to_string()),
-      Expr::FunctionCall {
-        name: "DiracDelta".to_string(),
-        args: vec![make_times(vec![
-          Expr::Identifier("I".to_string()),
-          s_expr.clone(),
-        ])]
-        .into(),
-      },
+      id_expr("Pi"),
+      call(
+        "DiracDelta",
+        vec![make_times(vec![id_expr("I"), s_expr.clone()])],
+      ),
     ]);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   };
@@ -2883,7 +2879,7 @@ fn inverse_mellin_inner(
   x: &Expr,
 ) -> Option<(Expr, bool)> {
   let neg = |e: Expr| make_times(vec![Expr::Integer(-1), e]);
-  let e_pow = |e: Expr| pow2(Expr::Identifier("E".to_string()), e);
+  let e_pow = |e: Expr| pow2(id_expr("E"), e);
   let is_s = |e: &Expr| matches!(e, Expr::Identifier(v) if v == sv);
   let is_pi = |e: &Expr| {
     matches!(e, Expr::Constant(c) if c == "Pi")
@@ -3216,11 +3212,8 @@ fn mellin_inner(expr: &Expr, x: &str, s: &Expr) -> Option<Expr> {
   let two_pi_delta = |arg: Expr| -> Expr {
     make_times(vec![
       Expr::Integer(2),
-      Expr::Identifier("Pi".to_string()),
-      call(
-        "DiracDelta",
-        vec![make_times(vec![Expr::Identifier("I".to_string()), arg])],
-      ),
+      id_expr("Pi"),
+      call("DiracDelta", vec![make_times(vec![id_expr("I"), arg])]),
     ])
   };
   let gamma = |arg: Expr| -> Expr { call1("Gamma", arg) };
@@ -3376,15 +3369,8 @@ fn mellin_inner(expr: &Expr, x: &str, s: &Expr) -> Option<Expr> {
         // displayed via Pi Csc[Pi t] when p == 1.
         let core = if matches!(p, Expr::Integer(1)) {
           make_times(vec![
-            Expr::Identifier("Pi".to_string()),
-            Expr::FunctionCall {
-              name: "Csc".to_string(),
-              args: vec![make_times(vec![
-                Expr::Identifier("Pi".to_string()),
-                s_eff.clone(),
-              ])]
-              .into(),
-            },
+            id_expr("Pi"),
+            call("Csc", vec![make_times(vec![id_expr("Pi"), s_eff.clone()])]),
           ])
         } else {
           make_times(vec![
@@ -3415,7 +3401,7 @@ fn mellin_inner(expr: &Expr, x: &str, s: &Expr) -> Option<Expr> {
             return None;
           }
           let half_pi_s = make_times(vec![
-            Expr::Identifier("Pi".to_string()),
+            id_expr("Pi"),
             s.clone(),
             call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
           ]);
@@ -3451,15 +3437,8 @@ fn mellin_inner(expr: &Expr, x: &str, s: &Expr) -> Option<Expr> {
             return None;
           }
           Some(make_times(vec![
-            Expr::Identifier("Pi".to_string()),
-            Expr::FunctionCall {
-              name: "Csc".to_string(),
-              args: vec![make_times(vec![
-                Expr::Identifier("Pi".to_string()),
-                s.clone(),
-              ])]
-              .into(),
-            },
+            id_expr("Pi"),
+            call("Csc", vec![make_times(vec![id_expr("Pi"), s.clone()])]),
             make_power(s.clone(), Expr::Integer(-1)),
           ]))
         }
@@ -3527,10 +3506,7 @@ fn mellin_inner(expr: &Expr, x: &str, s: &Expr) -> Option<Expr> {
               half.clone(),
               make_times(vec![half.clone(), s.clone()]),
             ])),
-            make_power(
-              make_sqrt(Expr::Identifier("Pi".to_string())),
-              Expr::Integer(-1),
-            ),
+            make_power(make_sqrt(id_expr("Pi")), Expr::Integer(-1)),
             make_power(s.clone(), Expr::Integer(-1)),
           ]))
         }
@@ -4663,9 +4639,9 @@ fn simplify_domain_constraint(constraint: &Expr, var: &str) -> Expr {
                 name: "Inequality".to_string(),
                 args: vec![
                   indexed[i].1.clone(),
-                  Expr::Identifier("Less".to_string()),
+                  id_expr("Less"),
                   var_expr.clone(),
-                  Expr::Identifier("Less".to_string()),
+                  id_expr("Less"),
                   indexed[i + 1].1.clone(),
                 ].into(),
               });
@@ -6425,7 +6401,7 @@ fn fourier_sin_cos_transform_inner(
       };
       return Some(make_plus(vec![
         Expr::Real(value),
-        make_times(vec![Expr::Real(0.0), Expr::Identifier("I".to_string())]),
+        make_times(vec![Expr::Real(0.0), id_expr("I")]),
       ]));
     }
     // Integer w branch: produce symbolic value.

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -70,7 +70,7 @@ pub fn dispatch_complex_and_special(
       }
       // If real part is 0 and imaginary is 1, return I
       if matches!(real, Expr::Integer(0)) && matches!(imag, Expr::Integer(1)) {
-        return Some(Ok(Expr::Identifier("I".to_string())));
+        return Some(Ok(id_expr("I")));
       }
       // If either component is inexact (Real/BigFloat) and the other is an
       // exact Integer/Rational, coerce the exact one to Real so the formed
@@ -116,17 +116,11 @@ pub fn dispatch_complex_and_special(
       if !imag_has_i {
         // If real part is 0, return b*I
         if matches!(real, Expr::Integer(0)) {
-          return Some(Ok(times2(
-            imag.clone(),
-            Expr::Identifier("I".to_string()),
-          )));
+          return Some(Ok(times2(imag.clone(), id_expr("I"))));
         }
         // If imaginary is 1, return a + I
         if matches!(imag, Expr::Integer(1)) {
-          return Some(Ok(plus2(
-            real.clone(),
-            Expr::Identifier("I".to_string()),
-          )));
+          return Some(Ok(plus2(real.clone(), id_expr("I"))));
         }
         // General case without I in imag. For concrete numeric components,
         // build a + b*I and EVALUATE it so the result lands in the canonical
@@ -145,7 +139,7 @@ pub fn dispatch_complex_and_special(
         if numeric_part(real) && numeric_part(imag) {
           let bi = match evaluate_function_call_ast(
             "Times",
-            &[imag.clone(), Expr::Identifier("I".to_string())],
+            &[imag.clone(), id_expr("I")],
           ) {
             Ok(v) => v,
             Err(e) => return Some(Err(e)),
@@ -157,7 +151,7 @@ pub fn dispatch_complex_and_special(
         // Plus/Times complex trees still works.
         return Some(Ok(plus2(
           real.clone(),
-          times2(imag.clone(), Expr::Identifier("I".to_string())),
+          times2(imag.clone(), id_expr("I")),
         )));
       }
       // Imaginary part contains I (iterated Complex), evaluate algebraically
@@ -191,7 +185,7 @@ pub fn dispatch_complex_and_special(
       // Fallback: build a + b*I expression and evaluate
       let bi = match evaluate_function_call_ast(
         "Times",
-        &[imag.clone(), Expr::Identifier("I".to_string())],
+        &[imag.clone(), id_expr("I")],
       ) {
         Ok(v) => v,
         Err(e) => return Some(Err(e)),
@@ -203,7 +197,7 @@ pub fn dispatch_complex_and_special(
         return Some(Ok(args[0].clone()));
       }
       Expr::Identifier(name) if name == "False" => {
-        return Some(Ok(Expr::Identifier("Undefined".to_string())));
+        return Some(Ok(id_expr("Undefined")));
       }
       _ => {
         return Some(Ok(unevaluated("ConditionalExpression", args)));
@@ -212,17 +206,17 @@ pub fn dispatch_complex_and_special(
     "DirectedInfinity" if args.len() <= 1 => {
       if args.is_empty() {
         // DirectedInfinity[] = ComplexInfinity
-        return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
+        return Some(Ok(id_expr("ComplexInfinity")));
       }
       match &args[0] {
         Expr::Integer(1) => {
-          return Some(Ok(Expr::Identifier("Infinity".to_string())));
+          return Some(Ok(id_expr("Infinity")));
         }
         Expr::Integer(-1) => {
-          return Some(Ok(neg1(Expr::Identifier("Infinity".to_string()))));
+          return Some(Ok(neg1(id_expr("Infinity"))));
         }
         Expr::Integer(0) => {
-          return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
+          return Some(Ok(id_expr("ComplexInfinity")));
         }
         _ => {
           // Real numeric arguments collapse to ±Infinity by sign.
@@ -232,12 +226,12 @@ pub fn dispatch_complex_and_special(
             && v.is_finite()
           {
             if v > 0.0 {
-              return Some(Ok(Expr::Identifier("Infinity".to_string())));
+              return Some(Ok(id_expr("Infinity")));
             }
             if v < 0.0 {
-              return Some(Ok(neg1(Expr::Identifier("Infinity".to_string()))));
+              return Some(Ok(neg1(id_expr("Infinity"))));
             }
-            return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
+            return Some(Ok(id_expr("ComplexInfinity")));
           }
           // Try to normalize: DirectedInfinity[z] -> DirectedInfinity[z/Abs[z]]
           if let Some(((re_n, re_d), (im_n, im_d))) =
@@ -246,13 +240,13 @@ pub fn dispatch_complex_and_special(
             if im_n == 0 {
               // Pure real: just check sign
               if re_n > 0 {
-                return Some(Ok(Expr::Identifier("Infinity".to_string())));
+                return Some(Ok(id_expr("Infinity")));
               } else if re_n < 0 {
                 return Some(Ok(neg1(Expr::Identifier(
                   "Infinity".to_string(),
                 ))));
               }
-              return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
+              return Some(Ok(id_expr("ComplexInfinity")));
             }
             // Compute magnitude squared: (re_n/re_d)^2 + (im_n/im_d)^2
             let mag_sq_num = re_n
@@ -286,7 +280,7 @@ pub fn dispatch_complex_and_special(
               };
               // Check if normalized reduced to 1 or -1
               if matches!(&normalized, Expr::Integer(1)) {
-                return Some(Ok(Expr::Identifier("Infinity".to_string())));
+                return Some(Ok(id_expr("Infinity")));
               }
               if matches!(&normalized, Expr::Integer(-1)) {
                 return Some(Ok(neg1(Expr::Identifier(
@@ -338,7 +332,7 @@ pub fn dispatch_complex_and_special(
               let nim = im / mag;
               if nim == 0.0 {
                 if nre > 0.0 {
-                  return Some(Ok(Expr::Identifier("Infinity".to_string())));
+                  return Some(Ok(id_expr("Infinity")));
                 }
                 if nre < 0.0 {
                   return Some(Ok(neg1(Expr::Identifier(
@@ -348,8 +342,7 @@ pub fn dispatch_complex_and_special(
               }
               // Build `re + im*I` so the regular Times printer handles
               // sign placement and `0. + r*I` Re/Im split.
-              let im_term =
-                times2(Expr::Real(nim), Expr::Identifier("I".to_string()));
+              let im_term = times2(Expr::Real(nim), id_expr("I"));
               let direction = plus2(Expr::Real(nre), im_term);
               let direction = match evaluate_expr_to_expr(&direction) {
                 Ok(v) => v,
@@ -448,7 +441,7 @@ pub fn dispatch_complex_and_special(
         if args.len() == 3 {
           return Some(crate::evaluator::evaluate_expr_to_expr(&args[2]));
         }
-        return Some(Ok(Expr::Identifier("$Aborted".to_string())));
+        return Some(Ok(id_expr("$Aborted")));
       }
       return Some(result);
     }
@@ -484,7 +477,7 @@ pub fn dispatch_complex_and_special(
         if args.len() == 3 {
           return Some(crate::evaluator::evaluate_expr_to_expr(&args[2]));
         }
-        return Some(Ok(Expr::Identifier("$Aborted".to_string())));
+        return Some(Ok(id_expr("$Aborted")));
       }
       return Some(result);
     }
@@ -649,14 +642,10 @@ pub fn dispatch_complex_and_special(
             name: "InformationDataGrid".to_string(),
             args: vec![
               Expr::List(
-                vec![Expr::FunctionCall {
-                  name: "Rule".to_string(),
-                  args: vec![
-                    Expr::Identifier("System`".to_string()),
-                    Expr::List(matching.into()),
-                  ]
-                  .into(),
-                }]
+                vec![call(
+                  "Rule",
+                  vec![id_expr("System`"), Expr::List(matching.into())],
+                )]
                 .into(),
               ),
               bool_expr(is_full),
@@ -691,7 +680,7 @@ pub fn dispatch_complex_and_special(
       let tags: Vec<Expr> = match args.get(1) {
         Some(Expr::List(items)) => items.to_vec(),
         Some(t) => vec![t.clone()],
-        None => vec![Expr::Identifier("None".to_string())],
+        None => vec![id_expr("None")],
       };
       crate::SOW_STACK.with(|stack| {
         let mut stack = stack.borrow_mut();
@@ -1269,7 +1258,7 @@ pub fn dispatch_complex_and_special(
               crate::functions::mesh_region::mesh_measure(&mesh)
                 .unwrap_or_else(|| unevaluated(name, args))
             } else if (*d as usize) < mesh.dimension() {
-              Expr::Identifier("Infinity".to_string())
+              id_expr("Infinity")
             } else {
               Expr::Integer(0)
             }
@@ -1630,13 +1619,11 @@ pub fn dispatch_complex_and_special(
     // formula over a temporary variable and rewrite it to a `#1`-slot
     // function so it composes with Map etc.
     "FindSequenceFunction" if args.len() == 1 => {
-      let formula = match find_sequence_function(
-        &args[0],
-        &Expr::Identifier("\u{f3a7}fsfvar".to_string()),
-      ) {
-        Ok(f) => f,
-        Err(e) => return Some(Err(e)),
-      };
+      let formula =
+        match find_sequence_function(&args[0], &id_expr("\u{f3a7}fsfvar")) {
+          Ok(f) => f,
+          Err(e) => return Some(Err(e)),
+        };
       // If the formula couldn't be found it comes back as the unevaluated
       // 2-arg call; keep the operator form unevaluated in that case.
       if let Expr::FunctionCall {
@@ -2969,10 +2956,8 @@ fn box_subexpr_via_user_rules(expr: &Expr) -> Expr {
     let has_format_rule = crate::evaluator::assignment::FORMAT_VALUES
       .with(|m| m.borrow().contains_key(head));
     if has_format_rule {
-      let format_call = call(
-        "Format",
-        vec![expr.clone(), Expr::Identifier("StandardForm".to_string())],
-      );
+      let format_call =
+        call("Format", vec![expr.clone(), id_expr("StandardForm")]);
       if let Ok(formatted) =
         crate::evaluator::evaluate_expr_to_expr(&format_call)
       {
@@ -2999,10 +2984,7 @@ fn box_subexpr_via_user_rules(expr: &Expr) -> Expr {
   if !has_user_rule {
     return expr_to_box_form(expr);
   }
-  let call = call(
-    "MakeBoxes",
-    vec![expr.clone(), Expr::Identifier("StandardForm".to_string())],
-  );
+  let call = call("MakeBoxes", vec![expr.clone(), id_expr("StandardForm")]);
   match crate::evaluator::evaluate_expr_to_expr(&call) {
     Ok(result) => result,
     Err(_) => expr_to_box_form(expr),
@@ -3929,13 +3911,13 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
                 replacement: Box::new(bool_expr(true)),
               },
               Expr::Rule {
-                pattern: Box::new(Expr::Identifier("NumberMarks".to_string())),
+                pattern: Box::new(id_expr("NumberMarks")),
                 replacement: Box::new(bool_expr(true)),
               },
             ]
             .into(),
           },
-          Expr::Identifier("FullForm".to_string()),
+          id_expr("FullForm"),
         ]
         .into(),
       }
@@ -3971,7 +3953,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           call("FormBox", vec![inner_box, Expr::Identifier(name.clone())]),
           Expr::Identifier(name.clone()),
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("Editable".to_string())),
+            pattern: Box::new(id_expr("Editable")),
             replacement: Box::new(bool_expr(true)),
           },
         ]
@@ -4009,7 +3991,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
       let form_box =
         call("FormBox", vec![inner_box, Expr::Identifier(form_name)]);
       let tag = if args.len() == 1 {
-        Expr::Identifier("Format".to_string())
+        id_expr("Format")
       } else {
         // `#1 &` — an anonymous Function with body Slot(1).
         Expr::Function {
@@ -4049,11 +4031,11 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
             args: vec![args[0].clone()].into(),
           },
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("Editable".to_string())),
+            pattern: Box::new(id_expr("Editable")),
             replacement: Box::new(bool_expr(true)),
           },
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("AutoDelete".to_string())),
+            pattern: Box::new(id_expr("AutoDelete")),
             replacement: Box::new(bool_expr(true)),
           },
         ]
@@ -4153,7 +4135,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
                 pattern: Box::new(Expr::Identifier(
                   "BaselinePosition".to_string(),
                 )),
-                replacement: Box::new(Expr::Identifier("Baseline".to_string())),
+                replacement: Box::new(id_expr("Baseline")),
               },
             ]
             .into(),
@@ -4165,7 +4147,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           // substitution we used for the PaneBox text.
           call1("OutputForm", replace_graphics_with_placeholder(&args[0])),
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("Editable".to_string())),
+            pattern: Box::new(id_expr("Editable")),
             replacement: Box::new(bool_expr(false)),
           },
         ]
@@ -4201,7 +4183,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
                 replacement: Box::new(bool_expr(true)),
               },
               Expr::Rule {
-                pattern: Box::new(Expr::Identifier("NumberMarks".to_string())),
+                pattern: Box::new(id_expr("NumberMarks")),
                 replacement: Box::new(bool_expr(true)),
               },
             ]
@@ -4209,11 +4191,11 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           },
           call1("InputForm", args[0].clone()),
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("Editable".to_string())),
+            pattern: Box::new(id_expr("Editable")),
             replacement: Box::new(bool_expr(true)),
           },
           Expr::Rule {
-            pattern: Box::new(Expr::Identifier("AutoDelete".to_string())),
+            pattern: Box::new(id_expr("AutoDelete")),
             replacement: Box::new(bool_expr(true)),
           },
         ]
@@ -5116,10 +5098,9 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
   match name {
     // `HoldForm` leaves a mark on the box tree — a `TagBox` naming it — so
     // the boxes still say the expression was held; it draws as its content.
-    "HoldForm" if args.len() == 1 => call(
-      "TagBox",
-      vec![tf(&args[0]), Expr::Identifier("HoldForm".into())],
-    ),
+    "HoldForm" if args.len() == 1 => {
+      call("TagBox", vec![tf(&args[0]), id_expr("HoldForm")])
+    }
     // Wrappers that only hold or re-label their content: typeset what is
     // inside them.
     "HoldComplete" | "HoldCompleteForm" | "Defer" | "Identity"
@@ -5135,8 +5116,8 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
       let mut style_args = vec![tf_display(&args[0])];
       style_args.extend(args[1..].iter().cloned());
       style_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("StripOnInput".into())),
-        replacement: Box::new(Expr::Identifier("False".into())),
+        pattern: Box::new(id_expr("StripOnInput")),
+        replacement: Box::new(bool_expr(false)),
       });
       call("StyleBox", style_args)
     }
@@ -7622,7 +7603,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
       // Unbounded regions have infinite measure in their intrinsic dimension.
       "HalfPlane" | "InfinitePlane" | "HalfLine" | "InfiniteLine"
       | "HalfSpace" | "ConicHullRegion" => {
-        return Ok(Expr::Identifier("Infinity".to_string()));
+        return Ok(id_expr("Infinity"));
       }
       // Parallelogram[p, {v1, v2}] — the area spanned by v1 and v2 is
       // Sqrt[Det of the Gram matrix] = Sqrt[(v1.v1)(v2.v2) - (v1.v2)^2],
@@ -7970,8 +7951,8 @@ fn compute_region_bounds(expr: &Expr) -> Expr {
     && let (Expr::List(p1), Expr::List(p2)) = (&points[0], &points[1])
     && p1.len() == p2.len()
   {
-    let inf = || Expr::Identifier("Infinity".to_string());
-    let neg_inf = || neg1(Expr::Identifier("Infinity".to_string()));
+    let inf = || id_expr("Infinity");
+    let neg_inf = || neg1(id_expr("Infinity"));
     let mut bounds = Vec::with_capacity(p1.len());
     for (a, b) in p1.iter().zip(p2.iter()) {
       let diff = call("Subtract", vec![b.clone(), a.clone()]);
@@ -9624,7 +9605,7 @@ fn platonic_scaled_metric(
 /// Sphere, Disk, Triangle, and 2-D Cuboid/Ball).
 fn compute_surface_area(expr: &Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = || Ok(call1("SurfaceArea", expr.clone()));
-  let undefined = || Ok(Expr::Identifier("Undefined".to_string()));
+  let undefined = || Ok(id_expr("Undefined"));
   let Expr::FunctionCall { name, args } = expr else {
     return unevaluated();
   };
@@ -10032,7 +10013,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
         if p.len() == 3 {
           Ok(Expr::Integer(1))
         } else {
-          Ok(Expr::Identifier("Undefined".to_string()))
+          Ok(id_expr("Undefined"))
         }
       }
       2 => {
@@ -10043,7 +10024,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
           return Ok(call1("Volume", expr.clone()));
         }
         if p1.len() != 3 {
-          return Ok(Expr::Identifier("Undefined".to_string()));
+          return Ok(id_expr("Undefined"));
         }
         // Build (p2_i - p1_i) for each dimension and take Abs of the product.
         let diffs: Vec<Expr> = p1
@@ -10073,7 +10054,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
   // Volume is the 3-dimensional measure, so it is only defined for solids of
   // intrinsic dimension 3. Lower-dimensional regions (and surfaces) return
   // Undefined; 3-D balls and ellipsoids get their closed-form volume.
-  let undefined = || Ok(Expr::Identifier("Undefined".to_string()));
+  let undefined = || Ok(id_expr("Undefined"));
   if let Expr::FunctionCall { name, args } = expr {
     match name.as_str() {
       // Ball[c, r] — the solid n-ball. Volume is defined only in 3-D, where
@@ -10198,7 +10179,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
               factorial_small(3),
             ))
           } else {
-            Ok(Expr::Identifier("Undefined".to_string()))
+            Ok(id_expr("Undefined"))
           };
         }
         if let Expr::List(pts) = &args[0]
@@ -10370,7 +10351,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           && matches!((&args[0], &args[1]),
             (Expr::List(c), Expr::List(r)) if c.len() == r.len() && c.len() != 2) =>
       {
-        Ok(Expr::Identifier("Undefined".to_string()))
+        Ok(id_expr("Undefined"))
       }
       // Rectangle[] = 1, Rectangle[{x1,y1}] = 1, Rectangle[{x1,y1}, {x2,y2}] = |x2-x1| * |y2-y1|
       "Rectangle" => {
@@ -10571,7 +10552,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           if matches!(&filled, Expr::Integer(0))
             || matches!(&filled, Expr::Real(v) if *v == 0.0)
           {
-            return Ok(Expr::Identifier("Undefined".to_string()));
+            return Ok(id_expr("Undefined"));
           }
           // Holes that degenerate the same way simply cut nothing out.
           let mut terms = vec![filled];
@@ -10607,7 +10588,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           return Ok(call1("Area", expr.clone()));
         };
         if d < 0.0 {
-          return Ok(Expr::Identifier("Undefined".to_string()));
+          return Ok(id_expr("Undefined"));
         }
         let factor = call("Times", vec![rx, ry]);
         const TWO_PI: f64 = std::f64::consts::TAU;
@@ -10647,11 +10628,11 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         crate::evaluator::evaluate_expr_to_expr(&area)
       }
       // Circle has no area (it's 1D)
-      "Circle" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Circle" => Ok(id_expr("Undefined")),
       // A Tetrahedron is a 3-D solid, so its 2-area is Undefined.
-      "Tetrahedron" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Tetrahedron" => Ok(id_expr("Undefined")),
       // Prism and Pyramid are 3-D solids: their 2-area is Undefined.
-      "Prism" | "Pyramid" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Prism" | "Pyramid" => Ok(id_expr("Undefined")),
       // A Parallelogram is always a planar (2-D) region, so its Area equals
       // its RegionMeasure. Delegate to keep the two in sync. A two-vector
       // Parallelepiped is likewise planar; any other Parallelepiped is a
@@ -10666,7 +10647,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           expr.clone(),
         ))
       }
-      "Parallelepiped" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Parallelepiped" => Ok(id_expr("Undefined")),
       // Simplex[{p0, p1, p2}] in the plane — the triangle area |Det[edges]|/2.
       // A higher-dimensional simplex has Undefined 2-area.
       "Simplex" if args.len() == 1 => {
@@ -10678,7 +10659,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
           return if *n == 2 {
             Ok(crate::functions::math_ast::make_rational(1, 2))
           } else {
-            Ok(Expr::Identifier("Undefined".to_string()))
+            Ok(id_expr("Undefined"))
           };
         }
         if let Expr::List(pts) = &args[0]
@@ -10687,7 +10668,7 @@ fn compute_area(expr: &Expr) -> Result<Expr, InterpreterError> {
         {
           det_measure(edges, 2)
         } else if matches!(&args[0], Expr::List(pts) if pts.len() != 3) {
-          Ok(Expr::Identifier("Undefined".to_string()))
+          Ok(id_expr("Undefined"))
         } else {
           Ok(call1("Area", expr.clone()))
         }
@@ -11168,8 +11149,7 @@ fn compute_region_centroid(expr: &Expr) -> Result<Expr, InterpreterError> {
       "HalfSpace" if half_space_parts(args).is_some() => {
         let (normal, _) = half_space_parts(args).unwrap();
         Ok(Expr::List(
-          vec![Expr::Identifier("Indeterminate".to_string()); normal.len()]
-            .into(),
+          vec![id_expr("Indeterminate"); normal.len()].into(),
         ))
       }
       // DiskSegment — the segment centroid lies on the angular bisector
@@ -12054,7 +12034,7 @@ fn compute_arc_length(expr: &Expr) -> Result<Expr, InterpreterError> {
       }
       // Unbounded 1-D regions have infinite arc length.
       "HalfLine" | "InfiniteLine" if !args.is_empty() => {
-        Ok(Expr::Identifier("Infinity".to_string()))
+        Ok(id_expr("Infinity"))
       }
       // Line[{{x1,y1},{x2,y2},...}] -> sum of segment lengths
       "Line" => {
@@ -12069,7 +12049,7 @@ fn compute_arc_length(expr: &Expr) -> Result<Expr, InterpreterError> {
       // Other filled regions (Disk, Polygon, Triangle, Rectangle, Ball,
       // Ellipsoid) are not curves, so their arc length is Undefined.
       "Disk" | "Polygon" | "Triangle" | "Rectangle" | "Ball" | "Ellipsoid" => {
-        Ok(Expr::Identifier("Undefined".to_string()))
+        Ok(id_expr("Undefined"))
       }
       // Simplex[n]: only the 1-simplex is a curve, with arc length 1; every
       // other standard simplex is a filled region, so its arc length is
@@ -12084,7 +12064,7 @@ fn compute_arc_length(expr: &Expr) -> Result<Expr, InterpreterError> {
         if *n == 1 {
           Ok(Expr::Integer(1))
         } else {
-          Ok(Expr::Identifier("Undefined".to_string()))
+          Ok(id_expr("Undefined"))
         }
       }
       _ => unevaluated(),
@@ -12176,7 +12156,7 @@ fn compute_perimeter(expr: &Expr) -> Result<Expr, InterpreterError> {
         crate::evaluator::evaluate_expr_to_expr(&perimeter)
       }
       // Circle is a 1D curve, not a 2D region – Perimeter is Undefined
-      "Circle" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Circle" => Ok(id_expr("Undefined")),
       // Rectangle[{x1,y1},{x2,y2}] -> 2*(|x2-x1| + |y2-y1|)
       "Rectangle" => {
         if args.is_empty() {
@@ -12251,7 +12231,7 @@ fn compute_perimeter(expr: &Expr) -> Result<Expr, InterpreterError> {
         unevaluated()
       }
       // Line is a 1D curve, Perimeter is Undefined
-      "Line" => Ok(Expr::Identifier("Undefined".to_string())),
+      "Line" => Ok(id_expr("Undefined")),
       _ => unevaluated(),
     },
     _ => unevaluated(),
@@ -12567,7 +12547,7 @@ fn compute_planar_angle(
     })
   };
   if is_zero(v1_comps) || is_zero(v2_comps) {
-    return Ok(Expr::Identifier("Indeterminate".to_string()));
+    return Ok(id_expr("Indeterminate"));
   }
 
   // Build dot product: v1.v2
@@ -13528,10 +13508,7 @@ fn compute_circular_arc_through(
   for point in &coords {
     let delta =
       |i: usize| call("Subtract", vec![point[i].clone(), centre[i].clone()]);
-    let turn = call(
-      "Times",
-      vec![Expr::Integer(2), Expr::Identifier("Pi".to_string())],
-    );
+    let turn = call("Times", vec![Expr::Integer(2), id_expr("Pi")]);
     angles.push(eval_call(
       "Mod",
       vec![eval_call("ArcTan", vec![delta(0), delta(1)])?, turn],

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -226,7 +226,7 @@ pub fn dispatch_datetime_functions(
               Expr::List(vec![Expr::List(vec![start, end].into())].into()),
               Expr::String("Day".to_string()),
               Expr::String("Gregorian".to_string()),
-              Expr::Identifier("None".to_string()),
+              id_expr("None"),
             ]
             .into(),
           }));
@@ -273,9 +273,7 @@ pub fn dispatch_datetime_functions(
     "DateObject" => {
       // DateObject[] → current instant (same shape as `Now`)
       if args.is_empty() {
-        return Some(crate::evaluator::evaluate_expr_to_expr(
-          &Expr::Identifier("Now".to_string()),
-        ));
+        return Some(crate::evaluator::evaluate_expr_to_expr(&id_expr("Now")));
       }
       // `DateObject[date, granularity]` re-tags a date that is already a
       // `DateObject`: `DateObject[Now, "Hour"]` is the hour `Now` falls in,
@@ -323,7 +321,7 @@ pub fn dispatch_datetime_functions(
               inner_args
                 .get(3)
                 .cloned()
-                .unwrap_or_else(|| Expr::Identifier("None".to_string())),
+                .unwrap_or_else(|| id_expr("None")),
             );
           }
           return Some(Ok(call("DateObject", new_args)));

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -9,14 +9,10 @@ fn delete_missing_type(type_expr: &Expr) -> Expr {
     && name == "TypeSystem`Vector"
     && args.len() == 2
   {
-    return Expr::FunctionCall {
-      name: "TypeSystem`Vector".to_string(),
-      args: vec![
-        args[0].clone(),
-        Expr::Identifier("TypeSystem`AnyLength".to_string()),
-      ]
-      .into(),
-    };
+    return call(
+      "TypeSystem`Vector",
+      vec![args[0].clone(), id_expr("TypeSystem`AnyLength")],
+    );
   }
   type_expr.clone()
 }
@@ -1747,9 +1743,8 @@ fn evaluate_function_call_ast_inner(
     && matches!(&args[position], Expr::Identifier(s) | Expr::Constant(s) if s == "All")
   {
     let mut rewritten = args.to_vec();
-    rewritten[position] = Expr::List(
-      vec![Expr::Integer(0), Expr::Identifier("Infinity".to_string())].into(),
-    );
+    rewritten[position] =
+      Expr::List(vec![Expr::Integer(0), id_expr("Infinity")].into());
     return evaluate_function_call_ast(name, &rewritten);
   }
 
@@ -2199,7 +2194,7 @@ fn evaluate_function_call_ast_inner(
   if name == "EndPackage" && args.is_empty() {
     if !crate::has_package_context() {
       crate::emit_message("EndPackage::noctx: No previous context defined.");
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     crate::pop_context();
     if let Some(active) = crate::pop_context_path() {
@@ -2225,7 +2220,7 @@ fn evaluate_function_call_ast_inner(
       }
       crate::push_context_path(merged);
     }
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Needs["pkg`"] loads the file providing the context — from a paclet in a
@@ -2327,11 +2322,11 @@ fn evaluate_function_call_ast_inner(
     }
     if crate::utils::is_standard_distribution_context(ctx) {
       register_standard_context_symbols(ctx);
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     // An already-loaded context is not read a second time.
     if crate::packages_list().iter().any(|pkg| pkg == ctx) {
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -2364,7 +2359,7 @@ fn evaluate_function_call_ast_inner(
           "Get::noopen: Cannot open {requested}."
         ));
         crate::emit_message_to_stdout(&nocont);
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       };
       restore_path();
       result?;
@@ -2374,10 +2369,10 @@ fn evaluate_function_call_ast_inner(
         forget_alias();
         crate::emit_message_to_stdout(&nocont);
       }
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     #[cfg(target_arch = "wasm32")]
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
 
   // Package/message/system functions - no-op in Woxi, returns Null
@@ -2386,7 +2381,7 @@ fn evaluate_function_call_ast_inner(
     || name == "BeginPackage"
     || name == "ClearAttributes"
   {
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // Off[Head::tag, ...] / On[Head::tag, ...] — toggle message suppression.
@@ -2411,7 +2406,7 @@ fn evaluate_function_call_ast_inner(
         }
       }
     }
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
   // Remove[syms...] - fully remove the named symbols (drop env, defs,
   // attrs, options). Unlike Clear, a Removed symbol is gone from Names.
@@ -2431,7 +2426,7 @@ fn evaluate_function_call_ast_inner(
         crate::evaluator::assignment::remove_messages_of(sym);
       }
     }
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // SetOptions[f] (no rules) returns the current options of `f`, matching
@@ -2683,7 +2678,7 @@ fn evaluate_function_call_ast_inner(
             .into(),
         ),
         Expr::List(vec![Expr::Integer(0)].into()),
-        Expr::Identifier("MachinePrecision".to_string()),
+        id_expr("MachinePrecision"),
         Expr::String("Unevaluated".to_string()),
       ]
       .into(),
@@ -4621,7 +4616,7 @@ fn evaluate_function_call_ast_inner(
           if let Expr::Rule { pattern, .. } = opt
             && matches!(pattern.as_ref(), Expr::Identifier(n) if n == "Method")
           {
-            **pattern = Expr::Identifier("GraphLayout".to_string());
+            **pattern = id_expr("GraphLayout");
           }
         }
       }
@@ -4635,7 +4630,7 @@ fn evaluate_function_call_ast_inner(
           });
         }
         forwarded.push(Expr::Rule {
-          pattern: Box::new(Expr::Identifier("GraphLayout".to_string())),
+          pattern: Box::new(id_expr("GraphLayout")),
           replacement: Box::new(Expr::List(spec.into())),
         });
       }
@@ -4850,7 +4845,7 @@ fn evaluate_function_call_ast_inner(
     {
       ga.push(Expr::List(
         vec![Expr::Rule {
-          pattern: Box::new(Expr::Identifier("GraphLayout".to_string())),
+          pattern: Box::new(id_expr("GraphLayout")),
           replacement: Box::new(Expr::String("TutteEmbedding".to_string())),
         }]
         .into(),
@@ -6248,7 +6243,7 @@ fn evaluate_function_call_ast_inner(
       };
       let wdist_to_expr = |d: f64| -> Expr {
         if d.is_infinite() {
-          Expr::Identifier("Infinity".to_string())
+          id_expr("Infinity")
         } else {
           Expr::Real(d)
         }
@@ -6286,7 +6281,7 @@ fn evaluate_function_call_ast_inner(
 
     let dist_to_expr = |d: i128| -> Expr {
       if d < 0 {
-        Expr::Identifier("Infinity".to_string())
+        id_expr("Infinity")
       } else {
         Expr::Integer(d)
       }
@@ -6374,7 +6369,7 @@ fn evaluate_function_call_ast_inner(
 
     let dist_to_expr = |d: i128| -> Expr {
       if d < 0 {
-        Expr::Identifier("Infinity".to_string())
+        id_expr("Infinity")
       } else {
         Expr::Integer(d)
       }
@@ -6538,7 +6533,7 @@ fn evaluate_function_call_ast_inner(
       // graph is strongly connected (every vertex reaches every other).
       let strongly_connected =
         all_dists.iter().all(|d| d.iter().all(|&x| x >= 0));
-      let infinity = || Expr::Identifier("Infinity".to_string());
+      let infinity = || id_expr("Infinity");
 
       match name {
         "GraphDiameter" => {
@@ -9633,10 +9628,10 @@ fn evaluate_function_call_ast_inner(
           crate::emit_message(&format!(
             "DeleteFile::fdnfnd: Directory or file \"{path}\" not found."
           ));
-          return Ok(Expr::Identifier("$Failed".to_string()));
+          return Ok(fail_expr());
         }
       }
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     // Non-string / non-list-of-strings argument: emit the
     // wolframscript-style type-error message and leave the call
@@ -9667,7 +9662,7 @@ fn evaluate_function_call_ast_inner(
         crate::emit_message(&format!(
           "RenameFile::fdnfnd: Directory or file \"{abs}\" not found."
         ));
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
     }
   }
@@ -9686,20 +9681,20 @@ fn evaluate_function_call_ast_inner(
           "RenameDirectory::fdnfnd: Directory or file \"{}\" not found.",
           to_abs(source)
         ));
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
       if crate::vfs::exists(dest) {
         crate::emit_message(&format!(
           "RenameDirectory::eexist: {dest} already exists."
         ));
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
       match std::fs::rename(
         crate::vfs::resolve(source),
         crate::vfs::resolve(dest),
       ) {
         Ok(()) => return Ok(Expr::String(to_abs(dest))),
-        Err(_) => return Ok(Expr::Identifier("$Failed".to_string())),
+        Err(_) => return Ok(fail_expr()),
       }
     }
     return Ok(unevaluated("RenameDirectory", args));
@@ -9723,12 +9718,12 @@ fn evaluate_function_call_ast_inner(
       crate::emit_message(&format!(
         "DeleteDirectory::dirnf: Directory {path} not found."
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     match std::fs::remove_dir(&resolved) {
-      Ok(()) => return Ok(Expr::Identifier("Null".to_string())),
+      Ok(()) => return Ok(null_expr()),
       Err(_) => {
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
     }
   }
@@ -9744,18 +9739,18 @@ fn evaluate_function_call_ast_inner(
       crate::emit_message(&format!(
         "CopyFile::fdnfnd: Directory or file \"{abs}\" not found."
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     if crate::vfs::exists(dest) {
       crate::emit_message(&format!("CopyFile::eexist: {dest} already exists."));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     match std::fs::copy(crate::vfs::resolve(source), crate::vfs::resolve(dest))
     {
       Ok(_) => return Ok(Expr::String(dest.clone())),
       Err(e) => {
         crate::emit_message(&format!("CopyFile::failed: {e}"));
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
     }
   }
@@ -9797,7 +9792,7 @@ fn evaluate_function_call_ast_inner(
         |e| e.to_string(),
       );
       crate::emit_message(&format!("CreateDirectory::failed: {message}"));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     if args.len() == 1 {
       if let Expr::String(path) = &args[0] {
@@ -9805,18 +9800,18 @@ fn evaluate_function_call_ast_inner(
           crate::emit_message(&format!(
             "CreateDirectory::eexist: {path} already exists."
           ));
-          return Ok(Expr::Identifier("$Failed".to_string()));
+          return Ok(fail_expr());
         }
         match std::fs::create_dir_all(crate::vfs::resolve(path)) {
           Ok(()) => return Ok(Expr::String(path.clone())),
           Err(e) => {
             crate::emit_message(&format!("CreateDirectory::failed: {e}"));
-            return Ok(Expr::Identifier("$Failed".to_string()));
+            return Ok(fail_expr());
           }
         }
       }
       // Non-string argument
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
   }
 
@@ -10856,7 +10851,7 @@ fn evaluate_function_call_ast_inner(
       _ => return unevaluated(),
     };
     // Base angle theta0: explicit, or the default Pi/2 - (n-1)*Pi/n.
-    let pi = || Expr::Identifier("Pi".to_string());
+    let pi = || id_expr("Pi");
     let base = theta.unwrap_or_else(|| {
       minus2(
         div2(pi(), Expr::Integer(2)),
@@ -10951,7 +10946,7 @@ fn evaluate_function_call_ast_inner(
         print!("{contents}");
       }
       crate::capture_stdout(contents.trim_end_matches('\n'));
-      return Ok(Expr::Identifier("Null".to_string()));
+      return Ok(null_expr());
     }
     crate::emit_message(&format!("General::noopen: Cannot open {path}."));
     return Ok(unevaluated("FilePrint", args));
@@ -10994,7 +10989,7 @@ fn evaluate_function_call_ast_inner(
 
   // Neural network layer/model functions return $Failed for invalid arguments
   if matches!(name, "TotalLayer" | "NetEncoder") {
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
 
   // Morphological operations: Opening, Closing, Erosion, Dilation —
@@ -11131,7 +11126,7 @@ fn evaluate_function_call_ast_inner(
 
   // ClearSystemCache[] - no-op, returns Null
   if name == "ClearSystemCache" {
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
 
   // XML`Parser`XMLGetString[xml] — minimal stub: return an expression
@@ -11144,7 +11139,7 @@ fn evaluate_function_call_ast_inner(
     if let Expr::String(s) = &args[0]
       && !is_well_formed_xml(s)
     {
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
     return Ok(Expr::CurriedCall {
       func: Box::new(call1("XMLObject", Expr::String("Document".to_string()))),
@@ -13545,7 +13540,7 @@ fn bspline_structured(
     Expr::List(degrees.iter().map(|&d| Expr::Integer(d as i128)).collect());
   let closed: Expr = Expr::List((0..dim).map(|_| bool_expr(false)).collect());
   let mut net_slot: Vec<Expr> = net.to_vec();
-  net_slot.push(Expr::Identifier("Automatic".to_string()));
+  net_slot.push(id_expr("Automatic"));
   let knot_lists: Expr =
     Expr::List(knots.iter().map(|k| bspline_real_list(k)).collect());
   let zeros: Expr = Expr::List((0..dim).map(|_| Expr::Integer(0)).collect());
@@ -13559,7 +13554,7 @@ fn bspline_structured(
       Expr::List(net_slot.into()),
       knot_lists,
       zeros,
-      Expr::Identifier("MachinePrecision".to_string()),
+      id_expr("MachinePrecision"),
       Expr::String("Unevaluated".to_string()),
     ]
     .into(),

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -80,7 +80,7 @@ pub fn dispatch_evaluation_control(
       return Some(evaluate_expr_to_expr(&stripped));
     }
     "TimeRemaining" if args.is_empty() => {
-      return Some(Ok(Expr::Identifier("Infinity".to_string())));
+      return Some(Ok(id_expr("Infinity")));
     }
     "Out" => {
       // `Out[]` is `Out[-1]`, and a negative index counts back from the
@@ -872,7 +872,7 @@ pub fn dispatch_evaluation_control(
         if args.len() >= 3 {
           return Some(evaluate_expr_to_expr(&args[2]));
         }
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       } else if args.len() == 4 {
         return Some(evaluate_expr_to_expr(&args[3]));
       }

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -99,9 +99,7 @@ fn indexed_color_function(n: i128) -> Expr {
     args: vec![
       Expr::Integer(n),
       Expr::String("Indexed".to_string()),
-      Expr::List(
-        vec![Expr::Integer(1), Expr::Identifier("Infinity".to_string())].into(),
-      ),
+      Expr::List(vec![Expr::Integer(1), id_expr("Infinity")].into()),
       blend,
     ]
     .into(),
@@ -174,15 +172,8 @@ fn gradient_strip_image(controls: &[(f64, f64, f64)]) -> Expr {
       Expr::List(
         vec![
           option("ImageSize", Expr::Integer(250)),
-          option("ContentSelectable", Expr::Identifier("False".to_string())),
-          option(
-            "AspectRatio",
-            Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::Integer(1)),
-              right: Box::new(Expr::Integer(8)),
-            },
-          ),
+          option("ContentSelectable", bool_expr(false)),
+          option("AspectRatio", div2(Expr::Integer(1), Expr::Integer(8))),
           option(
             "PlotRange",
             Expr::List(vec![unit_corner(0, 1), unit_corner(0, 1)].into()),
@@ -336,7 +327,7 @@ fn import_svg(path: &str, is_url: bool) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "Import::nffil: File {path} not found during Import."
     ));
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
   let svg = import_read_text(path, is_url)?;
   Ok(crate::graphics_result(svg))
@@ -353,7 +344,7 @@ fn import_pdf_element(
     crate::emit_message(&format!(
       "Import::nffil: File {path} not found during Import."
     ));
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
   use crate::functions::pdf_import;
   let pages =
@@ -377,7 +368,7 @@ fn import_pdf_element(
         crate::emit_message(&format!(
           "Import::noelem: The Import element \"{e}\" is not present when importing as PDF."
         ));
-        Ok(Expr::Identifier("$Failed".to_string()))
+        Ok(fail_expr())
       }
     },
     // {"Pages", n} — one page, counted from 1.
@@ -397,14 +388,14 @@ fn import_pdf_element(
       crate::emit_message(&format!(
         "Import::noelem: The Import element {{\"Pages\", {n}}} is not present when importing as PDF."
       ));
-      Ok(Expr::Identifier("$Failed".to_string()))
+      Ok(fail_expr())
     }
     Some(other) => {
       crate::emit_message(&format!(
         "Import::noelem: The Import element {} is not present when importing as PDF.",
         crate::syntax::expr_to_string(other)
       ));
-      Ok(Expr::Identifier("$Failed".to_string()))
+      Ok(fail_expr())
     }
   }
 }
@@ -439,7 +430,7 @@ fn import_json(
   let content = import_read_text(path, is_url)?;
   Ok(match serde_json::from_str::<serde_json::Value>(&content) {
     Ok(value) => json_value_to_expr(&value, raw),
-    Err(_) => Expr::Identifier("$Failed".to_string()),
+    Err(_) => fail_expr(),
   })
 }
 
@@ -459,10 +450,10 @@ fn import_netpbm(path: &str) -> Expr {
     crate::emit_message_to_stdout(&format!(
       "Import::nffil: File {path} not found during Import."
     ));
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   }
   let Ok(bytes) = std::fs::read(crate::vfs::resolve(path)) else {
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   };
   // A valid Netpbm stream starts with `P1`..`P6` followed by whitespace.
   let valid_magic = bytes.len() >= 3
@@ -474,12 +465,12 @@ fn import_netpbm(path: &str) -> Expr {
     crate::emit_message_to_stdout(
       "Import::fmterr: Cannot import data as PPM format.",
     );
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   }
   // Magic looks plausible but Woxi doesn't yet parse Netpbm pixel data.
   // Return $Failed silently — matches wolframscript on a valid file when
   // parsing succeeds (no message; wolframscript returns `Image[…]`).
-  Expr::Identifier("$Failed".to_string())
+  fail_expr()
 }
 
 /// Import a host-registered virtual file (WASM). The browser host registers
@@ -523,7 +514,7 @@ fn import_virtual(
     let raw = matches!(element, Some("RawJSON"));
     return Ok(match serde_json::from_str::<serde_json::Value>(&content) {
       Ok(value) => json_value_to_expr(&value, raw),
-      Err(_) => Expr::Identifier("$Failed".to_string()),
+      Err(_) => fail_expr(),
     });
   }
 
@@ -671,7 +662,7 @@ fn exact_json_numbers(
 fn json_value_to_expr(value: &serde_json::Value, raw: bool) -> Expr {
   use serde_json::Value;
   match value {
-    Value::Null => Expr::Identifier("Null".to_string()),
+    Value::Null => null_expr(),
     Value::Bool(true) => bool_expr(true),
     Value::Bool(false) => bool_expr(false),
     Value::Number(n) => {
@@ -1186,12 +1177,12 @@ pub fn dispatch_image_functions(
           "Import::general: A format must be specified when importing \
            from a pipe.",
         );
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       let command = command_file_spec(&path).unwrap_or_default();
       let failed = || {
         crate::emit_message(&format!("Import::nffil: Cannot open {path}."));
-        Some(Ok(Expr::Identifier("$Failed".to_string())))
+        Some(Ok(fail_expr()))
       };
       let Some(bytes) = run_command_capture_bytes(command) else {
         return failed();
@@ -1404,7 +1395,7 @@ pub fn dispatch_image_functions(
                            string."
                         ),
                       });
-                      Expr::Identifier("$Failed".to_string())
+                      fail_expr()
                     }
                   }
                 }),
@@ -1820,7 +1811,7 @@ pub fn dispatch_image_functions(
           "Import::noelem: The Import element \"{element}\" is not present \
            when importing as {format}."
         ));
-        Some(Ok(Expr::Identifier("$Failed".to_string())))
+        Some(Ok(fail_expr()))
       };
 
       // `"Numeric" -> False` keeps every field as the string it was written
@@ -1933,7 +1924,7 @@ pub fn dispatch_image_functions(
                    {line} character: {character} in input string."
                 ),
               });
-              Expr::Identifier("$Failed".to_string())
+              fail_expr()
             }
           },
         ));
@@ -1945,7 +1936,7 @@ pub fn dispatch_image_functions(
       if format == "JSON" || format == "RawJSON" {
         if content.trim().is_empty() {
           crate::emit_message("Import::jsonnullinput: Data in input is null.");
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
         let raw = format == "RawJSON";
         return Some(Ok(
@@ -1959,7 +1950,7 @@ pub fn dispatch_image_functions(
                 _ => parsed,
               }
             }
-            Err(_) => Expr::Identifier("$Failed".to_string()),
+            Err(_) => fail_expr(),
           },
         ));
       }
@@ -2000,7 +1991,7 @@ pub fn dispatch_image_functions(
           crate::emit_message(
             "Import::fmterr: Cannot import data as TSV format.",
           );
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
         let trimmed = content.strip_suffix('\n').unwrap_or(&content);
         let rows: Vec<Vec<String>> = if trimmed.is_empty() {
@@ -2045,7 +2036,7 @@ pub fn dispatch_image_functions(
         crate::emit_message(
           "Import::fmterr: Cannot import data as CSV format.",
         );
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       if let Some(element) = &requested_element
         && !crate::functions::csv_ast::is_csv_element(element)

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -267,7 +267,7 @@ fn run_process_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "RunProcess::pbad: {} is not a valid RunProcess property.",
         crate::syntax::expr_to_string(other)
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
   };
   let input: Option<String> = match positional.get(2) {
@@ -340,7 +340,7 @@ fn run_process_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "RunProcess::pnfd: Program {program} not found. Check Environment[\"PATH\"]."
     ));
-    Ok(Expr::Identifier("$Failed".to_string()))
+    Ok(fail_expr())
   };
   // A replaced environment also replaces the search path: the program name
   // is looked up in *its* `PATH`, not the interpreter's, which is the only
@@ -420,11 +420,10 @@ fn run_process_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // A process that was killed by a signal has no exit code.
   let exit_code = match status {
-    Ok(s) => s.code().map_or_else(
-      || Expr::Identifier("None".to_string()),
-      |c| Expr::Integer(i128::from(c)),
-    ),
-    Err(_) => Expr::Identifier("None".to_string()),
+    Ok(s) => s
+      .code()
+      .map_or_else(|| id_expr("None"), |c| Expr::Integer(i128::from(c))),
+    Err(_) => id_expr("None"),
   };
   let stdout =
     Expr::String(String::from_utf8_lossy(&stdout_bytes).into_owned());
@@ -725,7 +724,7 @@ fn write_string_to_channel(
     return Ok(unevaluated(caller, args));
   };
   write_targets_bytes(&targets, text.as_bytes(), caller)?;
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Send `bytes` to a write target, appending for files. `caller` only names
@@ -1034,7 +1033,7 @@ pub(crate) fn evaluate_file(
         error,
         path.display()
       ));
-      Ok(Expr::Identifier("$Failed".to_string()))
+      Ok(fail_expr())
     }
     other => other,
   })
@@ -1050,7 +1049,7 @@ pub(crate) fn evaluate_source(content: &str) -> Result<Expr, InterpreterError> {
   // `interpret` reports a `Null` result as the "\0" display-suppression
   // sentinel; as the value of `Get` it is the symbol `Null` again.
   if result_str == "\0" {
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
   // Take the value itself where the evaluation recorded one: reading its
   // display text back both loses whatever `OutputForm` does not spell out
@@ -1156,7 +1155,7 @@ pub fn dispatch_io_functions(
         // General::stop suppression, and reaches the same stream as
         // built-in messages.
         crate::emit_message(&format!("{sym_name}::{tag}: {filled}"));
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
     }
     // HTTPRequest[url] / HTTPRequest[url, assoc] / HTTPRequest[assoc] —
@@ -1178,7 +1177,7 @@ pub fn dispatch_io_functions(
     // CLI/snapshot test loop, so any other URL also returns $Failed.
     "URLFetch" if args.len() == 1 || args.len() == 2 => {
       if let Expr::String(_) = &args[0] {
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
     }
     // Environment["name"] — return the named environment variable value
@@ -1186,7 +1185,7 @@ pub fn dispatch_io_functions(
       if let Expr::String(var_name) = &args[0] {
         return Some(Ok(match std::env::var(var_name) {
           Ok(val) => Expr::String(val),
-          Err(_) => Expr::Identifier("$Failed".to_string()),
+          Err(_) => fail_expr(),
         }));
       }
       return Some(Ok(unevaluated("Environment", args)));
@@ -1233,7 +1232,7 @@ pub fn dispatch_io_functions(
           pattern: Box::new(Expr::String(var.to_string())),
           replacement: Box::new(match std::env::var(var) {
             Ok(val) => Expr::String(val),
-            Err(_) => Expr::Identifier("None".to_string()),
+            Err(_) => id_expr("None"),
           }),
         }
       };
@@ -1306,11 +1305,7 @@ pub fn dispatch_io_functions(
         }
         other => matches!(apply_rule(other), Some(true)),
       };
-      return Some(Ok(if ok {
-        Expr::Identifier("Null".to_string())
-      } else {
-        Expr::Identifier("$Failed".to_string())
-      }));
+      return Some(Ok(if ok { null_expr() } else { fail_expr() }));
     }
     // Streams[] — return list of open streams (stdout and stderr)
     "Streams" if args.is_empty() => {
@@ -1350,7 +1345,7 @@ pub fn dispatch_io_functions(
           "ReadString::noopen: Cannot open {}.",
           filename
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       return Some(match String::from_utf8(bytes) {
         Ok(content) => Ok(Expr::String(content)),
@@ -1390,7 +1385,7 @@ pub fn dispatch_io_functions(
             crate::emit_message(&format!(
               "ReadString::noopen: Cannot open {path}."
             ));
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         }
         Expr::FunctionCall {
@@ -1403,7 +1398,7 @@ pub fn dispatch_io_functions(
           match get_stream_content(*id as usize) {
             Some((c, pos)) => (c, pos, Some(*id as usize)),
             None => {
-              return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+              return Some(Ok(id_expr("EndOfFile")));
             }
           }
         }
@@ -1414,7 +1409,7 @@ pub fn dispatch_io_functions(
       let Some((text, consumed)) =
         read_string_chunk(rest, terminator.as_deref())
       else {
-        return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+        return Some(Ok(id_expr("EndOfFile")));
       };
       if let Some(id) = stream_id {
         set_stream_position(id, position + consumed);
@@ -1451,7 +1446,7 @@ pub fn dispatch_io_functions(
         crate::emit_message_to_stdout(&format!(
           "StringTemplate::fnfnd: File \"{filename}\" not found."
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       let bound_args = if args.len() == 2 {
         Some(args[1].clone())
@@ -1488,7 +1483,7 @@ pub fn dispatch_io_functions(
             crate::emit_message_to_stdout(&format!(
               "XMLTemplate::fnfnd: File \"{filename}\" not found."
             ));
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         }
         // URL[…] / CloudObject[…] and other specifications are left
@@ -1532,7 +1527,7 @@ pub fn dispatch_io_functions(
           "Get::noopen: Cannot open {}.",
           path.display()
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       return Some(result);
     }
@@ -1558,7 +1553,7 @@ pub fn dispatch_io_functions(
       // Woxi keeps every built-in in one namespace, so there is nothing to
       // read and nothing to define.
       if crate::utils::is_standard_distribution_context(&filename) {
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
       // `"!command"` evaluates the code the command writes to its standard
       // output, the read counterpart of `Put["!command"]`.
@@ -1567,7 +1562,7 @@ pub fn dispatch_io_functions(
           crate::emit_message_to_stdout(&format!(
             "Get::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         };
         return Some(evaluate_source(&content));
       }
@@ -1580,7 +1575,7 @@ pub fn dispatch_io_functions(
         crate::emit_message_to_stdout(&format!(
           "Get::noopen: Cannot open {filename}."
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       return Some(result);
     }
@@ -1650,16 +1645,16 @@ pub fn dispatch_io_functions(
       // `"!command"` feeds the expressions to a command instead of a file.
       if let Some(command) = command_file_spec(&filename) {
         if run_command_with_input(command, to_write.as_bytes()) {
-          return Some(Ok(Expr::Identifier("Null".to_string())));
+          return Some(Ok(null_expr()));
         }
         crate::emit_message(&format!("Put::noopen: Cannot open {filename}."));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       match std::fs::write(crate::vfs::resolve(&filename), to_write) {
-        Ok(()) => return Some(Ok(Expr::Identifier("Null".to_string()))),
+        Ok(()) => return Some(Ok(null_expr())),
         Err(_e) => {
           crate::emit_message(&format!("Put::noopen: Cannot open {filename}."));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
       }
     }
@@ -1684,12 +1679,12 @@ pub fn dispatch_io_functions(
         // A pipe has nothing to append to, so `"!command"` just runs.
         if let Some(command) = command_file_spec(&filename) {
           if run_command_with_input(command, to_write.as_bytes()) {
-            return Some(Ok(Expr::Identifier("Null".to_string())));
+            return Some(Ok(null_expr()));
           }
           crate::emit_message(&format!(
             "PutAppend::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
         if let Ok(mut file) = std::fs::OpenOptions::new()
           .create(true)
@@ -1700,16 +1695,16 @@ pub fn dispatch_io_functions(
             crate::emit_message(&format!(
               "PutAppend::noopen: Cannot open {filename}."
             ));
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         } else {
           crate::emit_message(&format!(
             "PutAppend::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
       }
-      return Some(Ok(Expr::Identifier("Null".to_string())));
+      return Some(Ok(null_expr()));
     }
     #[cfg(not(target_arch = "wasm32"))]
     "Export" if args.len() >= 2 => {
@@ -2212,7 +2207,7 @@ pub fn dispatch_io_functions(
         return Some(Ok(
           match crate::functions::xml_ast::xml_to_string(&args[0]) {
             Some(text) => Expr::String(text),
-            None => Expr::Identifier("$Failed".to_string()),
+            None => fail_expr(),
           },
         ));
       }
@@ -2229,7 +2224,7 @@ pub fn dispatch_io_functions(
         // back unevaluated.
         return Some(Ok(match export_string_json(&args[0], 0, compact) {
           Some(json) => Expr::String(json),
-          None => Expr::Identifier("$Failed".to_string()),
+          None => fail_expr(),
         }));
       }
       // "String" is the expression's own text: ExportString[{{1, 2}}, "String"]
@@ -2327,10 +2322,10 @@ pub fn dispatch_io_functions(
             let id_usize = *id as usize;
             match get_stream_content(id_usize) {
               Some((c, p)) => (c, p, Some(id_usize)),
-              None => return Some(Ok(Expr::Identifier("$Failed".to_string()))),
+              None => return Some(Ok(fail_expr())),
             }
           } else {
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         }
         _ => {
@@ -2338,7 +2333,7 @@ pub fn dispatch_io_functions(
           crate::emit_message(&format!(
             "Find::stream: {arg_str} is not a string, SocketObject, InputStream[ ] or OutputStream[ ]."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
       };
 
@@ -2360,7 +2355,7 @@ pub fn dispatch_io_functions(
       if let Some(id) = stream_id {
         set_stream_position(id, content.len());
       }
-      return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+      return Some(Ok(id_expr("EndOfFile")));
     }
     #[cfg(not(target_arch = "wasm32"))]
     "FindList" => {
@@ -2368,7 +2363,7 @@ pub fn dispatch_io_functions(
       // search strings (literal, case-sensitive substrings). Errors return
       // $Failed with the matching wolframscript message; a failed file in
       // a file LIST contributes a $Failed element instead.
-      let failed = || Some(Ok(Expr::Identifier("$Failed".to_string())));
+      let failed = || Some(Ok(fail_expr()));
       let call_display = || expr_to_output(&unevaluated("FindList", args));
       if args.len() < 2 {
         let (tag, noun) = if args.len() == 1 {
@@ -2455,7 +2450,7 @@ pub fn dispatch_io_functions(
           if !is_list {
             return failed();
           }
-          out.push(Expr::Identifier("$Failed".to_string()));
+          out.push(fail_expr());
           continue;
         };
         // A `"!command"` entry searches that command's output.
@@ -2473,7 +2468,7 @@ pub fn dispatch_io_functions(
             if !is_list {
               return failed();
             }
-            out.push(Expr::Identifier("$Failed".to_string()));
+            out.push(fail_expr());
           }
           Ok(content) => {
             for line in content.lines() {
@@ -2839,7 +2834,7 @@ pub fn dispatch_io_functions(
           crate::emit_message_to_stdout(&format!(
             "OpenRead::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         };
         StreamKind::Command(std::rc::Rc::new(RefCell::new(state)))
       } else {
@@ -2847,7 +2842,7 @@ pub fn dispatch_io_functions(
           crate::emit_message_to_stdout(&format!(
             "OpenRead::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
         // The stream is bound to the file the name resolves to now, so a
         // later `SetDirectory` cannot redirect reads from it.
@@ -2886,7 +2881,7 @@ pub fn dispatch_io_functions(
           crate::emit_message_to_stdout(&format!(
             "OpenWrite::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         };
         StreamKind::CommandSink(std::rc::Rc::new(RefCell::new(state)))
       } else {
@@ -3047,7 +3042,7 @@ pub fn dispatch_io_functions(
             if offset < bytes.len() {
               Some(Expr::Integer(bytes[offset] as i128))
             } else {
-              Some(Expr::Identifier("EndOfFile".to_string()))
+              Some(id_expr("EndOfFile"))
             }
           }
           Expr::String(s) if s == "Character8" => {
@@ -3057,7 +3052,7 @@ pub fn dispatch_io_functions(
               let c = bytes[offset] as char;
               Some(Expr::String(c.to_string()))
             } else {
-              Some(Expr::Identifier("EndOfFile".to_string()))
+              Some(id_expr("EndOfFile"))
             }
           }
           _ => None,
@@ -3168,7 +3163,7 @@ pub fn dispatch_io_functions(
           crate::emit_message_to_stdout(&format!(
             "OpenAppend::noopen: Cannot open {filename}."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         };
         StreamKind::CommandSink(std::rc::Rc::new(RefCell::new(state)))
       } else {
@@ -3207,14 +3202,10 @@ pub fn dispatch_io_functions(
       let id = register_stream("String".to_string(), StreamKind::Text(text));
       // Use Symbol `String` (not the string literal "String") so the
       // formatted form matches wolframscript: `InputStream[String, id]`.
-      return Some(Ok(Expr::FunctionCall {
-        name: "InputStream".to_string(),
-        args: vec![
-          Expr::Identifier("String".to_string()),
-          Expr::Integer(id as i128),
-        ]
-        .into(),
-      }));
+      return Some(Ok(call(
+        "InputStream",
+        vec![id_expr("String"), Expr::Integer(id as i128)],
+      )));
     }
     // Close[stream] — close an open stream
     "Close" if args.len() == 1 => {
@@ -3237,7 +3228,7 @@ pub fn dispatch_io_functions(
             // Close[FileStream] returns the file path as a String;
             // Close[StringToStream[…]] returns the symbol `String`.
             Some((_, StreamKind::Text(_))) => {
-              return Some(Ok(Expr::Identifier("String".to_string())));
+              return Some(Ok(id_expr("String")));
             }
             #[cfg(not(target_arch = "wasm32"))]
             Some((name, StreamKind::File(_))) => {
@@ -3389,7 +3380,7 @@ pub fn dispatch_io_functions(
             crate::emit_message(&format!(
               "OpenRead::noopen: Cannot open {path}."
             ));
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         }
         Expr::FunctionCall {
@@ -3401,7 +3392,7 @@ pub fn dispatch_io_functions(
             match get_stream_line_content(id) {
               Some((content, pos)) => (content, pos, Some(id)),
               None => {
-                return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+                return Some(Ok(id_expr("EndOfFile")));
               }
             }
           } else {
@@ -3415,7 +3406,7 @@ pub fn dispatch_io_functions(
 
       let remaining = &content[position.min(content.len())..];
       if remaining.is_empty() {
-        return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+        return Some(Ok(id_expr("EndOfFile")));
       }
 
       // Find end of line
@@ -3521,7 +3512,7 @@ pub fn dispatch_io_functions(
         let read_type = if args.len() == 2 {
           &args[1]
         } else {
-          &Expr::Identifier("Expression".to_string())
+          &id_expr("Expression")
         };
 
         // Handle list of types: Read[stream, {type1, type2, ...}]
@@ -3560,7 +3551,7 @@ pub fn dispatch_io_functions(
       {
         return Some(Err(e));
       }
-      return Some(Ok(Expr::Identifier("Null".to_string())));
+      return Some(Ok(null_expr()));
     }
     // WriteString[stream, "text1", "text2", ...] — write strings to a stream
     #[cfg(not(target_arch = "wasm32"))]
@@ -3758,12 +3749,12 @@ pub fn dispatch_io_functions(
             crate::emit_message(&format!(
               "Save::noopen: Cannot open {filename}."
             ));
-            return Some(Ok(Expr::Identifier("$Failed".to_string())));
+            return Some(Ok(fail_expr()));
           }
         }
       }
 
-      return Some(Ok(Expr::Identifier("Null".to_string())));
+      return Some(Ok(null_expr()));
     }
     // FileNames[] — list all files in current directory
     // FileNames["pattern"] — list files matching pattern
@@ -3920,7 +3911,7 @@ pub fn dispatch_io_functions(
         crate::emit_message(&format!(
           "FileFormat::nffil: File not found during FileFormat[{name}]."
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       return Some(Ok(unevaluated("FileFormat", args)));
     }
@@ -3977,7 +3968,7 @@ pub fn dispatch_io_functions(
       let Ok(data) = std::fs::read(&path) else {
         let abs = path.to_string_lossy();
         crate::emit_message(&format!("FileHash::noopen: Cannot open {abs}."));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       let Some(hex) =
         crate::functions::string_ast::hash_bytes(&data, &hash_type)
@@ -3985,7 +3976,7 @@ pub fn dispatch_io_functions(
         crate::emit_message(&format!(
           "Hash::invhash: {hash_type} is not a valid Hash specification."
         ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       };
       return Some(Ok(
         if let Some(result) =
@@ -4067,7 +4058,7 @@ pub fn dispatch_io_functions(
           crate::emit_message(&format!(
             "FileByteCount::fdnfnd: Directory or file \"{name}\" not found."
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
       }
     }
@@ -4085,7 +4076,7 @@ pub fn dispatch_io_functions(
       crate::emit_message(&format!(
         "AbsoluteFileName::fdnfnd: Directory or file \"{name}\" not found."
       ));
-      return Some(Ok(Expr::Identifier("$Failed".to_string())));
+      return Some(Ok(fail_expr()));
     }
     // FindFile["name"] — return the absolute path if the file exists,
     // else `$Failed`. A context string like "MyPaclet`" resolves through
@@ -4101,18 +4092,18 @@ pub fn dispatch_io_functions(
             Some(path) => {
               Expr::String(crate::utils::wolfram_path_string(&path))
             }
-            None => Expr::Identifier("$Failed".to_string()),
+            None => fail_expr(),
           },
         ));
       }
       // Any other context-ish name can't be resolved to a file on disk.
       // Match wolframscript's `$Failed` return.
       if name.contains('`') {
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       return Some(Ok(match crate::utils::canonicalize(name) {
         Ok(p) => Expr::String(crate::utils::wolfram_path_string(&p)),
-        Err(_) => Expr::Identifier("$Failed".to_string()),
+        Err(_) => fail_expr(),
       }));
     }
     // FileNameDrop["path", n] — drop n path components
@@ -4220,7 +4211,7 @@ pub fn dispatch_io_functions(
         crate::capture_stdout_raw(&prompt);
       }
       let Some(line) = crate::read_stdin_line() else {
-        return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+        return Some(Ok(id_expr("EndOfFile")));
       };
       if name == "InputString" {
         return Some(Ok(Expr::String(line)));
@@ -4244,7 +4235,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
   };
 
   if remaining.is_empty() {
-    return (Expr::Identifier("EndOfFile".to_string()), 0);
+    return (id_expr("EndOfFile"), 0);
   }
 
   match type_name {
@@ -4253,7 +4244,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
       let trimmed = remaining.trim_start();
       let skipped = remaining.len() - trimmed.len();
       if trimmed.is_empty() {
-        return (Expr::Identifier("EndOfFile".to_string()), remaining.len());
+        return (id_expr("EndOfFile"), remaining.len());
       }
       // Read until whitespace
       let end = trimmed
@@ -4267,7 +4258,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
       let trimmed = remaining.trim_start();
       let skipped = remaining.len() - trimmed.len();
       if trimmed.is_empty() {
-        return (Expr::Identifier("EndOfFile".to_string()), remaining.len());
+        return (id_expr("EndOfFile"), remaining.len());
       }
       // Try to parse a number
       let mut end = 0;
@@ -4292,7 +4283,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
         }
       }
       if end == 0 || (!has_int_part && !is_real) {
-        return (Expr::Identifier("$Failed".to_string()), skipped);
+        return (fail_expr(), skipped);
       }
       let num_str = &trimmed[..end];
       if is_real {
@@ -4302,7 +4293,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
       } else if let Ok(n) = num_str.parse::<i128>() {
         return (Expr::Integer(n), skipped + end);
       }
-      (Expr::Identifier("$Failed".to_string()), skipped)
+      (fail_expr(), skipped)
     }
     "String" => {
       // Read until newline
@@ -4325,7 +4316,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
       let trimmed = remaining.trim_start();
       let skipped = remaining.len() - trimmed.len();
       if trimmed.is_empty() {
-        return (Expr::Identifier("EndOfFile".to_string()), remaining.len());
+        return (id_expr("EndOfFile"), remaining.len());
       }
       let bytes = trimmed.as_bytes();
       let mut i = 0;
@@ -4369,7 +4360,7 @@ fn read_single_type(remaining: &str, read_type: &Expr) -> (Expr, usize) {
         .and_then(|parsed| crate::evaluator::evaluate_expr_to_expr(&parsed));
       match value {
         Ok(expr) => (expr, advance),
-        Err(_) => (Expr::Identifier("$Failed".to_string()), advance),
+        Err(_) => (fail_expr(), advance),
       }
     }
   }
@@ -5248,13 +5239,13 @@ fn with_epilog(name: &str, args: &[Expr], markers: &Expr) -> Expr {
         _ => markers.clone(),
       };
       new_args[pos] = Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Epilog".to_string())),
+        pattern: Box::new(id_expr("Epilog")),
         replacement: Box::new(merged),
       };
     }
     None => {
       new_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Epilog".to_string())),
+        pattern: Box::new(id_expr("Epilog")),
         replacement: Box::new(markers.clone()),
       });
     }

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -2882,14 +2882,8 @@ pub fn dispatch_linear_algebra_functions(
         {
           use crate::functions::math_ast::make_rational;
           let cos_pi = |num: i128, den: i128| -> Expr {
-            let angle = Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![
-                make_rational(num, den),
-                Expr::Identifier("Pi".to_string()),
-              ]
-              .into(),
-            };
+            let angle =
+              call("Times", vec![make_rational(num, den), id_expr("Pi")]);
             call1("Cos", angle)
           };
           let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
@@ -2975,14 +2969,7 @@ pub fn dispatch_linear_algebra_functions(
               // Simplify the fraction 2*exp/n
               let (snum, sden) = rat_reduce(2 * exp, n as i128);
               let angle = if sden == 1 {
-                Expr::FunctionCall {
-                  name: "Times".to_string(),
-                  args: vec![
-                    Expr::Integer(snum),
-                    Expr::Identifier("Pi".to_string()),
-                  ]
-                  .into(),
-                }
+                call("Times", vec![Expr::Integer(snum), id_expr("Pi")])
               } else {
                 Expr::FunctionCall {
                   name: "Times".to_string(),
@@ -2991,21 +2978,15 @@ pub fn dispatch_linear_algebra_functions(
                       "Rational",
                       vec![Expr::Integer(snum), Expr::Integer(sden)],
                     ),
-                    Expr::Identifier("Pi".to_string()),
+                    id_expr("Pi"),
                   ]
                   .into(),
                 }
               };
               // Build (Cos[angle] + I*Sin[angle]) / Sqrt[n]
               let cos_part = call1("Cos", angle.clone());
-              let sin_part = Expr::FunctionCall {
-                name: "Times".to_string(),
-                args: vec![
-                  Expr::Identifier("I".to_string()),
-                  call1("Sin", angle),
-                ]
-                .into(),
-              };
+              let sin_part =
+                call("Times", vec![id_expr("I"), call1("Sin", angle)]);
               let omega = call("Plus", vec![cos_part, sin_part]);
               let entry = call("Times", vec![omega, inv_sqrt_n.clone()]);
               row.push(entry);
@@ -3225,7 +3206,7 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
     let perm_data = Expr::List(
       vec![
         call1("Cycles", Expr::List(vec![].into())),
-        Expr::Identifier("Infinity".into()),
+        id_expr("Infinity"),
       ]
       .into(),
     );
@@ -3411,13 +3392,8 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
     Expr::Integer(0)
   };
 
-  let perm_data = Expr::List(
-    vec![
-      lu_pivots_to_cycles(&pivots),
-      Expr::Identifier("Infinity".into()),
-    ]
-    .into(),
-  );
+  let perm_data =
+    Expr::List(vec![lu_pivots_to_cycles(&pivots), id_expr("Infinity")].into());
 
   Ok(Expr::List(
     vec![
@@ -3494,7 +3470,7 @@ fn lu_infinity_condition(matrix: &[Vec<Expr>]) -> Expr {
   let norm_a = lu_infinity_norm(matrix);
 
   let Ok(inv) = evaluate_expr_to_expr(&call1("Inverse", orig)) else {
-    return Expr::Identifier("Infinity".into());
+    return id_expr("Infinity");
   };
   let mut inv_mat: Vec<Vec<Expr>> = Vec::with_capacity(n);
   match &inv {
@@ -3502,16 +3478,16 @@ fn lu_infinity_condition(matrix: &[Vec<Expr>]) -> Expr {
       for row in rows {
         match row {
           Expr::List(cols) if cols.len() == n => inv_mat.push(cols.to_vec()),
-          _ => return Expr::Identifier("Infinity".into()),
+          _ => return id_expr("Infinity"),
         }
       }
     }
-    _ => return Expr::Identifier("Infinity".into()),
+    _ => return id_expr("Infinity"),
   }
   let norm_inv = lu_infinity_norm(&inv_mat);
   match (norm_a, norm_inv) {
     (Some(a), Some(b)) => Expr::Real(a * b),
-    _ => Expr::Identifier("Infinity".into()),
+    _ => id_expr("Infinity"),
   }
 }
 
@@ -3743,7 +3719,7 @@ fn binary_dissimilarity_ast(name: &str, a: &Expr, b: &Expr) -> Expr {
   };
 
   if den == 0 {
-    return Expr::Identifier("Indeterminate".to_string());
+    return id_expr("Indeterminate");
   }
 
   crate::functions::math_ast::make_rational(num, den)
@@ -4018,7 +3994,7 @@ fn matrix_power_2x2_symbolic_block(
   // Power[I, n]]`, which is mathematically wrong for symbolic n.
   let lam_power = |re: i128, im: i128| -> Expr {
     let base = if re == 0 && im == 1 {
-      Expr::Identifier("I".to_string())
+      id_expr("I")
     } else if re == 0 {
       call("Complex", vec![Expr::Integer(0), Expr::Integer(im)])
     } else {
@@ -4031,7 +4007,7 @@ fn matrix_power_2x2_symbolic_block(
 
   // `λ_1 − λ_2 = k·I`. Use Complex form for the same reason as above.
   let lambda_diff = if k == 1 {
-    Expr::Identifier("I".to_string())
+    id_expr("I")
   } else {
     call("Complex", vec![Expr::Integer(0), Expr::Integer(k)])
   };
@@ -4341,10 +4317,7 @@ fn rotation_matrix_plane(
   let e2 = evaluate_expr_to_expr(&call1("Normalize", w))?;
 
   let outer = |a: &Expr, b: &Expr| {
-    call(
-      "Outer",
-      vec![Expr::Identifier("Times".to_string()), a.clone(), b.clone()],
-    )
+    call("Outer", vec![id_expr("Times"), a.clone(), b.clone()])
   };
   let sin = call1("Sin", theta.clone());
   let cos_m1 =

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -996,9 +996,7 @@ fn expr_tree_decompose(e: &Expr) -> Option<(Expr, Vec<Expr>)> {
     Expr::FunctionCall { name, args } => {
       Some((Expr::Identifier(name.clone()), args.to_vec()))
     }
-    Expr::List(items) => {
-      Some((Expr::Identifier("List".to_string()), items.to_vec()))
-    }
+    Expr::List(items) => Some((id_expr("List"), items.to_vec())),
     Expr::CurriedCall { func, args } => Some(((**func).clone(), args.clone())),
     Expr::BinaryOp { .. }
     | Expr::UnaryOp { .. }
@@ -1016,10 +1014,7 @@ fn expr_tree_decompose(e: &Expr) -> Option<(Expr, Vec<Expr>)> {
 /// "HeadTrees" (see ExpressionTree docs).
 fn build_expression_tree(e: &Expr, structure: &str) -> Expr {
   match expr_tree_decompose(e) {
-    None => call(
-      "Tree",
-      vec![e.clone(), Expr::Identifier("None".to_string())],
-    ),
+    None => call("Tree", vec![e.clone(), id_expr("None")]),
     Some((head, args)) => {
       let children: Vec<Expr> = args
         .iter()
@@ -1027,7 +1022,7 @@ fn build_expression_tree(e: &Expr, structure: &str) -> Expr {
         .collect();
       let data = match structure {
         "Subexpressions" => e.clone(),
-        "Atoms" => Expr::Identifier("Null".to_string()),
+        "Atoms" => null_expr(),
         // A compound head becomes its own tree; an atomic head stays as-is.
         "HeadTrees" if expr_tree_decompose(&head).is_some() => {
           build_expression_tree(&head, "HeadTrees")
@@ -1284,10 +1279,7 @@ fn tree_replacement_value(v: &Expr) -> Expr {
   {
     v.clone()
   } else {
-    call(
-      "Tree",
-      vec![v.clone(), Expr::Identifier("None".to_string())],
-    )
+    call("Tree", vec![v.clone(), id_expr("None")])
   }
 }
 
@@ -3948,7 +3940,7 @@ pub fn dispatch_list_operations(
         return Some(Ok(Expr::FunctionCall {
           name: "WeightedData".to_string(),
           args: vec![
-            Expr::Identifier("Automatic".to_string()),
+            id_expr("Automatic"),
             Expr::List(vec![args[0].clone(), args[1].clone()].into()),
           ]
           .into(),
@@ -4178,10 +4170,7 @@ pub fn dispatch_list_operations(
             if is_tree(c) {
               c.clone()
             } else {
-              call(
-                "Tree",
-                vec![c.clone(), Expr::Identifier("None".to_string())],
-              )
+              call("Tree", vec![c.clone(), id_expr("None")])
             }
           })
           .collect();
@@ -4634,7 +4623,7 @@ pub fn dispatch_list_operations(
     }
     // TreeScan[f, tree] — apply f to every node's data bottom-up, for effect.
     "TreeScan" if args.len() == 2 => match tree_scan(&args[0], &args[1]) {
-      Ok(Some(())) => return Some(Ok(Expr::Identifier("Null".to_string()))),
+      Ok(Some(())) => return Some(Ok(null_expr())),
       Ok(None) => {
         crate::emit_message(&format!(
           "TreeScan::tree: Tree expected at position 2 in {}.",
@@ -5057,8 +5046,7 @@ pub fn dispatch_list_operations(
     // effects and returns Null, matching wolframscript.
     "Do" | "ParallelDo" if args.len() == 1 => {
       return Some(
-        crate::evaluator::evaluate_expr_to_expr(&args[0])
-          .map(|_| Expr::Identifier("Null".to_string())),
+        crate::evaluator::evaluate_expr_to_expr(&args[0]).map(|_| null_expr()),
       );
     }
     "Do" | "ParallelDo" if args.len() >= 2 => {
@@ -5256,7 +5244,7 @@ pub fn dispatch_list_operations(
     }
     // Composition[] -> Identity
     "Composition" if args.is_empty() => {
-      return Some(Ok(Expr::Identifier("Identity".to_string())));
+      return Some(Ok(id_expr("Identity")));
     }
     // Composition[f] -> f
     "Composition" if args.len() == 1 => {
@@ -5283,7 +5271,7 @@ pub fn dispatch_list_operations(
     }
     // RightComposition[] -> Identity
     "RightComposition" if args.is_empty() => {
-      return Some(Ok(Expr::Identifier("Identity".to_string())));
+      return Some(Ok(id_expr("Identity")));
     }
     // RightComposition[f] -> f
     "RightComposition" if args.len() == 1 => {
@@ -5473,7 +5461,7 @@ pub fn dispatch_list_operations(
       return Some(list_helpers_ast::tensor_expand_ast(&args[0]));
     }
     "Inner" if args.len() == 3 => {
-      let plus = Expr::Identifier("Plus".to_string());
+      let plus = id_expr("Plus");
       return Some(list_helpers_ast::inner_ast(
         &args[0], &args[1], &args[2], &plus,
       ));
@@ -7405,7 +7393,7 @@ pub fn dispatch_list_operations(
           return Some(Ok(Expr::Integer(min_val)));
         }
         // Empty Cycles → wolframscript returns Infinity (no moved points).
-        return Some(Ok(Expr::Identifier("Infinity".to_string())));
+        return Some(Ok(id_expr("Infinity")));
       }
       if let Expr::List(perm) = &args[0] {
         let mut min_val: Option<i128> = None;
@@ -9558,7 +9546,7 @@ fn build_sparse_array_csr(
   let make_outer = |inner: Expr| Expr::FunctionCall {
     name: "SparseArray".to_string(),
     args: vec![
-      Expr::Identifier("Automatic".to_string()),
+      id_expr("Automatic"),
       dims_list.clone(),
       default.clone(),
       inner,

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1825,7 +1825,7 @@ pub fn dispatch_math_functions(
     "StieltjesGamma" if args.len() == 1 => {
       let unevaluated = unevaluated("StieltjesGamma", args);
       return Some(Ok(match &args[0] {
-        Expr::Integer(0) => Expr::Identifier("EulerGamma".to_string()),
+        Expr::Integer(0) => id_expr("EulerGamma"),
         Expr::Integer(n) if *n >= 1 => unevaluated,
         Expr::Identifier(_) => unevaluated,
         other => {
@@ -2017,7 +2017,7 @@ pub fn dispatch_math_functions(
           return Some(Ok(Expr::Integer(0)));
         }
         Expr::Identifier(s) if s == "ComplexInfinity" => {
-          return Some(Ok(Expr::Identifier("Indeterminate".to_string())));
+          return Some(Ok(id_expr("Indeterminate")));
         }
         Expr::UnaryOp {
           op: UnaryOperator::Minus,
@@ -3379,14 +3379,8 @@ pub fn dispatch_math_functions(
           && matches!(&imin_expr, Expr::Integer(1))
           && matches!(&imax_expr, Expr::Identifier(s) if s == "Infinity")
         {
-          let result = Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: vec![
-              Expr::Integer(-1),
-              Expr::Identifier("GoldenRatio".to_string()),
-            ]
-            .into(),
-          };
+          let result =
+            call("Plus", vec![Expr::Integer(-1), id_expr("GoldenRatio")]);
           return Some(crate::evaluator::evaluate_expr_to_expr(&result));
         }
         if let (Expr::Integer(imin), Expr::Integer(imax)) =
@@ -5017,7 +5011,7 @@ fn qgamma_ast(z_expr: &Expr, q_expr: &Expr) -> Result<Expr, InterpreterError> {
   };
   if n <= 0 {
     // Poles at the non-positive integers.
-    return Ok(Expr::Identifier("ComplexInfinity".to_string()));
+    return Ok(id_expr("ComplexInfinity"));
   }
   if n == 1 {
     // QGamma[1, q] = 1, but an inexact (machine-real) q yields an inexact 1.
@@ -5430,10 +5424,7 @@ fn substitute_complex_vars(expr: &Expr, vars: &[String]) -> Expr {
   match expr {
     Expr::Identifier(name) if vars.iter().any(|v| v == name) => plus2(
       call1("Re", Expr::Identifier(name.clone())),
-      times2(
-        Expr::Identifier("I".to_string()),
-        call1("Im", Expr::Identifier(name.clone())),
-      ),
+      times2(id_expr("I"), call1("Im", Expr::Identifier(name.clone()))),
     ),
     // `Re[z]`, `Im[z]`, `Arg[z]` for a complex-vars `z` are
     // primitives Wolfram emits as-is. `Arg[anything-with-z]` is also
@@ -5688,9 +5679,9 @@ fn group_imag_terms(expr: &Expr) -> Expr {
     };
   }
   let i_term = if matches!(imag, Expr::Integer(1)) {
-    Expr::Identifier("I".to_string())
+    id_expr("I")
   } else {
-    call("Times", vec![Expr::Identifier("I".to_string()), imag])
+    call("Times", vec![id_expr("I"), imag])
   };
   if real_parts.is_empty() {
     return crate::evaluator::evaluate_expr_to_expr(&i_term).unwrap_or(i_term);
@@ -6223,10 +6214,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let sinh_b = call1("Sinh", im);
               return ce_simplify(plus2(
                 times2(sin_a, cosh_b),
-                times2(
-                  Expr::Identifier("I".to_string()),
-                  times2(cos_a, sinh_b),
-                ),
+                times2(id_expr("I"), times2(cos_a, sinh_b)),
               ));
             }
             // Cos[a + I*b] = Cos[a]*Cosh[b] - I*Sin[a]*Sinh[b]
@@ -6237,10 +6225,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let sinh_b = call1("Sinh", im);
               return ce_simplify(minus2(
                 times2(cos_a, cosh_b),
-                times2(
-                  Expr::Identifier("I".to_string()),
-                  times2(sin_a, sinh_b),
-                ),
+                times2(id_expr("I"), times2(sin_a, sinh_b)),
               ));
             }
             // Sinh[a + I*b] = Sinh[a]*Cos[b] + I*Cosh[a]*Sin[b]
@@ -6251,10 +6236,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let sin_b = call1("Sin", im);
               return ce_simplify(plus2(
                 times2(sinh_a, cos_b),
-                times2(
-                  Expr::Identifier("I".to_string()),
-                  times2(cosh_a, sin_b),
-                ),
+                times2(id_expr("I"), times2(cosh_a, sin_b)),
               ));
             }
             // Tanh[a + I*b] = (Sinh[2a] + I*Sin[2b]) / (Cos[2b] + Cosh[2a]).
@@ -6273,7 +6255,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let imag_part = div2(sin_2b, denom);
               return ce_simplify(plus2(
                 real_part,
-                times2(Expr::Identifier("I".to_string()), imag_part),
+                times2(id_expr("I"), imag_part),
               ));
             }
             // Cosh[a + I*b] = Cosh[a]*Cos[b] + I*Sinh[a]*Sin[b]
@@ -6284,10 +6266,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let sin_b = call1("Sin", im);
               return ce_simplify(plus2(
                 times2(cosh_a, cos_b),
-                times2(
-                  Expr::Identifier("I".to_string()),
-                  times2(sinh_a, sin_b),
-                ),
+                times2(id_expr("I"), times2(sinh_a, sin_b)),
               ));
             }
             // Exp[a + I*b] = E^a*Cos[b] + I*E^a*Sin[b]
@@ -6297,7 +6276,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
               let sin_b = call1("Sin", im);
               return ce_simplify(plus2(
                 times2(exp_a.clone(), cos_b),
-                times2(Expr::Identifier("I".to_string()), times2(exp_a, sin_b)),
+                times2(id_expr("I"), times2(exp_a, sin_b)),
               ));
             }
             // Abs[a + I*b] = Sqrt[a^2 + b^2]
@@ -6326,10 +6305,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
             let mag_sq =
               plus2(pow2(re, Expr::Integer(2)), pow2(im, Expr::Integer(2)));
             let log_term = div2(call1("Log", mag_sq), Expr::Integer(2));
-            let arg_term = times2(
-              Expr::Identifier("I".to_string()),
-              call1("Arg", arg.clone()),
-            );
+            let arg_term = times2(id_expr("I"), call1("Arg", arg.clone()));
             return ce_simplify(plus2(log_term, arg_term));
           }
           // Real argument (im == 0): Abs[u] = Sqrt[u^2]. The im != 0 case is
@@ -6348,10 +6324,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
             });
           }
           "Conjugate" => {
-            return ce_simplify(minus2(
-              re,
-              times2(Expr::Identifier("I".to_string()), im),
-            ));
+            return ce_simplify(minus2(re, times2(id_expr("I"), im)));
           }
           _ => {}
         }
@@ -6392,7 +6365,7 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
           let sin_b = call1("Sin", inner_arg);
           return ce_simplify(plus2(
             times2(exp_a.clone(), cos_b),
-            times2(Expr::Identifier("I".to_string()), times2(exp_a, sin_b)),
+            times2(id_expr("I"), times2(exp_a, sin_b)),
           ));
         }
       }
@@ -6571,7 +6544,7 @@ fn trig_to_exp_recursive(expr: &Expr) -> Expr {
   match expr {
     Expr::FunctionCall { name, args } if args.len() == 1 => {
       let arg = trig_to_exp_recursive(&args[0]);
-      let i = Expr::Identifier("I".to_string());
+      let i = id_expr("I");
       let e = const_expr("E");
       let half = call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
       match name.as_str() {

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -325,10 +325,7 @@ pub fn dispatch_plotting(
       // Substitute z -> x + I*y in f.
       let xy_expr = plus2(
         Expr::Identifier(xv.clone()),
-        times2(
-          Expr::Identifier("I".to_string()),
-          Expr::Identifier(yv.clone()),
-        ),
+        times2(id_expr("I"), Expr::Identifier(yv.clone())),
       );
       let body = crate::syntax::substitute_variable(&args[0], &zvar, &xy_expr);
       let modulus = call1("Abs", body);
@@ -401,12 +398,9 @@ pub fn dispatch_plotting(
               // {z, r} → corners (-r - r·I, r + r·I)
               let r = items[1].clone();
               let neg_r = call1("Minus", r.clone());
-              let corner_lo = plus2(
-                neg_r.clone(),
-                times2(neg_r.clone(), Expr::Identifier("I".to_string())),
-              );
-              let corner_hi =
-                plus2(r.clone(), times2(r, Expr::Identifier("I".to_string())));
+              let corner_lo =
+                plus2(neg_r.clone(), times2(neg_r.clone(), id_expr("I")));
+              let corner_hi = plus2(r.clone(), times2(r, id_expr("I")));
               (name.clone(), corner_lo, corner_hi)
             }
           }
@@ -418,10 +412,7 @@ pub fn dispatch_plotting(
       let yv = "y".to_string();
       let xy_expr = plus2(
         Expr::Identifier(xv.clone()),
-        times2(
-          Expr::Identifier("I".to_string()),
-          Expr::Identifier(yv.clone()),
-        ),
+        times2(id_expr("I"), Expr::Identifier(yv.clone())),
       );
       let pred = crate::syntax::substitute_variable(&args[0], &zvar, &xy_expr);
       let eval_part = |e: &Expr, part: &str| -> Expr {
@@ -577,7 +568,7 @@ pub fn dispatch_plotting(
           println!();
         }
         crate::capture_stdout("");
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
       // Printing consumes its arguments, so an `Unevaluated[…]` wrapper
       // comes off first: `Print[Unevaluated[Symbol]]` writes `Symbol`.
@@ -589,7 +580,7 @@ pub fn dispatch_plotting(
         println!("{display_str}");
       }
       crate::capture_stdout(&display_str);
-      Some(Ok(Expr::Identifier("Null".to_string())))
+      Some(Ok(null_expr()))
     }
     _ => None,
   }

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -315,7 +315,7 @@ pub fn dispatch_predicate_functions(
         return false_result();
       }
       // A fresh variable avoids any collision with symbols in the input.
-      let var = Expr::Identifier("AlgebraicIntegerQ$x".to_string());
+      let var = id_expr("AlgebraicIntegerQ$x");
       let mp = match evaluate_expr_to_expr(&call(
         "MinimalPolynomial",
         vec![args[0].clone(), var.clone()],

--- a/src/evaluator/dispatch/string_functions.rs
+++ b/src/evaluator/dispatch/string_functions.rs
@@ -136,8 +136,8 @@ pub fn dispatch_string_functions(
       if let Expr::String(_) = &args[0] {
         let te_args = vec![
           args[0].clone(),
-          Expr::Identifier("InputForm".to_string()),
-          Expr::Identifier("HoldComplete".to_string()),
+          id_expr("InputForm"),
+          id_expr("HoldComplete"),
         ];
         return Some(crate::functions::string_ast::to_expression_ast(&te_args));
       }

--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -87,7 +87,7 @@ pub fn dispatch_structural(
       });
       let mut compiled_args = vec![args[0].clone(), args[1].clone()];
       if listable {
-        compiled_args.push(Expr::Identifier("Listable".to_string()));
+        compiled_args.push(id_expr("Listable"));
       }
       return Some(Ok(call("CompiledFunction", compiled_args)));
     }
@@ -96,7 +96,7 @@ pub fn dispatch_structural(
         (expr_to_i128(&args[0]), expr_to_i128(&args[1]))
       {
         if d == 0 {
-          return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
+          return Some(Ok(id_expr("ComplexInfinity")));
         }
         return Some(Ok(crate::functions::math_ast::make_rational(n, d)));
       }

--- a/src/evaluator/dispatch/wavelet_functions.rs
+++ b/src/evaluator/dispatch/wavelet_functions.rs
@@ -58,7 +58,7 @@ pub(super) fn dispatch_wavelet_functions(
       {
         Some(crate::evaluator::function_application::apply_curried_call(
           &args[0],
-          &[Expr::Identifier("All".to_string())],
+          &[id_expr("All")],
         ))
       } else {
         None

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -497,7 +497,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
   match name {
     "$RecursionLimit" => Some(Expr::Integer(1024)),
     "$IterationLimit" => Some(Expr::Integer(4096)),
-    "$HistoryLength" => Some(Expr::Identifier("Infinity".to_string())),
+    "$HistoryLength" => Some(id_expr("Infinity")),
     // Wolframscript runs each script as a fresh session, so `$Line` —
     // the input-line counter — always reads as 1 regardless of how many
     // statements have been evaluated.
@@ -534,7 +534,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
     // (2^-1022), not the smallest subnormal — so their product rounds
     // cleanly to ~4.
     "$MinMachineNumber" => Some(Expr::Real(f64::MIN_POSITIVE)),
-    "$MaxPrecision" => Some(Expr::Identifier("Infinity".to_string())),
+    "$MaxPrecision" => Some(id_expr("Infinity")),
     "$MinPrecision" => Some(Expr::Integer(0)),
     "$SystemWordLength" => Some(Expr::Integer(usize::BITS as i128)),
     // -1 for little-endian, 1 for big-endian (Wolfram convention).
@@ -729,11 +729,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
         })
         .unwrap_or_else(|| {
           Expr::List(
-            vec![
-              Expr::Identifier("StandardForm".to_string()),
-              Expr::Identifier("TraditionalForm".to_string()),
-            ]
-            .into(),
+            vec![id_expr("StandardForm"), id_expr("TraditionalForm")].into(),
           )
         });
       if let Expr::List(box_items) = &box_forms {
@@ -797,11 +793,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
         })
         .unwrap_or_else(|| {
           Expr::List(
-            vec![
-              Expr::Identifier("StandardForm".to_string()),
-              Expr::Identifier("TraditionalForm".to_string()),
-            ]
-            .into(),
+            vec![id_expr("StandardForm"), id_expr("TraditionalForm")].into(),
           )
         });
       if let Expr::List(box_items) = &box_forms {
@@ -822,11 +814,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
     }
     // `$BoxForms` — the default box-form list, {StandardForm, TraditionalForm}.
     "$BoxForms" => Some(Expr::List(
-      vec![
-        Expr::Identifier("StandardForm".to_string()),
-        Expr::Identifier("TraditionalForm".to_string()),
-      ]
-      .into(),
+      vec![id_expr("StandardForm"), id_expr("TraditionalForm")].into(),
     )),
     // Fixed list of supported encodings, in wolframscript's exact order.
     // This is a registry-style list, not an alphabetical sort — EUC-JP

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-  binop, bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2,
-  pow2, times2, unevaluated,
+  binop, bool_expr, call, call0, call1, const_expr, div2, fail_expr, id_expr,
+  minus2, neg1, null_expr, plus2, pow2, times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -517,10 +517,8 @@ pub fn graphics_symbolic_form(expr: &Expr) -> Option<Expr> {
         if let Some(polygon_points) = series_fill_polygon(s) {
           let fill_color = s.fill_color.unwrap_or(s.color);
           let opacity = s.fill_opacity.unwrap_or(0.2);
-          let styled_fill = Expr::FunctionCall {
-            name: "Opacity".to_string(),
-            args: vec![Expr::Real(opacity), rgb_expr(fill_color)].into(),
-          };
+          let styled_fill =
+            call("Opacity", vec![Expr::Real(opacity), rgb_expr(fill_color)]);
           let polygon = Expr::FunctionCall {
             name: "Polygon".to_string(),
             args: vec![Expr::List(
@@ -664,7 +662,7 @@ fn extract_part_ast_rest(
       // Integer index: access by position (return value, not rule)
       Expr::Integer(i) => {
         if *i == 0 {
-          return Ok(Expr::Identifier("Association".to_string()));
+          return Ok(id_expr("Association"));
         }
         if let Some((k, v)) = entry_at(*i) {
           return Ok(crate::functions::association_ast::assoc_entry_value(
@@ -719,7 +717,7 @@ fn extract_part_ast_rest(
                     pattern,
                     replacement,
                   } => ((**pattern).clone(), (**replacement).clone()),
-                  _ => (r.clone(), Expr::Identifier("Null".to_string())),
+                  _ => (r.clone(), null_expr()),
                 })
                 .collect(),
             )
@@ -897,7 +895,7 @@ fn extract_part_ast_rest(
     Expr::List(items) => {
       if idx == 0 {
         // Part[{...}, 0] returns the head, which is List
-        return Ok(Expr::Identifier("List".to_string()));
+        return Ok(id_expr("List"));
       }
       let len = items.len() as i64;
       let actual_idx = if idx < 0 { len + idx } else { idx - 1 };

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -420,8 +420,7 @@ fn try_ast_pattern_replace_impl(
       }
       // The `List` head is itself a subexpression: `{a} /. x_Symbol :> f[x]`
       // becomes `f[List][f[a]]`. Keep the `List` node when the head is intact.
-      let new_head =
-        recurse(&Expr::Identifier("List".to_string()), &mut any_matched)?;
+      let new_head = recurse(&id_expr("List"), &mut any_matched)?;
       if any_matched {
         Ok(Some(match new_head {
           Expr::Identifier(ref h) if h == "List" => Expr::List(results.into()),
@@ -588,7 +587,7 @@ fn try_ast_pattern_replace_impl(
       let mut any = false;
       let np = recurse(sub_pat, &mut any)?;
       let nr = recurse(sub_rep, &mut any)?;
-      let new_head = recurse(&Expr::Identifier("Rule".to_string()), &mut any)?;
+      let new_head = recurse(&id_expr("Rule"), &mut any)?;
       if any {
         Ok(Some(match new_head {
           Expr::Identifier(ref h) if h == "Rule" => Expr::Rule {
@@ -608,8 +607,7 @@ fn try_ast_pattern_replace_impl(
       let mut any = false;
       let np = recurse(sub_pat, &mut any)?;
       let nr = recurse(sub_rep, &mut any)?;
-      let new_head =
-        recurse(&Expr::Identifier("RuleDelayed".to_string()), &mut any)?;
+      let new_head = recurse(&id_expr("RuleDelayed"), &mut any)?;
       if any {
         Ok(Some(match new_head {
           Expr::Identifier(ref h) if h == "RuleDelayed" => Expr::RuleDelayed {
@@ -1980,10 +1978,7 @@ fn try_symbol_replace_all(
           .unwrap_or_else(|| left.as_ref().clone());
         let new_right = try_symbol_replace_all(right, pattern_sym, replacement)
           .unwrap_or_else(|| right.as_ref().clone());
-        let power = |head: Expr| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![head, Expr::Integer(-1)].into(),
-        };
+        let power = |head: Expr| call("Power", vec![head, Expr::Integer(-1)]);
         return Some(if pattern_sym == "Times" {
           build_with_head(vec![new_left, power(new_right)], replacement)
         } else {
@@ -3359,9 +3354,7 @@ fn full_form_head_args(expr: &Expr) -> Option<(Expr, Vec<Expr>)> {
     Expr::FunctionCall { name, args } => {
       Some((Expr::Identifier(name.clone()), args.to_vec()))
     }
-    Expr::List(items) => {
-      Some((Expr::Identifier("List".to_string()), items.to_vec()))
-    }
+    Expr::List(items) => Some((id_expr("List"), items.to_vec())),
     // `h[a][b]`: the head is the compound `h[a]`.
     Expr::CurriedCall { func, args } => Some(((**func).clone(), args.clone())),
     // Patterns and everything else go through the canonical decomposition,
@@ -4001,11 +3994,9 @@ fn head_and_args(expr: &Expr) -> Option<(Expr, Vec<Expr>)> {
     {
       Some(((**func).clone(), args.clone()))
     }
-    Expr::List(items) => {
-      Some((Expr::Identifier("List".to_string()), items.to_vec()))
-    }
+    Expr::List(items) => Some((id_expr("List"), items.to_vec())),
     Expr::Association(pairs) => Some((
-      Expr::Identifier("Association".to_string()),
+      id_expr("Association"),
       pairs
         .iter()
         .map(|(key, value)| Expr::Rule {

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -1128,7 +1128,7 @@ pub fn for_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// AST-based With implementation - substitutes bindings into body before evaluation.
@@ -1161,7 +1161,7 @@ pub fn with_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut vars = Vec::new();
       for var in locals {
         // `With[{x := v}, …]` substitutes `v` unevaluated.
-        let init = var.init.unwrap_or(Expr::Identifier("Null".to_string()));
+        let init = var.init.unwrap_or(null_expr());
         let val = if var.delayed {
           init
         } else {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -66,3 +66,14 @@ pub fn bool_expr(b: bool) -> Expr {
 pub fn const_expr(name: &str) -> Expr {
   Expr::Constant(name.to_string())
 }
+
+pub fn id_expr(name: &str) -> Expr {
+  Expr::Identifier(name.to_string())
+}
+
+pub fn null_expr() -> Expr {
+  id_expr("Null")
+}
+pub fn fail_expr() -> Expr {
+  id_expr("$Failed")
+}


### PR DESCRIPTION
This PR adds an id_expr helper, which replaces Expr::Identifier("Foo".to_string()) with id_expr("Foo"). It also adds two special case helpers for "Null" (null_expr) and "$Failed" (fail_expr). To keep the PR reasonably sized, it applies the changes only to src/evaluator/*.

It also applies the call helpers where the id_expr changes exposed more opportunities to use them.