### PR TITLE
Support multidimensional Interpolation coordinate/value pairs; fix FUNC_DEFS reentrancy panic

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -5579,10 +5579,49 @@ pub fn interpolation_ast(
   // equivalent built with `Join`) produces — is 2-D scattered data. It
   // interpolates like `ListInterpolation`'s grid once the distinct x/y
   // coordinates recover the grid structure; see `try_2d_scattered_interpolation`.
-  if head != "ListInterpolation"
-    && matches!(&data_list[0], Expr::List(items) if items.len() == 3)
+  //
+  // The documented multidimensional form `{{{x1, y1}, f1}, {{x2, y2}, f2},
+  // ...}` — a list of `{coords, value}` pairs — carries the same grid, just
+  // nested rather than flattened; normalize it to the flat triple shape so
+  // both reach `try_2d_scattered_interpolation`.
+  let flattened_2d_pairs: Option<Vec<Expr>> = if head != "ListInterpolation"
+    && matches!(&data_list[0], Expr::List(items)
+      if items.len() == 2
+        && matches!(&items[0], Expr::List(coords) if coords.len() == 2)
+        && !matches!(&items[1], Expr::List(_)))
+  {
+    data_list
+      .iter()
+      .map(|item| {
+        let Expr::List(parts) = item else {
+          return None;
+        };
+        if parts.len() != 2 {
+          return None;
+        }
+        let Expr::List(coords) = &parts[0] else {
+          return None;
+        };
+        if coords.len() != 2 {
+          return None;
+        }
+        Some(Expr::List(
+          vec![coords[0].clone(), coords[1].clone(), parts[1].clone()].into(),
+        ))
+      })
+      .collect::<Option<Vec<Expr>>>()
+  } else {
+    None
+  };
+  let triples_2d: Option<&[Expr]> =
+    flattened_2d_pairs.as_deref().or_else(|| {
+      (head != "ListInterpolation"
+        && matches!(&data_list[0], Expr::List(items) if items.len() == 3))
+      .then_some(data_list.as_slice())
+    });
+  if let Some(triples) = triples_2d
     && let Some(result) = try_2d_scattered_interpolation(
-      data_list,
+      triples,
       interp_order_xy.map_or(interp_order, |(a, _)| a),
       interp_order_xy.map_or(interp_order, |(_, b)| b),
       head,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6100,9 +6100,17 @@ fn store_function_definition(
     )
   };
 
-  FUNC_DEFS.with(|m| {
+  // `rule_dominates` below may evaluate a candidate rule's default/condition
+  // expressions (e.g. to compare `x_:f[]` against another optional default)
+  // and that evaluation can reach `get_defined_names`, which reads
+  // `FUNC_DEFS` itself. Holding this thread local's `borrow_mut` across that
+  // call would panic on the reentrant borrow, so the retain — the only step
+  // that actually mutates `entry` — runs under its own short borrow, and the
+  // rule-ordering comparison runs against a snapshot taken after it, with no
+  // borrow of `FUNC_DEFS` live.
+  let snapshot: Vec<_> = FUNC_DEFS.with(|m| {
     let mut defs = m.borrow_mut();
-    let entry = defs.entry(func_name).or_insert_with(Vec::new);
+    let entry = defs.entry(func_name.clone()).or_insert_with(Vec::new);
     let arity = params.len();
     if has_any_condition {
       // Conditional definition: only remove existing definitions with same arity
@@ -6143,31 +6151,39 @@ fn store_function_definition(
           || evaluator::assignment::body_is_conditional(body)
       });
     }
-    // Add the new definition with parsed AST, conditions, defaults, and head constraints.
-    // Insert by the rule partial order: place the new rule before the first
-    // existing rule it strictly dominates (is more specific than). Rules it does
-    // not dominate — including incomparable ones, such as a guarded but
-    // structurally looser rule vs an unguarded tighter one — keep definition
-    // order, matching Wolfram.
-    let pos = entry
-      .iter()
-      .position(|(p, c, d, h, bt, b)| {
-        crate::evaluator::assignment::rule_dominates(
-          &params,
-          &heads,
-          &blank_types,
-          &conditions,
-          &defaults,
-          &body_expr,
-          p,
-          h,
-          bt,
-          c,
-          d,
-          b,
-        )
-      })
-      .unwrap_or(entry.len());
+    entry.clone()
+  });
+  // Add the new definition with parsed AST, conditions, defaults, and head constraints.
+  // Insert by the rule partial order: place the new rule before the first
+  // existing rule it strictly dominates (is more specific than). Rules it does
+  // not dominate — including incomparable ones, such as a guarded but
+  // structurally looser rule vs an unguarded tighter one — keep definition
+  // order, matching Wolfram.
+  let pos = snapshot
+    .iter()
+    .position(|(p, c, d, h, bt, b)| {
+      crate::evaluator::assignment::rule_dominates(
+        &params,
+        &heads,
+        &blank_types,
+        &conditions,
+        &defaults,
+        &body_expr,
+        p,
+        h,
+        bt,
+        c,
+        d,
+        b,
+      )
+    })
+    .unwrap_or(snapshot.len());
+  FUNC_DEFS.with(|m| {
+    let mut defs = m.borrow_mut();
+    let entry = defs.entry(func_name).or_insert_with(Vec::new);
+    // `entry` may have grown or shrunk since the snapshot if `rule_dominates`
+    // reentrantly stored another definition; clamp rather than panic.
+    let pos = pos.min(entry.len());
     entry.insert(
       pos,
       (params, conditions, defaults, heads, blank_types, body_expr),

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -12282,6 +12282,78 @@ mod interpolation_2d_scattered {
        blame NDSolve: {err}"
     );
   }
+
+  // The documented multidimensional scattered-data form is a list of
+  // `{coords, value}` pairs — `{{{x1, y1}, f1}, {{x2, y2}, f2}, ...}` —
+  // rather than the flat `{x, y, z}` triples `Flatten[Table[Table[…]]]`
+  // produces. Both shapes describe the same grid and must interpolate
+  // identically.
+  mod coordinate_value_pairs {
+    use super::*;
+
+    #[test]
+    fn exact_grid_point_matches_flat_triple_form() {
+      assert_eq!(
+        interpret(
+          "Interpolation[Flatten[Table[{{x, y}, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+           InterpolationOrder -> 1][1, 1]"
+        )
+        .unwrap(),
+        "3"
+      );
+    }
+
+    #[test]
+    fn interpolated_point_matches_flat_triple_form() {
+      assert_eq!(
+        interpret(
+          "Interpolation[Flatten[Table[{{x, y}, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+           InterpolationOrder -> 1][2.5, 1.5]"
+        )
+        .unwrap(),
+        "5.5"
+      );
+    }
+
+    #[test]
+    fn per_axis_interpolation_order() {
+      assert_eq!(
+        interpret(
+          "Interpolation[Flatten[Table[{{x, y}, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+           InterpolationOrder -> {1, 1}][2, 3]"
+        )
+        .unwrap(),
+        "8"
+      );
+    }
+
+    #[test]
+    fn property_domain() {
+      assert_eq!(
+        interpret(
+          "Interpolation[Flatten[Table[{{x, y}, x + y}, {x, 0, 3}, {y, 0, 3}], 1]][\"Domain\"]"
+        )
+        .unwrap(),
+        "{{0, 3}, {0, 3}}"
+      );
+    }
+
+    // Scattered (non-rectangular) `{coords, value}` data falls back to the
+    // ordinary handling exactly like the flat-triple form does, rather than
+    // being misread as a partial grid.
+    #[test]
+    fn incomplete_grid_does_not_crash_or_blame_ndsolve() {
+      let err =
+        interpret("Interpolation[{{{1, 1}, 2}, {{1, 2}, 3}, {{2, 1}, 4}}]")
+          .unwrap_err()
+          .to_string();
+      assert!(
+        !err.contains("NDSolve"),
+        "a numeric-conversion failure reached from Interpolation must not \
+         blame NDSolve: {err}"
+      );
+    }
+  }
 }
 
 mod trig_expand {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -22452,6 +22452,35 @@ SaveDefinitions -> True]";
     );
   }
 
+  /// Regression test for a `RefCell` reentrancy panic in
+  /// `store_function_definition` (`src/lib.rs`): comparing a newly stored
+  /// rule against the function's existing overloads (to place it by
+  /// specificity) can itself evaluate a guard expression, which can define
+  /// a qualified symbol and read `FUNC_DEFS` back — while the outer scan
+  /// still held it mutably borrowed. `set_delayed_ast` (the AST-evaluation
+  /// path `Initialization :> (...)` runs through) already released its
+  /// borrow before each comparison for exactly this reason;
+  /// `store_function_definition` (the fresh-source-text path a top-level
+  /// `f[x_] := body` line parses through) had drifted from it and still
+  /// held the borrow across `rule_dominates`. Two same-arity guarded
+  /// overloads of one helper are enough to trigger the comparison.
+  #[test]
+  fn guarded_helper_overloads_in_manipulate_initialization_do_not_panic() {
+    let code = "Manipulate[\
+      r1 + r2, \
+      {{r1, 6, \"left radius\"}, 2, 9, 1, Appearance -> \"Labeled\"}, \
+      {{r2, 4, \"right radius\"}, 2, 9, 1, Appearance -> \"Labeled\"}, \
+      Initialization :> (\
+        smallerRadius[r1_, r2_ /; r1 <= r2] := r1; \
+        smallerRadius[r1_, r2_ /; r1 > r2] := r2; \
+      )]";
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("minimal guarded-Initialization helper should build a state");
+    assert!(state.error.is_none(), "error: {:?}", state.error);
+  }
+
   /// Checked a randomly-sampled Wolfram Demonstrations Project notebook
   /// showing two externally tangent semicircles resting on a line, with a
   /// chain of progressively smaller circles inscribed between them.


### PR DESCRIPTION
## Summary
- `Interpolation` on 2-D scattered data now accepts the documented coordinate/value-pair form `{{{x, y}, f}, ...}` in addition to the flat `{x, y, f}` triple form it already supported — needed by a randomly-sampled Wolfram Demonstrations Project notebook (Ranque-Hilsch Vortex Tube) that stores its interpolation data that way.
- Fixed a pre-existing crash surfaced while getting that notebook's `Manipulate` to build in Woxi Studio: `store_function_definition` held the `FUNC_DEFS` thread-local borrowed mutably while calling `rule_dominates`, which can itself evaluate a guard expression and read `FUNC_DEFS` back, panicking on the reentrant borrow (`RefCell already mutably borrowed`). `set_delayed_ast` already avoided this exact hazard by releasing the borrow before each comparison; `store_function_definition` had drifted from that pattern and was brought back in line.

## Test plan
- [x] Added unit tests for the coordinate/value-pair `Interpolation` form in `tests/interpreter_tests/calculus.rs` (exact grid point, interpolated point, per-axis order, `"Domain"` property, incomplete-grid fallback)
- [x] Added a regression test in `woxi-studio/src/main.rs` reproducing the `FUNC_DEFS` reentrancy panic via two same-arity guarded overloads in a `Manipulate` `Initialization` block
- [x] `make test` — all 28504 tests pass
- [x] `cargo nextest run -p woxi-studio` — 226/227 pass (the one failure, `demonstration_two_pivoting_rays_trace_their_intersection`, is a pre-existing floating-point ULP-precision flake unrelated to this change, confirmed to already fail on `main`)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NGZuyJQFBXxtjyGkVxKTH


---
_Generated by [Claude Code](https://claude.ai/code/session_019NGZuyJQFBXxtjyGkVxKTH)_