### PR TITLE
Fix RandomVariate[BernoulliDistribution] and Graphics AxesLabel clipping

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -7620,6 +7620,36 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // against the opposite edge and clipped whatever sat at the far side.
   let y_axis_interior = axes.1 && bb.x_min <= 0.0 && 0.0 <= bb.x_max;
   let x_axis_interior = axes.0 && bb.y_min <= 0.0 && 0.0 <= bb.y_max;
+  // An AxesLabel sits at the end of its axis (Wolfram's placement), so
+  // the x label needs room to the right and the y label room above. The
+  // label arrives as SVG markup (plain text, or with sub/superscript
+  // tspans from `Style[…]`); approximate its rendered width from its
+  // visible character count at the same 14px sans-serif size it draws
+  // with, so a longer label reserves more room instead of overflowing a
+  // fixed gutter and getting clipped by the canvas edge.
+  fn axis_label_width(markup: &str) -> f64 {
+    let mut visible_chars = 0usize;
+    let mut in_tag = false;
+    for c in markup.chars() {
+      match c {
+        '<' => in_tag = true,
+        '>' => in_tag = false,
+        _ if !in_tag => visible_chars += 1,
+        _ => {}
+      }
+    }
+    visible_chars as f64 * 7.5
+  }
+  let has_x_axis_label =
+    axes_label.as_ref().is_some_and(|(x, _)| !x.is_empty());
+  let has_y_axis_label =
+    axes_label.as_ref().is_some_and(|(_, y)| !y.is_empty());
+  let x_axis_label_width = axes_label
+    .as_ref()
+    .map_or(0.0, |(x, _)| axis_label_width(x));
+  let y_axis_label_width = axes_label
+    .as_ref()
+    .map_or(0.0, |(_, y)| axis_label_width(y));
   let margin_left: f64 = if frame_gutter || (axes.1 && !y_axis_interior) {
     50.0
   } else if frame {
@@ -7628,7 +7658,14 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     6.0
   } else {
     0.0
-  } + if has_left_caption { 20.0 } else { 0.0 };
+  } + if has_left_caption { 20.0 } else { 0.0 }
+    // The y-axis label is centred on the axis, so half its width bleeds
+    // left of it and needs its own room instead of running off the edge.
+    + if has_y_axis_label {
+      y_axis_label_width / 2.0
+    } else {
+      0.0
+    };
   let margin_bottom: f64 = if frame_gutter || (axes.0 && !x_axis_interior) {
     25.0
   } else if frame {
@@ -7638,12 +7675,6 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     0.0
   } + if has_bottom_caption { 20.0 } else { 0.0 };
-  // An AxesLabel sits at the end of its axis (Wolfram's placement), so
-  // the x label needs room to the right and the y label room above.
-  let has_x_axis_label =
-    axes_label.as_ref().is_some_and(|(x, _)| !x.is_empty());
-  let has_y_axis_label =
-    axes_label.as_ref().is_some_and(|(_, y)| !y.is_empty());
   let margin_right: f64 = if frame {
     10.0
   } else if y_axis_interior {
@@ -7652,8 +7683,11 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     6.0
   } else {
     0.0
-  } + if has_x_axis_label { 24.0 } else { 0.0 }
-    + if has_right_caption { 20.0 } else { 0.0 };
+  } + if has_x_axis_label {
+    x_axis_label_width + 8.0
+  } else {
+    0.0
+  } + if has_right_caption { 20.0 } else { 0.0 };
   // A multi-line title (a `Grid`/`Column` label) claims one further line
   // height per extra row on top of the single-line strip.
   let label_strip: f64 = match &plot_label {

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1600,6 +1600,32 @@ pub fn random_variate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
     }
