### PR TITLE
Fix RandomInteger[{imax}] range parsing for Woxi Studio notebook support

### DIFF
--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -52,6 +52,18 @@ pub fn random_integer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           ))
         }
       }
+      // `RandomInteger[{imax}]` omits `imin`, which defaults to 0 — same as
+      // the bare `RandomInteger[imax]` form (wolframscript accepts both).
+      Expr::List(items) if items.len() == 1 => {
+        if let Expr::Integer(max) = &items[0] {
+          let (lo, hi) = if *max < 0 { (*max, 0) } else { (0, *max) };
+          Ok(Expr::Integer(crate::with_rng(|rng| rng.gen_range(lo..=hi))))
+        } else {
+          Err(InterpreterError::EvaluationError(
+            "RandomInteger: range must be integers".into(),
+          ))
+        }
+      }
       _ => Err(InterpreterError::EvaluationError(
         "RandomInteger: invalid argument".into(),
       )),
@@ -82,6 +94,16 @@ pub fn random_integer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             (&items[0], &items[1])
           {
             (*min, *max)
+          } else {
+            return Err(InterpreterError::EvaluationError(
+              "RandomInteger: range must be integers".into(),
+            ));
+          }
+        }
+        // `RandomInteger[{imax}, dims]` omits `imin`, which defaults to 0.
+        Expr::List(items) if items.len() == 1 => {
+          if let Expr::Integer(max) = &items[0] {
+            (0i128, *max)
           } else {
             return Err(InterpreterError::EvaluationError(
               "RandomInteger: range must be integers".into(),

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -6786,6 +6786,34 @@ mod random_integer {
     );
     assert_eq!(interpret("RandomInteger[0]").unwrap(), "0");
   }
+
+  // `RandomInteger[{imax}]` omits `imin`, which defaults to 0 — same as the
+  // bare `RandomInteger[imax]` form. Regression for the Wolfram
+  // Demonstrations `RandomInteger[{1}, {rows, cols}]` idiom, which used to
+  // raise "invalid range" instead of drawing a 0/1 array.
+  #[test]
+  fn single_element_range() {
+    assert_eq!(
+      interpret("AllTrue[Table[RandomInteger[{5}], {100}], 0 <= # <= 5 &]")
+        .unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn single_element_range_with_dims() {
+    assert_eq!(
+      interpret("Dimensions[RandomInteger[{1}, {20, 10}]]").unwrap(),
+      "{20, 10}"
+    );
+    assert_eq!(
+      interpret(
+        "AllTrue[Flatten[RandomInteger[{1}, {20, 10}]], # == 0 || # == 1 &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
 }
 
 mod distributions {


### PR DESCRIPTION
## Summary

- As part of a scheduled compatibility check, I fetched a random Wolfram
  Demonstration notebook (a cellular-automaton/sound generator) and tested
  it against Woxi Studio's `.nb` parser and the `woxi` interpreter using
  the existing `woxi-studio/examples/{dump_notebook,test_notebook}.rs`
  tooling.
- The notebook's `Manipulate` includes a "random" initial-condition option
  that seeds a grid with `RandomInteger[{1}, {20, 10}]` — a single-element
  list range (`{imax}`, omitting `imin`, which defaults to `0`), same as
  the bare `RandomInteger[imax]` form.
- Woxi's `RandomInteger` only accepted a two-element `{imin, imax}` list
  or a bare integer, so this raised `RandomInteger: invalid range` instead
  of producing a 0/1 array — meaning Woxi Studio could not fully evaluate
  this Demonstration's "random" shape option.
- Fixed both the 1-argument (`RandomInteger[{imax}]`) and 2-argument
  (`RandomInteger[{imax}, dims]`) code paths to treat a single-element
  range list the same as the bare-integer form.
- Added regression unit tests covering both forms.

Note: per the task instructions, no code from the (copyrighted) Demonstration
notebook itself was copied into the repository — the fix and its tests use
independently written reproductions of the underlying construct.

## Test plan

- [x] `make test` (all 28,504 unit tests pass)
- [x] `make format`
- [x] Manually verified via `cargo run --bin woxi -- eval` and the
      `woxi-studio` `dump_notebook`/`test_notebook` example binaries that
      the downloaded Demonstration notebook now parses and evaluates
      without error, including its `RandomInteger[{1}, {20, 10}]`
      "random" branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9CFbvJGy8PQqWDzq7Gy6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9CFbvJGy8PQqWDzq7Gy6V)_