+    Expr::FunctionCall { name, args: dargs }
+      if name == "BernoulliDistribution" && dargs.len() == 1 =>
+    {
+      // BernoulliDistribution[p]: 1 with probability p, 0 with probability
+      // 1 - p (a single Binomial[1, p] trial).
+      let prob = expr_to_num(&dargs[0]).ok_or_else(|| {
+        InterpreterError::EvaluationError(
+          "BernoulliDistribution: invalid success probability".into(),
+        )
+      })?;
+      if !(0.0..=1.0).contains(&prob) {
+        return Ok(unevaluated("RandomVariate", args));
+      }
+      let sample_bernoulli = || -> i128 {
+        crate::with_rng(|rng| (rng.gen_range(0.0..1.0) < prob) as i128)
+      };
+      match n {
+        None => Ok(Expr::Integer(sample_bernoulli())),
+        Some(count) => {
+          let out: Vec<Expr> = (0..count)
+            .map(|_| Expr::Integer(sample_bernoulli()))
+            .collect();
+          Ok(Expr::List(out.into()))
+        }
+      }
+    }
     _ => Ok(unevaluated("RandomVariate", args)),
   }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -6171,6 +6171,80 @@ mod plot3d {
       assert!(!svg.contains("</tspan>"), "{svg}");
     }
 
+    /// A multi-character `AxesLabel` on a plain `Graphics[]` (not a `Plot`,
+    /// which sizes its own margins separately) used to reserve a fixed,
+    /// too-small gutter for the label text, so the outer word ran past the
+    /// declared canvas width and was clipped by the SVG viewport.
+    #[test]
+    fn graphics_axes_label_does_not_overflow_the_canvas() {
+      let svg = export_svg(
+        r#"Graphics[{Rectangle[{0, 0}, {1, 1}]}, Axes -> True,
+          AxesLabel -> {"state", "visits"}, ImageSize -> {260, 240}]"#,
+      );
+      let (canvas_w, canvas_h) = {
+        let tag = svg.lines().next().unwrap();
+        let get = |name: &str| -> f64 {
+          tag
+            .split(&format!("{name}=\""))
+            .nth(1)
+            .and_then(|v| v.split('"').next())
+            .and_then(|v| v.parse().ok())
+            .unwrap()
+        };
+        (get("width"), get("height"))
+      };
+      // The labels are drawn inside `<g transform="translate(mx,my)">`, so
+      // their own `x`/`y` are local to that group — add its offset back to
+      // get canvas-absolute coordinates.
+      let (margin_left, _margin_top) = {
+        let line = svg
+          .lines()
+          .find(|l| l.contains("<g transform=\"translate("))
+          .unwrap_or_else(|| panic!("no margin group: {svg}"));
+        let inner = line
+          .split("translate(")
+          .nth(1)
+          .and_then(|v| v.split(')').next())
+          .unwrap_or_else(|| panic!("bad transform: {line}"));
+        let mut parts = inner.split(',').map(|v| v.parse::<f64>().unwrap());
+        (parts.next().unwrap(), parts.next().unwrap())
+      };
+      let text_tag = |content: &str| -> String {
+        svg
+          .lines()
+          .find(|l| l.contains(&format!(">{content}<")))
+          .unwrap_or_else(|| panic!("no {content} label in {svg}"))
+          .to_string()
+      };
+      let attr = |line: &str, name: &str| -> f64 {
+        line
+          .split(&format!("{name}=\""))
+          .nth(1)
+          .and_then(|v| v.split('"').next())
+          .and_then(|v| v.parse().ok())
+          .unwrap_or_else(|| panic!("no {name} in {line}"))
+      };
+      // The x label starts to the right of the axis and reads left to
+      // right, so its whole run — start plus its rendered width — must
+      // stay left of the canvas edge instead of being clipped by it.
+      let state = text_tag("state");
+      let state_x = margin_left + attr(&state, "x");
+      assert!(
+        state_x + "state".len() as f64 * 7.0 < canvas_w,
+        "x AxesLabel overflows the canvas ({state_x} on a {canvas_w} wide \
+         canvas): {state}"
+      );
+      // The y label is centred on the y axis, so its left half must stay
+      // right of the canvas' left edge (x = 0).
+      let visits = text_tag("visits");
+      let visits_x = margin_left + attr(&visits, "x");
+      assert!(
+        visits_x - "visits".len() as f64 * 7.0 / 2.0 > 0.0,
+        "y AxesLabel overflows the canvas' left edge ({visits_x}): {visits}"
+      );
+      assert!(canvas_h > 0.0, "sanity: canvas has a height");
+    }
+
     /// A named style brings its size and colour from the stylesheet:
     /// `Style[…, "Section"]` is large and orange, `"Label"` small and
     /// black. Measured against wolframscript's own rendering.

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -7134,6 +7134,69 @@ mod random_variate {
   }
 
   #[test]
+  fn bernoulli_single_is_zero_or_one() {
+    // BernoulliDistribution[p] samples 0 or 1, never left unevaluated.
+    assert_eq!(
+      interpret(
+        "AllTrue[Table[RandomVariate[BernoulliDistribution[0.5]], {50}], \
+         (# == 0 || # == 1) &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn bernoulli_deterministic_endpoints() {
+    // p = 0 always gives 0; p = 1 always gives 1.
+    assert_eq!(
+      interpret("RandomVariate[BernoulliDistribution[0]]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("RandomVariate[BernoulliDistribution[1]]").unwrap(),
+      "1"
+    );
+  }
+
+  #[test]
+  fn bernoulli_list_all_zero_or_one() {
+    assert_eq!(
+      interpret(
+        "AllTrue[RandomVariate[BernoulliDistribution[0.5], 100], \
+         (# == 0 || # == 1) &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn bernoulli_mean_near_p() {
+    // Mean of many Bernoulli(0.3) samples should be near p = 0.3.
+    let result: f64 =
+      interpret("Mean[N[RandomVariate[BernoulliDistribution[0.3], 3000]]]")
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(result > 0.2 && result < 0.4, "got {result}");
+  }
+
+  #[test]
+  fn bernoulli_random_integer_matches_random_variate() {
+    // RandomInteger[dist] delegates to RandomVariate exactly like
+    // RandomInteger[BinomialDistribution[...]] does.
+    assert_eq!(
+      interpret(
+        "AllTrue[Table[RandomInteger[BernoulliDistribution[0.5]], {50}], \
+         (# == 0 || # == 1) &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
   fn binormal_single() {
     // BinormalDistribution[rho] is 2-D standard normal with correlation rho.
     let result = interpret("RandomVariate[BinormalDistribution[1/2]]").unwrap();


### PR DESCRIPTION
## Summary

Found while checking whether Woxi Studio fully supports a random Wolfram Demonstrations notebook (a two-state discrete-time Markov chain simulation, fetched via the resource system's `RandomResourcePage` API). It didn't — for two separate, general reasons:

- `RandomVariate[BernoulliDistribution[p]]` (and `RandomInteger[BernoulliDistribution[p]]`, which delegates to it) fell through to the default unevaluated case: `BernoulliDistribution` was already fully supported for `PDF`/`CDF`/`Mean`/`Variance`/etc., but had no sampling implementation, so the interpreter returned symbolic garbage instead of an actual 0/1 draw. Any Manipulate or simulation built on a Bernoulli coin flip silently broke.
- `Graphics[]`'s own `AxesLabel` placement (distinct from `Plot`'s, which already sizes its margin to the label's width) reserved a fixed, too-small gutter for the label text, so multi-character labels (e.g. `"state"`, `"visits"`) ran past the declared `ImageSize` and were clipped by the SVG viewport's edge.

## Changes

- `src/functions/math_ast/random.rs`: add a `BernoulliDistribution[p]` arm to `random_variate_ast`, sampling 1 with probability `p` and 0 otherwise (mirroring the existing `BinomialDistribution` arm).
- `src/functions/graphics.rs`: size `Graphics[]`'s `margin_right`/`margin_left` from the `AxesLabel` text's estimated rendered width instead of a flat constant, so the x label's full run and the y label's centred left half both stay inside the canvas.
- Regression tests for both fixes in `tests/interpreter_tests/list.rs` and `tests/interpreter_tests/graphics.rs`.

No verbatim code from the Demonstration was copied — only the general interpreter gaps it exposed were fixed.

## Test plan

- [x] `make test` (28,499 tests, all passing)
- [x] `make format`
- [x] Manually verified the fixed notebook's Manipulate widget builds without error via `woxi-studio`'s `dump_manipulate`/`dump_notebook` examples, with the bar chart and axis labels now rendering correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwEiiDoTcZKD3rEScQ8kN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwEiiDoTcZKD3rEScQ8kN4)_