### PR TITLE
Introduce fn id_expr helper, part 3

### DIFF
--- a/src/functions/audio_ast/data.rs
+++ b/src/functions/audio_ast/data.rs
@@ -158,7 +158,7 @@ pub fn make_audio(audio: &AudioData) -> Expr {
     vec![
       data,
       Expr::Rule {
-        pattern: Box::new(Expr::Identifier("SampleRate".to_string())),
+        pattern: Box::new(id_expr("SampleRate")),
         replacement: Box::new(rate_expr),
       },
     ],

--- a/src/functions/audio_ast/filters.rs
+++ b/src/functions/audio_ast/filters.rs
@@ -331,7 +331,7 @@ pub fn lowpass_filter_audio_ast(
       Expr::Real(omega),
       Expr::Integer(taps as i128),
       Expr::Rule {
-        pattern: Box::new(Expr::Identifier("SampleRate".to_string())),
+        pattern: Box::new(id_expr("SampleRate")),
         replacement: Box::new(Expr::Real(audio.rate)),
       },
     ]);

--- a/src/functions/audio_ast/mod.rs
+++ b/src/functions/audio_ast/mod.rs
@@ -1,6 +1,4 @@
-use crate::InterpreterError;
-use crate::helpers::{bool_expr, call, call1, unevaluated};
-use crate::syntax::{Expr, expr_to_string};
+use super::*;
 
 pub mod data;
 pub mod edit;

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -431,7 +431,7 @@ pub fn which_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// While[test, body] or While[test] - While loop
@@ -486,7 +486,7 @@ pub fn while_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Equal[a, b] or a == b - Tests for equality

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -90,7 +90,7 @@ pub fn d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       })
       .collect();
     let rule = Expr::Rule {
-      pattern: Box::new(Expr::Identifier("NonConstants".to_string())),
+      pattern: Box::new(id_expr("NonConstants")),
       replacement: Box::new(Expr::List(non_constants.into())),
     };
     let mut new_args = vec![expr.clone()];
@@ -515,7 +515,7 @@ pub fn integrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       match &args[0] {
         Expr::Identifier(s) if s == "Infinity" && lo_ne_hi => {
-          return Ok(Expr::Identifier("Infinity".to_string()));
+          return Ok(id_expr("Infinity"));
         }
         Expr::UnaryOp {
           op: UnaryOperator::Minus,
@@ -1074,16 +1074,10 @@ fn try_dirac_delta_integral(
     }
     // Symbolic root over the whole real line: the delta always fires for a
     // real root → ConditionalExpression[g(x0)/|c|, x0 ∈ Reals].
-    None if is_negative_infinity(lo) && is_infinity(hi) => {
-      Some(Expr::FunctionCall {
-        name: "ConditionalExpression".to_string(),
-        args: vec![
-          sifted,
-          call("Element", vec![root, Expr::Identifier("Reals".to_string())]),
-        ]
-        .into(),
-      })
-    }
+    None if is_negative_infinity(lo) && is_infinity(hi) => Some(call(
+      "ConditionalExpression",
+      vec![sifted, call("Element", vec![root, id_expr("Reals")])],
+    )),
     // Symbolic root with finite bounds: position is undetermined — leave it
     // unevaluated (Wolfram returns a Piecewise/HeavisideTheta form).
     None => None,
@@ -2381,7 +2375,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               name: "Piecewise".to_string(),
               args: vec![
                 Expr::List(diffed_pieces.into()),
-                Expr::Identifier("Indeterminate".to_string()),
+                id_expr("Indeterminate"),
               ]
               .into(),
             })
@@ -3058,7 +3052,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let deriv_expr = Expr::CurriedCall {
             func: Box::new(Expr::CurriedCall {
               func: Box::new(call("Derivative", vec![Expr::Integer(1)])),
-              args: vec![Expr::Identifier("Abs".to_string())],
+              args: vec![id_expr("Abs")],
             }),
             args: args.to_vec(),
           };
@@ -3093,7 +3087,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let deriv_expr = Expr::CurriedCall {
             func: Box::new(Expr::CurriedCall {
               func: Box::new(call("Derivative", vec![Expr::Integer(1)])),
-              args: vec![Expr::Identifier("Sign".to_string())],
+              args: vec![id_expr("Sign")],
             }),
             args: args.to_vec(),
           };
@@ -3692,7 +3686,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                 )]
                 .into(),
               ),
-              Expr::Identifier("Indeterminate".to_string()),
+              id_expr("Indeterminate"),
             ]
             .into(),
           };
@@ -3733,7 +3727,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               Expr::List(
                 vec![Expr::List(vec![Expr::Integer(0), cond].into())].into(),
               ),
-              Expr::Identifier("Indeterminate".to_string()),
+              id_expr("Indeterminate"),
             ]
             .into(),
           };
@@ -3768,7 +3762,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               Expr::List(
                 vec![Expr::List(
                   vec![
-                    Expr::Identifier("Indeterminate".to_string()),
+                    id_expr("Indeterminate"),
                     Expr::Comparison {
                       operands: vec![args[0].clone(), Expr::Integer(0)],
                       operators: vec![ComparisonOp::Equal],
@@ -3817,7 +3811,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                 ]
                 .into(),
               ),
-              Expr::Identifier("Indeterminate".to_string()),
+              id_expr("Indeterminate"),
             ]
             .into(),
           };
@@ -9106,7 +9100,7 @@ fn harmonic_asymptotic(g: &Expr) -> Expr {
     name: "Plus".to_string(),
     args: vec![
       call1("Log", g.clone()),
-      Expr::Identifier("EulerGamma".to_string()),
+      id_expr("EulerGamma"),
       term(1, 2, -1),
       term(-1, 12, -2),
       term(1, 120, -4),
@@ -9193,11 +9187,8 @@ fn eval_at_infinity_is_one(expr: &Expr, var: &str) -> bool {
   }
   // Symbolic fallback for a base with free parameters (e.g. 1 + a/n): with
   // var -> Infinity the var-dependent terms vanish and the base is exactly 1.
-  let subst_inf = crate::syntax::substitute_variable(
-    expr,
-    var,
-    &Expr::Identifier("Infinity".to_string()),
-  );
+  let subst_inf =
+    crate::syntax::substitute_variable(expr, var, &id_expr("Infinity"));
   matches!(
     crate::evaluator::evaluate_expr_to_expr(&subst_inf),
     Ok(Expr::Integer(1))
@@ -9287,7 +9278,7 @@ fn limit_bounded_oscillating_sum(expr: &Expr, var_name: &str) -> Option<Expr> {
   // All same degree → Indeterminate. Otherwise → Interval[{-bound, bound}].
   let all_same_degree = degrees.windows(2).all(|w| w[0] == w[1]);
   if all_same_degree {
-    return Some(Expr::Identifier("Indeterminate".to_string()));
+    return Some(id_expr("Indeterminate"));
   }
   let bound: i128 = coeffs_abs.iter().sum();
   Some(Expr::FunctionCall {
@@ -10056,7 +10047,7 @@ fn limit_at_infinity(
       // and keeps wolframscript's `a Infinity` for a symbolic one.
       return crate::evaluator::evaluate_expr_to_expr(&times2(
         coeff,
-        Expr::Identifier("Infinity".to_string()),
+        id_expr("Infinity"),
       ));
     } else if order < -ORDER_EPS {
       return Ok(Expr::Integer(0));
@@ -10113,7 +10104,7 @@ fn limit_at_infinity(
     && let Expr::Identifier(arg_name) = &targs[0]
     && arg_name == var_name
   {
-    return Ok(Expr::Identifier("Indeterminate".to_string()));
+    return Ok(id_expr("Indeterminate"));
   }
 
   // Bounded oscillating sum at infinity: a sum of Sin/Cos terms with
@@ -10180,9 +10171,9 @@ fn limit_at_infinity(
   // grow slowly: Log[x], Sqrt[x], x^(1/3), Log[2 x], Log[Log[x]], Log[x]^2, …
   if let Some(s) = diverges_to_infinity(expr, var_name, point) {
     return Ok(if s >= 0 {
-      Expr::Identifier("Infinity".to_string())
+      id_expr("Infinity")
     } else {
-      neg1(Expr::Identifier("Infinity".to_string()))
+      neg1(id_expr("Infinity"))
     });
   }
 
@@ -10230,11 +10221,11 @@ fn limit_at_infinity(
   if let (Some(f1), Some(f2)) = (val1, val2) {
     // Both diverging to +infinity
     if f1 > 1e5 && f2 > f1 {
-      return Ok(Expr::Identifier("Infinity".to_string()));
+      return Ok(id_expr("Infinity"));
     }
     // Both diverging to -infinity
     if f1 < -1e5 && f2 < f1 {
-      return Ok(neg1(Expr::Identifier("Infinity".to_string())));
+      return Ok(neg1(id_expr("Infinity")));
     }
     // Approaching zero: both values small and getting smaller
     if f2.abs() < 1e-4 && f2.abs() < f1.abs() {
@@ -10420,9 +10411,9 @@ fn exp_growth_limit_at_infinity(
   // Divergence to ±Infinity.
   if f1.abs() > 1e5 && f2.abs() > f1.abs() {
     return Some(if f2 > 0.0 {
-      Expr::Identifier("Infinity".to_string())
+      id_expr("Infinity")
     } else {
-      neg1(Expr::Identifier("Infinity".to_string()))
+      neg1(id_expr("Infinity"))
     });
   }
   // Approaching zero — both probes tiny and shrinking (the relative-agreement
@@ -10552,7 +10543,7 @@ fn one_sided_limit_ast(
     LimitDirection::TwoSided => "FromAbove",
   };
   let direction_opt = Expr::Rule {
-    pattern: Box::new(Expr::Identifier("Direction".to_string())),
+    pattern: Box::new(id_expr("Direction")),
     replacement: Box::new(Expr::String(dir_str.to_string())),
   };
 
@@ -10605,7 +10596,7 @@ fn bounded_trig_extremum(
     && bounded_trig_extremum(&iargs[0], rule, "MaxLimit")?.is_some()
   {
     return Ok(Some(if fn_name == "MaxLimit" {
-      Expr::Identifier("Infinity".to_string())
+      id_expr("Infinity")
     } else {
       Expr::Integer(1)
     }));
@@ -10626,7 +10617,7 @@ fn bounded_trig_extremum(
       let base = call1(partner, iargs[0].clone());
       return Ok(bounded_trig_extremum(&base, rule, "MaxLimit")?.map(|_| {
         if fn_name == "MaxLimit" {
-          Expr::Identifier("Infinity".to_string())
+          id_expr("Infinity")
         } else {
           Expr::Integer(1)
         }
@@ -10643,9 +10634,9 @@ fn bounded_trig_extremum(
     let base = call1(partner, fargs[0].clone());
     return Ok(bounded_trig_extremum(&base, rule, "MaxLimit")?.map(|_| {
       if fn_name == "MaxLimit" {
-        Expr::Identifier("Infinity".to_string())
+        id_expr("Infinity")
       } else {
-        neg1(Expr::Identifier("Infinity".to_string()))
+        neg1(id_expr("Infinity"))
       }
     }));
   }
@@ -11208,7 +11199,7 @@ fn reconcile_one_sided_direct(
       && hi.is_finite()
       && (lo - hi).abs() > 1e-6 * (1.0 + lo.abs().max(hi.abs()))
     {
-      return Expr::Identifier("Indeterminate".to_string());
+      return id_expr("Indeterminate");
     }
     return direct;
   }
@@ -11263,9 +11254,9 @@ fn numerical_one_sided_limit(
       .find(|v| !v.is_infinite())
       .map_or_else(|| vals[0].is_sign_positive(), |v| *v > 0.0);
     if sign_positive {
-      return Some(Expr::Identifier("Infinity".to_string()));
+      return Some(id_expr("Infinity"));
     }
-    return Some(neg1(Expr::Identifier("Infinity".to_string())));
+    return Some(neg1(id_expr("Infinity")));
   }
 
   // Check if the values are monotonically diverging (sign consistent, magnitude increasing)
@@ -11277,9 +11268,9 @@ fn numerical_one_sided_limit(
     // Check that the growth is unbounded (magnitude at least doubles over the range)
     if vals.last().unwrap().abs() > 2.0 * vals.first().unwrap().abs() {
       if all_positive {
-        return Some(Expr::Identifier("Infinity".to_string()));
+        return Some(id_expr("Infinity"));
       }
-      return Some(neg1(Expr::Identifier("Infinity".to_string())));
+      return Some(neg1(id_expr("Infinity")));
     }
   }
 
@@ -11331,7 +11322,7 @@ fn numerical_two_sided_limit(
           return Some(a);
         }
         // Sides disagree — indeterminate
-        Some(Expr::Identifier("Indeterminate".to_string()))
+        Some(id_expr("Indeterminate"))
       } else {
         // At least one side is infinite — check if they match symbolically
         let a_str = expr_to_string(&a);
@@ -11340,7 +11331,7 @@ fn numerical_two_sided_limit(
           return Some(a);
         }
         // Different infinities — indeterminate
-        Some(Expr::Identifier("Indeterminate".to_string()))
+        Some(id_expr("Indeterminate"))
       }
     }
     _ => None,
@@ -12100,13 +12091,13 @@ fn limit_strategies(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let even_integer =
       (k - k.round()).abs() <= ORDER_EPS && (k.round() as i64) % 2 == 0;
     if !even_integer {
-      return Ok(Expr::Identifier("Indeterminate".to_string()));
+      return Ok(id_expr("Indeterminate"));
     }
     if let Some(c) = crate::functions::math_ast::try_eval_to_f64(&coeff) {
       return Ok(if c > 0.0 {
-        Expr::Identifier("Infinity".to_string())
+        id_expr("Infinity")
       } else {
-        neg1(Expr::Identifier("Infinity".to_string()))
+        neg1(id_expr("Infinity"))
       });
     }
   }
@@ -12617,7 +12608,7 @@ fn rewrite_pole_models(
       let um1 = plus(vec![u.clone(), Expr::Integer(-1)]);
       return plus(vec![
         pow(um1.clone(), -1),
-        Expr::Identifier("EulerGamma".to_string()),
+        id_expr("EulerGamma"),
         times(vec![
           Expr::Integer(-1),
           call("StieltjesGamma", vec![Expr::Integer(1)]),
@@ -12830,7 +12821,7 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let simplify_full = |e: Expr| -> Expr {
     let e = crate::evaluator::evaluate_expr_to_expr(&e).unwrap_or(e);
     crate::evaluator::evaluate_expr_to_expr(&call("Simplify", vec![e]))
-      .unwrap_or_else(|_| Expr::Identifier("Indeterminate".to_string()))
+      .unwrap_or_else(|_| id_expr("Indeterminate"))
   };
 
   // The internal pole-order probes evaluate at the singularity and would
@@ -14497,7 +14488,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       let mut new_sd = sd.to_vec();
       new_sd[0] = Expr::Identifier(var_name.clone());
-      new_sd[1] = Expr::Identifier("Infinity".to_string());
+      new_sd[1] = id_expr("Infinity");
       return Ok(call("SeriesData", new_sd));
     }
     // Could not produce a clean expansion — leave the call symbolic instead of
@@ -14798,14 +14789,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Log[x]
         Expr::Identifier(var_name.clone())
       };
-      let c0 = Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![
-          Expr::Identifier("EulerGamma".to_string()),
-          call1("Log", log_arg),
-        ]
-        .into(),
-      };
+      let c0 = call("Plus", vec![id_expr("EulerGamma"), call1("Log", log_arg)]);
       let mut coefficients = vec![c0];
       let mut factorial: i128 = 1;
       for k in 1..=order {
@@ -17035,7 +17019,7 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // and solve this polynomial for t using Solve
 
   // Build the polynomial expression in a temporary variable
-  let t_var = Expr::Identifier("AsymptoticSolve$t".to_string());
+  let t_var = id_expr("AsymptoticSolve$t");
 
   let mut poly_terms: Vec<Expr> = Vec::new();
   for (i, coeff) in coeffs.iter().enumerate() {
@@ -17083,7 +17067,7 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         operands: vec![poly_expr, Expr::Integer(0)],
         operators: vec![ComparisonOp::Equal],
       },
-      Expr::Identifier("AsymptoticSolve$t".to_string()),
+      id_expr("AsymptoticSolve$t"),
     ]
     .into(),
   };
@@ -17300,15 +17284,8 @@ pub fn discrete_convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::List(
         vec![
           k_expr,
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              Expr::Integer(-1),
-              Expr::Identifier("Infinity".to_string()),
-            ]
-            .into(),
-          },
-          Expr::Identifier("Infinity".to_string()),
+          call("Times", vec![Expr::Integer(-1), id_expr("Infinity")]),
+          id_expr("Infinity"),
         ]
         .into(),
       ),
@@ -18783,7 +18760,7 @@ fn series_at_infinity(
   };
   let mut rebased = series_args;
   rebased[0] = Expr::Identifier(var.to_string());
-  rebased[1] = Expr::Identifier("Infinity".to_string());
+  rebased[1] = id_expr("Infinity");
   Ok(Some(call("SeriesData", rebased)))
 }
 
@@ -18814,8 +18791,8 @@ impl Verdict {
 
   fn into_expr(self) -> Option<Expr> {
     match self {
-      Self::True => Some(Expr::Identifier("True".to_string())),
-      Self::False => Some(Expr::Identifier("False".to_string())),
+      Self::True => Some(bool_expr(true)),
+      Self::False => Some(bool_expr(false)),
       Self::Unknown => None,
     }
   }

--- a/src/functions/code_parser.rs
+++ b/src/functions/code_parser.rs
@@ -91,7 +91,7 @@ impl Token {
         Expr::Identifier(self.kind.clone()),
         Expr::String(self.text.clone()),
         Expr::Association(vec![(
-          Expr::Identifier("CodeParser`Source".to_string()),
+          id_expr("CodeParser`Source"),
           self.source(convention),
         )]),
       ]
@@ -998,7 +998,7 @@ fn group_tokens(
           Expr::Identifier(kind.to_string()),
           Expr::List(children.into()),
           Expr::Association(vec![(
-            Expr::Identifier("CodeParser`Source".to_string()),
+            id_expr("CodeParser`Source"),
             group.source(convention),
           )]),
         ]
@@ -1027,7 +1027,7 @@ pub fn code_concrete_parse(source: &str, convention: Convention) -> Expr {
   Expr::FunctionCall {
     name: "CodeParser`ContainerNode".to_string(),
     args: vec![
-      Expr::Identifier("String".to_string()),
+      id_expr("String"),
       Expr::List(children.into()),
       Expr::Association(vec![]),
     ]
@@ -1047,9 +1047,11 @@ pub fn code_parse(source: &str, convention: Convention) -> Expr {
   let children = match crate::parse(&prepared) {
     Ok(pairs) => pairs
       .filter(|pair| !matches!(pair.as_rule(), crate::Rule::EOI))
-      .map(|pair| Expr::FunctionCall {
-        name: "CodeParser`Abstract`Node".to_string(),
-        args: vec![crate::syntax::pair_to_expr(pair)].into(),
+      .map(|pair| {
+        call1(
+          "CodeParser`Abstract`Node",
+          crate::syntax::pair_to_expr(pair),
+        )
       })
       .collect::<Vec<_>>(),
     Err(error) => vec![error_node(source, &error.to_string(), convention)],
@@ -1057,7 +1059,7 @@ pub fn code_parse(source: &str, convention: Convention) -> Expr {
   Expr::FunctionCall {
     name: "CodeParser`ContainerNode".to_string(),
     args: vec![
-      Expr::Identifier("String".to_string()),
+      id_expr("String"),
       Expr::List(children.into()),
       Expr::Association(vec![]),
     ]
@@ -1085,12 +1087,9 @@ fn error_node(source: &str, message: &str, convention: Convention) -> Expr {
   Expr::FunctionCall {
     name: "CodeParser`ErrorNode".to_string(),
     args: vec![
-      Expr::Identifier("Token`Error`UnexpectedCharacter".to_string()),
+      id_expr("Token`Error`UnexpectedCharacter"),
       Expr::String(message.to_string()),
-      Expr::Association(vec![(
-        Expr::Identifier("CodeParser`Source".to_string()),
-        span,
-      )]),
+      Expr::Association(vec![(id_expr("CodeParser`Source"), span)]),
     ]
     .into(),
   }

--- a/src/functions/confirm_ast.rs
+++ b/src/functions/confirm_ast.rs
@@ -433,5 +433,5 @@ pub fn exception_types_ast(_args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn exception_type_registered_q_ast(
   _args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  Ok(Expr::Identifier("False".to_string()))
+  Ok(bool_expr(false))
 }

--- a/src/functions/convex_hull.rs
+++ b/src/functions/convex_hull.rs
@@ -124,11 +124,11 @@ fn convex_hull_mesh_2d(pts: &[Expr], args: &[Expr]) -> Expr {
   // Options. Method -> {"SeparateBoundaries" -> False} always; exact inputs also
   // carry WorkingPrecision -> Infinity.
   let method = Expr::Rule {
-    pattern: Box::new(Expr::Identifier("Method".to_string())),
+    pattern: Box::new(id_expr("Method")),
     replacement: Box::new(Expr::List(
       vec![Expr::Rule {
         pattern: Box::new(Expr::String("SeparateBoundaries".to_string())),
-        replacement: Box::new(Expr::Identifier("False".to_string())),
+        replacement: Box::new(bool_expr(false)),
       }]
       .into(),
     )),
@@ -141,8 +141,8 @@ fn convex_hull_mesh_2d(pts: &[Expr], args: &[Expr]) -> Expr {
   ];
   if all_exact {
     mesh_args.push(Expr::Rule {
-      pattern: Box::new(Expr::Identifier("WorkingPrecision".to_string())),
-      replacement: Box::new(Expr::Identifier("Infinity".to_string())),
+      pattern: Box::new(id_expr("WorkingPrecision")),
+      replacement: Box::new(id_expr("Infinity")),
     });
   }
 

--- a/src/functions/convolve_ast.rs
+++ b/src/functions/convolve_ast.rs
@@ -64,7 +64,7 @@ pub fn convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let unit_step_y = || call1("UnitStep", y.clone());
   let times = |factors: Vec<Expr>| call("Times", factors);
-  let e_sym = || Expr::Identifier("E".to_string());
+  let e_sym = || id_expr("E");
 
   // UnitStep[x] ⊛ UnitStep[x] → y*UnitStep[y]
   if is_call_on_x(&args[0], "UnitStep") && is_call_on_x(&args[1], "UnitStep") {

--- a/src/functions/csv_ast.rs
+++ b/src/functions/csv_ast.rs
@@ -274,7 +274,7 @@ pub fn csv_import_element(rows: &[Vec<String>], element: Option<&str>) -> Expr {
       if labelled {
         Expr::List(header.iter().map(|s| Expr::String(s.clone())).collect())
       } else {
-        Expr::Identifier("None".to_string())
+        id_expr("None")
       }
     }
 
@@ -460,7 +460,7 @@ pub fn csv_import_data_spec(
     crate::emit_message(
       "Import::noelem: The Import element is not present when importing as CSV.",
     );
-    Expr::Identifier("$Failed".to_string())
+    fail_expr()
   };
   let Some(row_idx) = resolve_position_spec(row_spec, rows.len()) else {
     return Ok(noelem());

--- a/src/functions/dataset_ast.rs
+++ b/src/functions/dataset_ast.rs
@@ -9,10 +9,7 @@ fn infer_type(expr: &Expr) -> Expr {
     Expr::String(_) => ts_atom("String"),
     Expr::Identifier(name) if name == "True" || name == "False" => {
       // TypeSystem`Atom[TypeSystem`Boolean]
-      call1(
-        "TypeSystem`Atom",
-        Expr::Identifier("TypeSystem`Boolean".to_string()),
-      )
+      call1("TypeSystem`Atom", id_expr("TypeSystem`Boolean"))
     }
     Expr::Identifier(name) if name == "Null" => ts_atom("Null"),
     Expr::Identifier(_) => ts_atom("String"),

--- a/src/functions/datetime_ast.rs
+++ b/src/functions/datetime_ast.rs
@@ -1078,7 +1078,7 @@ fn date_object_interval_bounds(obj_args: &[Expr]) -> Option<Expr> {
     out
   };
   let time_zone = if matches!(granularity, "Year" | "Month" | "Day") {
-    Expr::Identifier("None".to_string())
+    id_expr("None")
   } else {
     Expr::Real(0.0)
   };

--- a/src/functions/delaunay.rs
+++ b/src/functions/delaunay.rs
@@ -186,8 +186,8 @@ pub fn delaunay_mesh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   if exact {
     mesh_args.push(Expr::Rule {
-      pattern: Box::new(Expr::Identifier("WorkingPrecision".to_string())),
-      replacement: Box::new(Expr::Identifier("Infinity".to_string())),
+      pattern: Box::new(id_expr("WorkingPrecision")),
+      replacement: Box::new(id_expr("Infinity")),
     });
   }
   Ok(call("MeshRegion", mesh_args))

--- a/src/functions/dendrogram.rs
+++ b/src/functions/dendrogram.rs
@@ -303,7 +303,7 @@ fn distance_matrix(
 
   // Automatic: strings, compared by edit distance.
   if evaluated.iter().all(|e| matches!(e, Expr::String(_))) {
-    let edit = Expr::Identifier("EditDistance".to_string());
+    let edit = id_expr("EditDistance");
     let ok = fill(&|i, j| {
       apply_func_to_two_args(&edit, &evaluated[i], &evaluated[j])
         .ok()

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -279,9 +279,9 @@ fn assemble_value(quarter: i128, num: i128, den: i128) -> Expr {
   if num == 0 {
     return match quarter {
       0 => Expr::Integer(1),
-      1 => Expr::Identifier("I".to_string()),
+      1 => id_expr("I"),
       2 => Expr::Integer(-1),
-      _ => neg1(Expr::Identifier("I".to_string())),
+      _ => neg1(id_expr("I")),
     };
   }
   // Principal branch: the printed multiple of Pi is m = a/b = 2*num/den
@@ -554,14 +554,10 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(re_expr);
   }
   let im_expr = crate::functions::make_rational_expr(&im.0, &im.1);
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![
-      re_expr,
-      call("Times", vec![im_expr, Expr::Identifier("I".to_string())]),
-    ]
-    .into(),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&call(
+    "Plus",
+    vec![re_expr, call("Times", vec![im_expr, id_expr("I")])],
+  ))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/functions/element_data.rs
+++ b/src/functions/element_data.rs
@@ -2537,14 +2537,10 @@ fn format_electron_configuration_row(elem: &Element) -> Expr {
     parts.push(Expr::FunctionCall {
       name: "Superscript".to_string(),
       args: vec![
-        Expr::FunctionCall {
-          name: "Style".to_string(),
-          args: vec![
-            Expr::String(letter.to_string()),
-            Expr::Identifier("Italic".to_string()),
-          ]
-          .into(),
-        },
+        call(
+          "Style",
+          vec![Expr::String(letter.to_string()), id_expr("Italic")],
+        ),
         Expr::Integer(count),
       ]
       .into(),

--- a/src/functions/entity_ast.rs
+++ b/src/functions/entity_ast.rs
@@ -298,7 +298,7 @@ pub fn entity_unregister_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           stores.remove(idx);
         }
       });
-      Ok(Expr::Identifier("Null".to_string()))
+      Ok(null_expr())
     }
     _ => Ok(unevaluated("EntityUnregister", args)),
   }

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1383,11 +1383,7 @@ pub(crate) fn equation_zero_body(e: &Expr) -> Option<Expr> {
     }
     _ => return None,
   };
-  Some(Expr::BinaryOp {
-    op: BinaryOperator::Minus,
-    left: Box::new(lhs.clone()),
-    right: Box::new(rhs.clone()),
-  })
+  Some(minus2(lhs.clone(), rhs.clone()))
 }
 
 pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1583,8 +1579,8 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       == Some("Frame")
   }) {
     structure_args.push(Expr::Rule {
-      pattern: Box::new(Expr::Identifier("Frame".to_string())),
-      replacement: Box::new(Expr::Identifier("True".to_string())),
+      pattern: Box::new(id_expr("Frame")),
+      replacement: Box::new(bool_expr(true)),
     });
   }
   structure_args.extend(explicit);

--- a/src/functions/function_range_ast.rs
+++ b/src/functions/function_range_ast.rs
@@ -99,9 +99,9 @@ pub fn function_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Inequality".to_string(),
         args: vec![
           Expr::Integer(0),
-          Expr::Identifier("Less".to_string()),
+          id_expr("Less"),
           y.clone(),
-          Expr::Identifier("LessEqual".to_string()),
+          id_expr("LessEqual"),
           Expr::Integer(1),
         ]
         .into(),

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -800,7 +800,7 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         vec![
           Expr::String(expr_to_output(&label_expr)),
           Expr::Integer(16),
-          Expr::Identifier("Bold".to_string()),
+          id_expr("Bold"),
         ],
       ),
     };
@@ -820,7 +820,7 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // sized it — `LayeredGraphPlot[…, ImageSize -> {200, 50}]` asks for a
   // wide, short strip and has to get one.
   let image_size_opt = Expr::Rule {
-    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    pattern: Box::new(id_expr("ImageSize")),
     replacement: Box::new(image_size.unwrap_or(Expr::Integer(360))),
   };
 
@@ -868,7 +868,7 @@ fn flat_axis_plot_range(
   let pair =
     |a: f64, b: f64| Expr::List(vec![Expr::Real(a), Expr::Real(b)].into());
   Some(Expr::Rule {
-    pattern: Box::new(Expr::Identifier("PlotRange".to_string())),
+    pattern: Box::new(id_expr("PlotRange")),
     replacement: Box::new(Expr::List(vec![pair(x0, x1), pair(y0, y1)].into())),
   })
 }
@@ -4259,7 +4259,7 @@ pub fn weighted_adjacency_graph_ast(
       Expr::List(vertices.into()),
       Expr::List(edges.into()),
       Expr::Rule {
-        pattern: Box::new(Expr::Identifier("EdgeWeight".to_string())),
+        pattern: Box::new(id_expr("EdgeWeight")),
         replacement: Box::new(Expr::List(weights.into())),
       },
     ]
@@ -4333,10 +4333,10 @@ pub fn adjacency_matrix_to_graph(
       }
     }
   }
-  Some(Expr::FunctionCall {
-    name: "Graph".to_string(),
-    args: vec![Expr::List(verts.into()), Expr::List(edges.into())].into(),
-  })
+  Some(call(
+    "Graph",
+    vec![Expr::List(verts.into()), Expr::List(edges.into())],
+  ))
 }
 
 /// FindMinimumCostFlow[cmat, s, t] - minimum total cost of a maximum
@@ -5305,7 +5305,7 @@ pub fn highlight_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated());
   };
 
-  let default_style = Expr::Identifier("Red".to_string());
+  let default_style = id_expr("Red");
   let mut items: Vec<(Expr, Expr)> = Vec::new();
   collect_highlight_items(&args[1], &default_style, &mut items);
 
@@ -5351,7 +5351,7 @@ pub fn highlight_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
   merged.push(Expr::Rule {
-    pattern: Box::new(Expr::Identifier("GraphHighlight".to_string())),
+    pattern: Box::new(id_expr("GraphHighlight")),
     replacement: Box::new(Expr::List(highlighted.into())),
   });
 
@@ -6544,7 +6544,7 @@ fn directed_mean_graph_distance(expr: &Expr) -> Option<Expr> {
       }
     }
     if reached != n {
-      return Some(Expr::Identifier("Infinity".to_string()));
+      return Some(id_expr("Infinity"));
     }
     total += dist.iter().map(|&d| d as i128).sum::<i128>();
   }
@@ -6991,7 +6991,7 @@ pub fn graph_metric_ast(
           }
         }
         if reached != n {
-          return Ok(Expr::Identifier("Infinity".to_string()));
+          return Ok(id_expr("Infinity"));
         }
         total += dist.iter().map(|&d| d as i128).sum::<i128>();
       }
@@ -7392,8 +7392,8 @@ fn property_scope(property: &str) -> Option<Scope> {
 fn annotation_default(property: &str) -> Expr {
   match property {
     "GraphHighlight" => Expr::List(vec![].into()),
-    "VertexLabels" | "EdgeLabels" => Expr::Identifier("None".to_string()),
-    _ => Expr::Identifier("Automatic".to_string()),
+    "VertexLabels" | "EdgeLabels" => id_expr("None"),
+    _ => id_expr("Automatic"),
   }
 }
 
@@ -7587,10 +7587,7 @@ pub fn graph_annotation_ast(
   if graph_parts(graph).is_none() {
     return Ok(original());
   }
-  Ok(
-    annotation_value(graph, item, property)
-      .unwrap_or_else(|| Expr::Identifier("$Failed".to_string())),
-  )
+  Ok(annotation_value(graph, item, property).unwrap_or_else(fail_expr))
 }
 
 /// The annotations one vertex or edge offers: the ones every item of its kind
@@ -7857,8 +7854,8 @@ pub fn graph_set_property_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(Expr::List(items)) => items
         .get(i)
         .cloned()
-        .unwrap_or_else(|| Expr::Identifier("Automatic".to_string())),
-      _ => Expr::Identifier("Automatic".to_string()),
+        .unwrap_or_else(|| id_expr("Automatic")),
+      _ => id_expr("Automatic"),
     })
     .collect();
   if let Some(item) = item {

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11098,7 +11098,7 @@ fn merge_option(opts: &mut Vec<Expr>, opt: &Expr) {
     {
       let merged = merge_plot_ranges(&existing_repl, &replacement);
       opts[pos] = Expr::Rule {
-        pattern: Box::new(Expr::Identifier("PlotRange".to_string())),
+        pattern: Box::new(id_expr("PlotRange")),
         replacement: Box::new(merged),
       };
       return;
@@ -11133,7 +11133,7 @@ fn merge_plot_ranges(a: &Expr, b: &Expr) -> Expr {
   let range_to_expr = |r: Option<(f64, f64)>| -> Expr {
     match r {
       Some((lo, hi)) => Expr::List(vec![Expr::Real(lo), Expr::Real(hi)].into()),
-      None => Expr::Identifier("All".to_string()),
+      None => id_expr("All"),
     }
   };
 
@@ -11691,7 +11691,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       });
       if !has_option(&merged_options, "Axes") && !framed {
         merged_options.push(Expr::Rule {
-          pattern: Box::new(Expr::Identifier("Axes".to_string())),
+          pattern: Box::new(id_expr("Axes")),
           replacement: Box::new(bool_expr(true)),
         });
       }
@@ -11714,7 +11714,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           .filter(|r| r.is_finite() && *r > 0.0)
           .unwrap_or(1.0 / 1.618_033_988_749_895);
         merged_options.push(Expr::Rule {
-          pattern: Box::new(Expr::Identifier("AspectRatio".to_string())),
+          pattern: Box::new(id_expr("AspectRatio")),
           replacement: Box::new(Expr::Real(aspect)),
         });
       }
@@ -14254,7 +14254,7 @@ pub fn graphics_options(expr: &Expr) -> Option<Vec<Expr>> {
     }
   };
   Some(vec![Expr::Rule {
-    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    pattern: Box::new(id_expr("ImageSize")),
     replacement: Box::new(Expr::List(vec![size(w), size(h)].into())),
   }])
 }
@@ -15263,7 +15263,7 @@ fn with_default_image_size(expr: &Expr, size: i128) -> Expr {
   }
   let mut new_args = args.clone();
   new_args.push(Expr::Rule {
-    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    pattern: Box::new(id_expr("ImageSize")),
     replacement: Box::new(Expr::Integer(size)),
   });
   Expr::FunctionCall {
@@ -17327,7 +17327,7 @@ pub fn drop_shadowing_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Opacity".to_string(),
         args: vec![
           crate::functions::make_rational(1, 3),
-          call1("ThemeColor", Expr::Identifier("Foreground".to_string())),
+          call1("ThemeColor", id_expr("Foreground")),
         ]
         .into(),
       }),
@@ -18860,7 +18860,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
             .iter()
             .filter(|it| !is_control_type_marker(it))
             .cloned()
-            .chain(std::iter::once(Expr::Identifier("Locator".to_string())))
+            .chain(std::iter::once(id_expr("Locator")))
             .collect();
           if let Some(ParsedControl::Visible {
             control: mut c,
@@ -18899,7 +18899,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
               Expr::List(vec![Expr::Identifier(name.clone()), default].into()),
               choices,
               Expr::Rule {
-                pattern: Box::new(Expr::Identifier("ControlType".to_string())),
+                pattern: Box::new(id_expr("ControlType")),
                 replacement: Box::new(Expr::Identifier(
                   "PopupMenu".to_string(),
                 )),
@@ -19184,7 +19184,7 @@ fn apply_global_control_type(items: Vec<Expr>) -> Vec<Expr> {
         .iter()
         .cloned()
         .chain(std::iter::once(Expr::Rule {
-          pattern: Box::new(Expr::Identifier("ControlType".to_string())),
+          pattern: Box::new(id_expr("ControlType")),
           replacement: Box::new(control_type),
         }))
         .collect();
@@ -19363,10 +19363,9 @@ enum PopupScope<'a> {
 fn rewrap_in_popup_scopes(mut code: Expr, scopes: &[PopupScope]) -> Expr {
   for scope in scopes.iter().rev() {
     code = match scope {
-      PopupScope::Localize(head, binds) => Expr::FunctionCall {
-        name: (*head).to_string(),
-        args: vec![(*binds).clone(), code].into(),
-      },
+      PopupScope::Localize(head, binds) => {
+        call(head, vec![(*binds).clone(), code])
+      }
       PopupScope::Prefix([]) => code,
       PopupScope::Prefix(stmts) => {
         let mut items = stmts.to_vec();
@@ -19476,7 +19475,7 @@ fn strip_body_popup_menus(expr: &Expr, promoted: &[String]) -> Expr {
               )
         ) =>
     {
-      Expr::Identifier("Nothing".to_string())
+      id_expr("Nothing")
     }
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),
@@ -19518,7 +19517,7 @@ fn extract_body_togglerbars(expr: &Expr, displays: &mut Vec<String>) -> Expr {
         ) =>
     {
       displays.push(crate::syntax::expr_to_input_form(expr));
-      Expr::Identifier("Nothing".to_string())
+      id_expr("Nothing")
     }
     // A bare `Button[label, action, opts…]` drawn directly by the body (a
     // Demonstration's "throw"/"step" action mixed into a `Column` of
@@ -19530,7 +19529,7 @@ fn extract_body_togglerbars(expr: &Expr, displays: &mut Vec<String>) -> Expr {
       if name == "Button" && args.len() >= 2 =>
     {
       displays.push(crate::syntax::expr_to_input_form(expr));
-      Expr::Identifier("Nothing".to_string())
+      id_expr("Nothing")
     }
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),
@@ -21894,7 +21893,7 @@ fn parse_manipulate_control(
     let value_expr = explicit_initial
       .clone()
       .or_else(|| items.get(1).cloned())
-      .unwrap_or(Expr::Identifier("Null".to_string()));
+      .unwrap_or(null_expr());
     if is_hidden {
       // A `ControlType -> None` variable stays a live, mutable binding so
       // an interactive display can rewrite it. Without an explicit initial
@@ -24746,10 +24745,8 @@ mod manipulate_label_tests {
 
   #[test]
   fn style_italic_string_is_one_italic_run() {
-    let label = call(
-      "Style",
-      vec![Expr::String("t".into()), Expr::Identifier("Italic".into())],
-    );
+    let label =
+      call("Style", vec![Expr::String("t".into()), id_expr("Italic")]);
     assert_eq!(runs(&label), vec![run("t", true)]);
   }
 
@@ -24760,7 +24757,7 @@ mod manipulate_label_tests {
       vec![
         Expr::String("t".into()),
         Expr::Rule {
-          pattern: Box::new(Expr::Identifier("FontSlant".into())),
+          pattern: Box::new(id_expr("FontSlant")),
           replacement: Box::new(Expr::String("Italic".into())),
         },
       ],
@@ -24771,10 +24768,8 @@ mod manipulate_label_tests {
   #[test]
   fn text_subscript_style_renders_italic_base_and_upright_subscript() {
     // Text[Subscript[Style["m", Italic], 1]]  ->  italic "m", upright "₁"
-    let styled = call(
-      "Style",
-      vec![Expr::String("m".into()), Expr::Identifier("Italic".into())],
-    );
+    let styled =
+      call("Style", vec![Expr::String("m".into()), id_expr("Italic")]);
     let subscript = call("Subscript", vec![styled, Expr::Integer(1)]);
     let label = call1("Text", subscript);
     assert_eq!(runs(&label), vec![run("m", true), run("\u{2081}", false)]);
@@ -24782,26 +24777,21 @@ mod manipulate_label_tests {
 
   #[test]
   fn plain_identifier_passthrough() {
-    let label = Expr::Identifier("\u{03B8}".into());
+    let label = id_expr("\u{03B8}");
     assert_eq!(runs(&label), vec![run("\u{03B8}", false)]);
     assert_eq!(flatten_label_runs(&runs(&label)), "\u{03B8}");
   }
 
   #[test]
   fn superscript_renders_unicode() {
-    let label = call(
-      "Superscript",
-      vec![Expr::Identifier("x".into()), Expr::Integer(2)],
-    );
+    let label = call("Superscript", vec![id_expr("x"), Expr::Integer(2)]);
     assert_eq!(runs(&label), vec![run("x", false), run("\u{00B2}", false)]);
   }
 
   #[test]
   fn row_concatenates_parts_preserving_style() {
-    let italic_a = call(
-      "Style",
-      vec![Expr::String("a".into()), Expr::Identifier("Italic".into())],
-    );
+    let italic_a =
+      call("Style", vec![Expr::String("a".into()), id_expr("Italic")]);
     let row = call1(
       "Row",
       Expr::List(vec![italic_a, Expr::String("b".into())].into()),
@@ -24820,10 +24810,8 @@ mod manipulate_label_tests {
 
   #[test]
   fn derivative_of_an_italic_style_primes_an_italic_base() {
-    let italic_y = call(
-      "Style",
-      vec![Expr::String("y".into()), Expr::Identifier("Italic".into())],
-    );
+    let italic_y =
+      call("Style", vec![Expr::String("y".into()), id_expr("Italic")]);
     let label = call1(
       "Text",
       call1(
@@ -24842,7 +24830,7 @@ mod manipulate_label_tests {
 
   #[test]
   fn higher_derivative_orders_get_their_own_marks() {
-    let y = || Expr::Identifier("y".into());
+    let y = || id_expr("y");
     let marks = |order| flatten_label_runs(&runs(&derivative(order, y())));
     assert_eq!(marks(2), "y\u{2033}");
     assert_eq!(marks(3), "y\u{2034}");
@@ -24854,10 +24842,7 @@ mod manipulate_label_tests {
   /// `Derivative[n, f]`; both shapes must label the same.
   #[test]
   fn flattened_derivative_labels_like_the_curried_one() {
-    let flat = call(
-      "Derivative",
-      vec![Expr::Integer(1), Expr::Identifier("y".into())],
-    );
+    let flat = call("Derivative", vec![Expr::Integer(1), id_expr("y")]);
     assert_eq!(flatten_label_runs(&runs(&flat)), "y\u{2032}");
   }
 
@@ -24869,10 +24854,7 @@ mod manipulate_label_tests {
   fn subscript_of_directed_infinity_renders_the_infinity_glyph() {
     let label = call(
       "Subscript",
-      vec![
-        Expr::Identifier("N".into()),
-        call1("DirectedInfinity", Expr::Integer(1)),
-      ],
+      vec![id_expr("N"), call1("DirectedInfinity", Expr::Integer(1))],
     );
     assert_eq!(flatten_label_runs(&runs(&label)), "N\u{221E}");
   }
@@ -24885,10 +24867,7 @@ mod manipulate_label_tests {
   fn superscript_of_negative_infinity_renders_the_signed_glyph() {
     let label = call(
       "Superscript",
-      vec![
-        Expr::Identifier("x".into()),
-        call1("DirectedInfinity", Expr::Integer(-1)),
-      ],
+      vec![id_expr("x"), call1("DirectedInfinity", Expr::Integer(-1))],
     );
     assert_eq!(flatten_label_runs(&runs(&label)), "x\u{207B}\u{221E}");
   }
@@ -24897,7 +24876,7 @@ mod manipulate_label_tests {
   /// choice text) also renders as the glyph rather than the word.
   #[test]
   fn bare_infinity_symbol_renders_the_glyph() {
-    let label = Expr::Identifier("Infinity".into());
+    let label = id_expr("Infinity");
     assert_eq!(flatten_label_runs(&runs(&label)), "\u{221E}");
   }
 }

--- a/src/functions/http_ast.rs
+++ b/src/functions/http_ast.rs
@@ -104,7 +104,7 @@ pub fn http_request_extract(func_args: &[Expr], arg: &Expr) -> Option<Expr> {
         .map(|item| {
           let value = resolve(item).unwrap_or_else(|| {
             emit_notprop(item, func_args.len());
-            Expr::Identifier("$Failed".to_string())
+            fail_expr()
           });
           (item.clone(), value)
         })
@@ -166,9 +166,9 @@ fn http_request_property(func_args: &[Expr], prop: &str) -> Option<Expr> {
 
   let opt_str = |v: &Option<String>| match v {
     Some(s) => Expr::String(s.clone()),
-    None => Expr::Identifier("None".to_string()),
+    None => id_expr("None"),
   };
-  let none = || Expr::Identifier("None".to_string());
+  let none = || id_expr("None");
   match prop {
     "URL" => Some(Expr::String(build_url(&parts))),
     "Scheme" => Some(opt_str(&parts.scheme)),
@@ -264,13 +264,13 @@ fn http_request_property(func_args: &[Expr], prop: &str) -> Option<Expr> {
         .into(),
       })
     }
-    "Cookies" => Some(Expr::Identifier("Automatic".to_string())),
+    "Cookies" => Some(id_expr("Automatic")),
     "FormRules" => Some(none()),
     "Properties" => Some(Expr::List(
       PROPERTY_NAMES
         .iter()
         .map(|name| Expr::String(name.to_string()))
-        .chain(std::iter::once(Expr::Identifier("Method".to_string())))
+        .chain(std::iter::once(id_expr("Method")))
         .collect(),
     )),
     _ => None,
@@ -687,8 +687,8 @@ pub fn url_read_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
         ),
       ]),
       Expr::Rule {
-        pattern: Box::new(Expr::Identifier("CharacterEncoding".to_string())),
-        replacement: Box::new(Expr::Identifier("Automatic".to_string())),
+        pattern: Box::new(id_expr("CharacterEncoding")),
+        replacement: Box::new(id_expr("Automatic")),
       },
     ]
     .into(),
@@ -735,14 +735,10 @@ fn connection_failure(url: &str, func_args: &[Expr]) -> Expr {
           // value as the full RuleDelayed.
           Expr::RuleDelayed {
             pattern: Box::new(template_key),
-            replacement: Box::new(Expr::FunctionCall {
-              name: "MessageName".to_string(),
-              args: vec![
-                Expr::Identifier("URLRead".to_string()),
-                Expr::String("iurl".to_string()),
-              ]
-              .into(),
-            }),
+            replacement: Box::new(call(
+              "MessageName",
+              vec![id_expr("URLRead"), Expr::String("iurl".to_string())],
+            )),
           },
         ),
         (
@@ -909,11 +905,11 @@ pub fn url_parse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "URLParse::nvldval: {port} is not a valid value"
       ));
-      return Ok(Expr::Identifier("$Failed".to_string()));
+      return Ok(fail_expr());
     }
   };
 
-  let none = || Expr::Identifier("None".to_string());
+  let none = || id_expr("None");
   let opt_str = |v: &Option<String>| match v {
     Some(s) => Expr::String(s.clone()),
     None => none(),

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -986,11 +986,11 @@ pub fn image_color_space_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::Image { color_space, .. } = &args[0] {
     return Ok(match color_space {
       Some(cs) => Expr::String((*cs).to_string()),
-      None => Expr::Identifier("Automatic".to_string()),
+      None => id_expr("Automatic"),
     });
   }
   if is_valid_image3d(&args[0]) {
-    return Ok(Expr::Identifier("Automatic".to_string()));
+    return Ok(id_expr("Automatic"));
   }
   // Matches wolframscript: emit ImageColorSpace::imginv and return
   // unevaluated instead of erroring out.
@@ -8293,11 +8293,11 @@ pub fn import_image(path: &str) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "Import::nffil: File {path} not found during Import."
     ));
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
   let Ok(img) = image::open(crate::vfs::resolve(path)) else {
     // Wolfram returns $Failed when the file cannot be opened
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   };
   Ok(dynamic_image_to_expr(&img))
 }
@@ -9553,9 +9553,9 @@ fn image_measurement(
     // A single sample has no sample deviation. wolframscript reports that as
     // a one-element list for the plain measure and bare for the intensity
     // one, which is its own inconsistency rather than a rule.
-    "StandardDeviation" if data.len() / ch.max(1) < 2 => Some(Expr::List(
-      vec![Expr::Identifier("Indeterminate".to_string()); ch].into(),
-    )),
+    "StandardDeviation" if data.len() / ch.max(1) < 2 => {
+      Some(Expr::List(vec![id_expr("Indeterminate"); ch].into()))
+    }
     "StandardDeviation" => Some(per_channel(data, ch, |s| {
       real(samples_standard_deviation(s))
     })),
@@ -9629,7 +9629,7 @@ fn image_measurement(
     "Channels" => Some(Expr::Integer(ch as i128)),
     "ColorSpace" => Some(match color_space {
       Some(name) => Expr::String(name.to_string()),
-      None => Expr::Identifier("Automatic".to_string()),
+      None => id_expr("Automatic"),
     }),
     "ImageDimensions" => Some(Expr::List(
       vec![Expr::Integer(w as i128), Expr::Integer(h as i128)].into(),

--- a/src/functions/information_render.rs
+++ b/src/functions/information_render.rs
@@ -10,14 +10,10 @@ use super::*;
 
 /// Build a `Style[content, Bold]` Expr.
 fn bold_style(text: &str) -> Expr {
-  Expr::FunctionCall {
-    name: "Style".to_string(),
-    args: vec![
-      Expr::String(text.to_string()),
-      Expr::Identifier("Bold".to_string()),
-    ]
-    .into(),
-  }
+  call(
+    "Style",
+    vec![Expr::String(text.to_string()), id_expr("Bold")],
+  )
 }
 
 /// Build a `Style[content, color]` Expr where `color` is a named color identifier.
@@ -96,15 +92,8 @@ pub fn render_information_card_svg(
       name: "Style".to_string(),
       args: vec![
         Expr::String(title.to_string()),
-        Expr::Identifier("Bold".to_string()),
-        Expr::FunctionCall {
-          name: "Rule".to_string(),
-          args: vec![
-            Expr::Identifier("FontSize".to_string()),
-            Expr::Integer(16),
-          ]
-          .into(),
-        },
+        id_expr("Bold"),
+        call("Rule", vec![id_expr("FontSize"), Expr::Integer(16)]),
       ]
       .into(),
     },
@@ -130,26 +119,20 @@ pub fn render_information_card_svg(
 
   // Grid options: outer frame, left-aligned both columns with right-aligned
   // labels, modest spacing, alternating row backgrounds for readability.
-  let frame_opt = rule(Expr::Identifier("Frame".to_string()), bool_expr(true));
+  let frame_opt = rule(id_expr("Frame"), bool_expr(true));
   let alignment_opt = rule(
-    Expr::Identifier("Alignment".to_string()),
-    list(vec![list(vec![
-      Expr::Identifier("Right".to_string()),
-      Expr::Identifier("Left".to_string()),
-    ])]),
+    id_expr("Alignment"),
+    list(vec![list(vec![id_expr("Right"), id_expr("Left")])]),
   );
   let spacings_opt = rule(
-    Expr::Identifier("Spacings".to_string()),
+    id_expr("Spacings"),
     list(vec![Expr::Integer(2), Expr::Real(0.6)]),
   );
   let dividers_opt = rule(
-    Expr::Identifier("Dividers".to_string()),
+    id_expr("Dividers"),
     list(vec![
-      Expr::Identifier("None".to_string()),
-      list(vec![
-        Expr::Integer(2),
-        Expr::Identifier("LightGray".to_string()),
-      ]),
+      id_expr("None"),
+      list(vec![Expr::Integer(2), id_expr("LightGray")]),
     ]),
   );
 
@@ -196,13 +179,10 @@ pub fn render_information_grid_svg(
 
   let grid_data = list(rows);
 
-  let frame_opt = rule(Expr::Identifier("Frame".to_string()), bool_expr(true));
-  let alignment_opt = rule(
-    Expr::Identifier("Alignment".to_string()),
-    Expr::Identifier("Left".to_string()),
-  );
+  let frame_opt = rule(id_expr("Frame"), bool_expr(true));
+  let alignment_opt = rule(id_expr("Alignment"), id_expr("Left"));
   let spacings_opt = rule(
-    Expr::Identifier("Spacings".to_string()),
+    id_expr("Spacings"),
     list(vec![Expr::Integer(2), Expr::Real(0.6)]),
   );
 

--- a/src/functions/interval_ast.rs
+++ b/src/functions/interval_ast.rs
@@ -248,9 +248,8 @@ pub fn coth_csch_interval(head: &str, expr: &Expr) -> Option<Expr> {
   if head != "Coth" && head != "Csch" {
     return None;
   }
-  let inf = || Expr::Identifier("Infinity".to_string());
-  let neg_inf =
-    || times2(Expr::Integer(-1), Expr::Identifier("Infinity".to_string()));
+  let inf = || id_expr("Infinity");
+  let neg_inf = || times2(Expr::Integer(-1), id_expr("Infinity"));
   let eps = 1e-9;
   let spans = is_interval(expr)?;
   let mut out: Vec<(Expr, Expr)> = Vec::with_capacity(spans.len());
@@ -325,9 +324,8 @@ pub fn tan_cot_interval(head: &str, expr: &Expr) -> Option<Expr> {
     _ => return None,
   };
   let period = std::f64::consts::PI;
-  let inf = || Expr::Identifier("Infinity".to_string());
-  let neg_inf =
-    || times2(Expr::Integer(-1), Expr::Identifier("Infinity".to_string()));
+  let inf = || id_expr("Infinity");
+  let neg_inf = || times2(Expr::Integer(-1), id_expr("Infinity"));
 
   let spans = is_interval(expr)?;
   let mut out: Vec<(Expr, Expr)> = Vec::with_capacity(spans.len());
@@ -385,9 +383,8 @@ pub fn sec_csc_interval(head: &str, expr: &Expr) -> Option<Expr> {
     "Csc" => (0.0, FRAC_PI_2),
     _ => return None,
   };
-  let inf = || Expr::Identifier("Infinity".to_string());
-  let neg_inf =
-    || times2(Expr::Integer(-1), Expr::Identifier("Infinity".to_string()));
+  let inf = || id_expr("Infinity");
+  let neg_inf = || times2(Expr::Integer(-1), id_expr("Infinity"));
   let fold_min =
     |v: &[Expr]| v.iter().cloned().reduce(|a, b| numeric_min(&a, &b));
   let fold_max =
@@ -766,10 +763,7 @@ pub fn interval_member_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// is `Interval[{1 + Pi, 2 + Pi}]`, but `Interval[{1, 2}] + z` stays a sum.
 fn is_numeric_scalar(a: &Expr) -> bool {
   matches!(
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "NumericQ".to_string(),
-      args: vec![a.clone()].into(),
-    }),
+    crate::evaluator::evaluate_expr_to_expr(&call1("NumericQ", a.clone())),
     Ok(Expr::Identifier(ref t)) if t == "True"
   )
 }
@@ -954,7 +948,7 @@ pub fn try_interval_divide(
   //   1/[lo, 0]  (lo < 0)          -> [-Inf, 1/lo]
   // A same-sign span reciprocates as usual (and reverses orientation).
   let recip_spans = if let Some(spans) = &b_int {
-    let pos_inf = Expr::Identifier("Infinity".to_string());
+    let pos_inf = id_expr("Infinity");
     let neg_inf = call("Times", vec![Expr::Integer(-1), pos_inf.clone()]);
     let recip_one = |x: &Expr| eval_binop(&Expr::Integer(1), x, "Divide").ok();
     let mut recip = Vec::new();
@@ -1300,7 +1294,7 @@ fn centered_interval_box_op(args: &[Expr], op: BoxOp) -> Expr {
 fn extremum(xs: &[Expr], maximum: bool) -> Expr {
   let mut iter = xs.iter().cloned();
   let Some(mut best) = iter.next() else {
-    return Expr::Identifier("Indeterminate".to_string());
+    return id_expr("Indeterminate");
   };
   for x in iter {
     let ord = compare_numeric(&x, &best);
@@ -1321,7 +1315,7 @@ fn combine_complex(re: &Expr, im: &Expr) -> Expr {
   if is_zero {
     return re.clone();
   }
-  let im_term = eval_mul(im, &Expr::Identifier("I".to_string()));
+  let im_term = eval_mul(im, &id_expr("I"));
   eval_add(re, &im_term)
 }
 

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -6524,7 +6524,7 @@ pub fn vector_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if matches!(norm_u_expr, Expr::Integer(0))
     || matches!(norm_v_expr, Expr::Integer(0))
   {
-    return Ok(Expr::Identifier("Indeterminate".to_string()));
+    return Ok(id_expr("Indeterminate"));
   }
 
   // Build ArcCos[u.Conjugate[v] / (Norm[u] * Norm[v])] and evaluate. The
@@ -6964,10 +6964,7 @@ pub fn linear_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Build FittedModel association
   let assoc = Expr::Association(vec![
-    (
-      Expr::String("Type".to_string()),
-      Expr::Identifier("Linear".to_string()),
-    ),
+    (Expr::String("Type".to_string()), id_expr("Linear")),
     (Expr::String("FittedExpression".to_string()), fitted_expr),
     (
       Expr::String("BestFitParameters".to_string()),
@@ -7080,10 +7077,7 @@ pub fn nonlinear_model_fit_ast(
   ))?;
 
   let assoc = Expr::Association(vec![
-    (
-      Expr::String("Type".to_string()),
-      Expr::Identifier("Nonlinear".to_string()),
-    ),
+    (Expr::String("Type".to_string()), id_expr("Nonlinear")),
     (
       Expr::String("FittedExpression".to_string()),
       fitted_expr.clone(),
@@ -7264,10 +7258,7 @@ fn linear_model_fit_design_matrix_form(
     Expr::List(vec![design_matrix.clone(), response_vec.clone()].into());
 
   let assoc = Expr::Association(vec![
-    (
-      Expr::String("Type".to_string()),
-      Expr::Identifier("Linear".to_string()),
-    ),
+    (Expr::String("Type".to_string()), id_expr("Linear")),
     (Expr::String("FittedExpression".to_string()), fitted_expr),
     (
       Expr::String("BestFitParameters".to_string()),
@@ -7483,10 +7474,7 @@ pub fn logit_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   );
 
   let assoc = Expr::Association(vec![
-    (
-      Expr::String("Type".to_string()),
-      Expr::Identifier("Logit".to_string()),
-    ),
+    (Expr::String("Type".to_string()), id_expr("Logit")),
     (Expr::String("FittedExpression".to_string()), fitted_expr),
     (
       Expr::String("BestFitParameters".to_string()),
@@ -10345,7 +10333,7 @@ fn sparse_array_literal(n: usize, nonzeros: &[(usize, usize, Expr)]) -> Expr {
   Expr::FunctionCall {
     name: "SparseArray".to_string(),
     args: vec![
-      Expr::Identifier("Automatic".to_string()),
+      id_expr("Automatic"),
       Expr::List(
         vec![Expr::Integer(n as i128), Expr::Integer(n as i128)].into(),
       ),

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -391,7 +391,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
     "HalfNormalDistribution" if dargs.len() == 1 => {
       let theta = dargs[0].clone();
       // Median = Sqrt[Pi] * InverseErf[1/2] / theta
-      let sqrt_pi = call1("Sqrt", Expr::Identifier("Pi".to_string()));
+      let sqrt_pi = call1("Sqrt", id_expr("Pi"));
       let half = call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
       let inverse_erf_half = call1("InverseErf", half);
       let numer = call("Times", vec![sqrt_pi, inverse_erf_half]);
@@ -1115,11 +1115,7 @@ pub fn min_max_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   if items.is_empty() {
     return Ok(Expr::List(
-      vec![
-        Expr::Identifier("Infinity".to_string()),
-        neg1(Expr::Identifier("Infinity".to_string())),
-      ]
-      .into(),
+      vec![id_expr("Infinity"), neg1(id_expr("Infinity"))].into(),
     ));
   }
 

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -1146,7 +1146,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
           Err(e) => return Err(e),
         }
       }
-      Ok(Expr::Identifier("Null".to_string()))
+      Ok(null_expr())
     }
     Expr::List(items) if items.len() == 1 => {
       // Do[body, {n}] — repeat n times without iterator variable
@@ -1165,7 +1165,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
           Err(e) => return Err(e),
         }
       }
-      Ok(Expr::Identifier("Null".to_string()))
+      Ok(null_expr())
     }
     Expr::List(items) if items.len() >= 2 => {
       let var_name = match &items[0] {
@@ -1228,7 +1228,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
             if let Some(v) = early_return {
               return Ok(v);
             }
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // Fall through to the generic path if Characters[s] didn't
           // produce a String (e.g. threaded over a list).
@@ -1270,7 +1270,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
             if let Some(v) = early_return {
               return Ok(v);
             }
-            return Ok(Expr::Identifier("Null".to_string()));
+            return Ok(null_expr());
           }
           // Fall back to substitute when body uses var as a function head.
           for item in list_items {
@@ -1284,7 +1284,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
               Err(e) => return Err(e),
             }
           }
-          return Ok(Expr::Identifier("Null".to_string()));
+          return Ok(null_expr());
         }
       }
 
@@ -1371,7 +1371,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
             i += step;
           }
         }
-        return Ok(Expr::Identifier("Null".to_string()));
+        return Ok(null_expr());
       }
       // ENV-binding fast path.
       let prev = crate::ENV.with(|e| e.borrow_mut().remove(&var_name));
@@ -1439,7 +1439,7 @@ pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
       if let Some(v) = early_return {
         return Ok(v);
       }
-      Ok(Expr::Identifier("Null".to_string()))
+      Ok(null_expr())
     }
     _ => Err(InterpreterError::EvaluationError(
       "Do: invalid iterator specification".into(),
@@ -1480,10 +1480,8 @@ pub fn do_multi_ast(
     }
   }
   match do_multi_inner(body, iter_specs) {
-    Ok(()) => Ok(Expr::Identifier("Null".to_string())),
-    Err(InterpreterError::BreakSignal) => {
-      Ok(Expr::Identifier("Null".to_string()))
-    }
+    Ok(()) => Ok(null_expr()),
+    Err(InterpreterError::BreakSignal) => Ok(null_expr()),
     Err(InterpreterError::ReturnValue(val)) => Ok(*val),
     Err(e) => Err(e),
   }
@@ -2512,13 +2510,7 @@ pub fn sparse_array_normalize_ast(
 
   Ok(Expr::FunctionCall {
     name: "SparseArray".to_string(),
-    args: vec![
-      Expr::Identifier("Automatic".to_string()),
-      dims_expr,
-      default,
-      structure,
-    ]
-    .into(),
+    args: vec![id_expr("Automatic"), dims_expr, default, structure].into(),
   })
 }
 
@@ -3054,7 +3046,7 @@ pub fn distance_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Determine the distance function: default EuclideanDistance, or the
   // replacement of an optional `DistanceFunction -> f` rule.
-  let mut dist_fn = Expr::Identifier("EuclideanDistance".to_string());
+  let mut dist_fn = id_expr("EuclideanDistance");
   if let Some(opt) = args.get(1) {
     match opt {
       Expr::Rule {
@@ -3183,7 +3175,7 @@ pub fn sparse_array_property(sa_args: &[Expr], prop: &str) -> Option<Expr> {
             vec![
               structure[0].clone(),
               structure[1].clone(),
-              Expr::Identifier("Pattern".to_string()),
+              id_expr("Pattern"),
             ]
             .into(),
           ),

--- a/src/functions/list_helpers_ast/filtering.rs
+++ b/src/functions/list_helpers_ast/filtering.rs
@@ -844,10 +844,9 @@ fn position_visit(
   let (head, kids): (Option<Expr>, Kids) = match expr {
     // Rational / Complex are atoms: do not descend into their parts.
     _ if is_atomic_number(expr) => (None, Kids::None),
-    Expr::Association(pairs) => (
-      Some(Expr::Identifier("Association".to_string())),
-      Kids::Keyed(pairs.clone()),
-    ),
+    Expr::Association(pairs) => {
+      (Some(id_expr("Association")), Kids::Keyed(pairs.clone()))
+    }
     Expr::CurriedCall { func, args } => {
       (Some((**func).clone()), Kids::Indexed(args.clone()))
     }
@@ -928,7 +927,7 @@ fn cases_visit(
     // Rational / Complex are atoms: do not descend into their parts.
     _ if is_atomic_number(expr) => (None, Vec::new()),
     Expr::Association(pairs) => (
-      Some(Expr::Identifier("Association".to_string())),
+      Some(id_expr("Association")),
       pairs.iter().map(|(_, v)| v.clone()).collect(),
     ),
     Expr::CurriedCall { func, args } => (Some((**func).clone()), args.clone()),

--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -586,7 +586,7 @@ pub fn scan_ast(func: &Expr, list: &Expr) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::Identifier("Null".to_string()))
+  Ok(null_expr())
 }
 
 /// Scan[f, expr, levelspec] — apply `func` (for side effects) to each part of
@@ -605,7 +605,7 @@ pub fn scan_levelspec_ast(
       for item in items {
         apply_func_ast(func, item)?;
       }
-      Ok(Expr::Identifier("Null".to_string()))
+      Ok(null_expr())
     }
     // Level could not interpret the spec — keep the call unevaluated.
     _ => Ok(call(
@@ -1279,7 +1279,7 @@ pub fn tensor_product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(flat.into_iter().next().unwrap());
   }
 
-  let times = Expr::Identifier("Times".to_string());
+  let times = id_expr("Times");
   let is_scalar = |e: &Expr| -> bool {
     !matches!(e, Expr::List(_))
       && crate::functions::predicate_ast::is_numeric_q(e)

--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -426,8 +426,7 @@ fn map_with_heads(func: &Expr, expr: &Expr) -> Result<Expr, InterpreterError> {
         .map(|item| apply_func_ast(func, item))
         .collect();
       // Apply f to the head (List)
-      let new_head =
-        apply_func_ast(func, &Expr::Identifier("List".to_string()))?;
+      let new_head = apply_func_ast(func, &id_expr("List"))?;
       Ok(Expr::CurriedCall {
         func: Box::new(new_head),
         args: mapped?,
@@ -609,8 +608,8 @@ fn map_at_rebuilt(
   fn head_expr(expr: &Expr) -> Expr {
     match expr {
       Expr::CurriedCall { func, .. } => (**func).clone(),
-      Expr::Rule { .. } => Expr::Identifier("Rule".to_string()),
-      Expr::RuleDelayed { .. } => Expr::Identifier("RuleDelayed".to_string()),
+      Expr::Rule { .. } => id_expr("Rule"),
+      Expr::RuleDelayed { .. } => id_expr("RuleDelayed"),
       other => Expr::Identifier(
         super::element_access::parts_and_head(other)
           .and_then(|(_, h)| h)

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -3,16 +3,8 @@
 //! These functions work directly with `Expr` AST nodes, avoiding the string
 //! round-trips and re-parsing that the original `list_helpers.rs` functions use.
 
-use crate::InterpreterError;
-use crate::helpers::{
-  bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2, pow2,
-  times2, unevaluated,
-};
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
-  expr_to_string,
-};
-use num_bigint::{BigInt, Sign};
+use super::*;
+use num_bigint::Sign;
 
 mod aggregation;
 mod combinatorics;

--- a/src/functions/list_helpers_ast/set_operations.rs
+++ b/src/functions/list_helpers_ast/set_operations.rs
@@ -696,7 +696,7 @@ pub fn delete_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
     let rhs = match mult_expr {
       Some(m) => m.clone(),
-      None => Expr::Identifier("Infinity".to_string()),
+      None => id_expr("Infinity"),
     };
     return Ok(Expr::FunctionCall {
       name: "DeleteElements".to_string(),

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -5323,9 +5323,9 @@ fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
 
   // Build the expression: (final_num / final_den) * Pi^s
   let pi_power = if s == 1 {
-    Expr::Identifier("Pi".to_string())
+    id_expr("Pi")
   } else {
-    pow2(Expr::Identifier("Pi".to_string()), Expr::Integer(s as i128))
+    pow2(id_expr("Pi"), Expr::Integer(s as i128))
   };
 
   if final_num == 1 && final_den == 1 {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,7 +1,7 @@
 use crate::InterpreterError;
 use crate::helpers::{
-  binop, bool_expr, call, call0, call1, const_expr, div2, minus2, neg1, plus2,
-  pow2, times2, unevaluated,
+  binop, bool_expr, call, call0, call1, const_expr, div2, fail_expr, id_expr,
+  minus2, neg1, null_expr, plus2, pow2, times2, unevaluated,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -2471,7 +2471,7 @@ mod tests {
     expect_midi_pitch(
       music_pitch(&[call(
         "Quantity",
-        vec![Expr::Real(440.0), Expr::Identifier("Hertz".into())],
+        vec![Expr::Real(440.0), id_expr("Hertz")],
       )])
       .as_ref(),
       69,

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -6832,7 +6832,7 @@ fn interpolating_derivative_value_exact(
   end: usize,
   derivative_order: usize,
 ) -> Result<Option<Expr>, InterpreterError> {
-  let var = Expr::Identifier("\u{2620}ifderiv\u{2620}".to_string());
+  let var = id_expr("\u{2620}ifderiv\u{2620}");
   let Some(poly) = lagrange_polynomial(data_points, &var, start, end, true)
   else {
     return Ok(None);

--- a/src/functions/parametric_plot.rs
+++ b/src/functions/parametric_plot.rs
@@ -593,12 +593,12 @@ fn parametric_region_ast(
   // caller's own options come last so they win.
   let mut graphics_args = vec![Expr::List(items.into())];
   graphics_args.push(Expr::Rule {
-    pattern: Box::new(Expr::Identifier("Axes".to_string())),
-    replacement: Box::new(Expr::Identifier("True".to_string())),
+    pattern: Box::new(id_expr("Axes")),
+    replacement: Box::new(bool_expr(true)),
   });
   graphics_args.push(Expr::Rule {
-    pattern: Box::new(Expr::Identifier("AspectRatio".to_string())),
-    replacement: Box::new(Expr::Identifier("Automatic".to_string())),
+    pattern: Box::new(id_expr("AspectRatio")),
+    replacement: Box::new(id_expr("Automatic")),
   });
   graphics_args.extend(opt_args.iter().cloned());
   let mut result = crate::functions::graphics::graphics_ast(&graphics_args)?;

--- a/src/functions/periodic_table_plot.rs
+++ b/src/functions/periodic_table_plot.rs
@@ -499,7 +499,7 @@ fn phase_legended(graphics: Expr) -> Expr {
     vec![
       colors,
       labels,
-      rule("LegendLayout", Expr::Identifier("Row".to_string())),
+      rule("LegendLayout", id_expr("Row")),
       rule(
         "LegendLabel",
         call(
@@ -514,12 +514,6 @@ fn phase_legended(graphics: Expr) -> Expr {
   );
   call(
     "Legended",
-    vec![
-      graphics,
-      call(
-        "Placed",
-        vec![legend, Expr::Identifier("Below".to_string())],
-      ),
-    ],
+    vec![graphics, call("Placed", vec![legend, id_expr("Below")])],
   )
 }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -8473,13 +8473,7 @@ pub(crate) fn apply_common_plot_option(
 /// Build the compactifying substitution `Tan[Pi*inner/2]`, the bijection
 /// used to fold an infinite plot range into a finite display coordinate.
 fn tan_compactify(inner: Expr) -> Expr {
-  call1(
-    "Tan",
-    div2(
-      times2(Expr::Identifier("Pi".to_string()), inner),
-      Expr::Integer(2),
-    ),
-  )
+  call1("Tan", div2(times2(id_expr("Pi"), inner), Expr::Integer(2)))
 }
 
 /// Given the (possibly infinite) raw endpoints of a `Plot` range, return the
@@ -8534,7 +8528,7 @@ pub(crate) fn expr_mentions_var(expr: &Expr, var: &str) -> bool {
   // Substituting the variable with a sentinel changes the tree iff the
   // variable actually occurs; comparing structurally avoids hand-writing a
   // walker over every Expr variant.
-  let sentinel = Expr::Identifier("$WoxiPlotVarProbe$".to_string());
+  let sentinel = id_expr("$WoxiPlotVarProbe$");
   let replaced = crate::syntax::substitute_variable(expr, var, &sentinel);
   !crate::evaluator::pattern_matching::expr_equal(&replaced, expr)
 }

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -686,13 +686,13 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (names_axes, names_ratios) = (names("Axes"), names("BoxRatios"));
     if !names_axes {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Axes".to_string())),
-        replacement: Box::new(Expr::Identifier("True".to_string())),
+        pattern: Box::new(id_expr("Axes")),
+        replacement: Box::new(bool_expr(true)),
       });
     }
     if !names_ratios {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("BoxRatios".to_string())),
+        pattern: Box::new(id_expr("BoxRatios")),
         replacement: Box::new(Expr::List(
           vec![Expr::Integer(1), Expr::Integer(1), Expr::Real(Z_SCALE)].into(),
         )),
@@ -7612,11 +7612,10 @@ pub fn contour_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   let structure = {
-    let complex = Expr::FunctionCall {
-      name: "GraphicsComplex".to_string(),
-      args: vec![Expr::List(point_exprs.into()), Expr::List(content.into())]
-        .into(),
-    };
+    let complex = call(
+      "GraphicsComplex",
+      vec![Expr::List(point_exprs.into()), Expr::List(content.into())],
+    );
     let mut structure_args = vec![complex];
     structure_args.extend(args[4..].iter().cloned());
     let names = |opt: &str| {
@@ -7628,13 +7627,13 @@ pub fn contour_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (names_axes, names_ratios) = (names("Axes"), names("BoxRatios"));
     if !names_axes {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Axes".to_string())),
-        replacement: Box::new(Expr::Identifier("True".to_string())),
+        pattern: Box::new(id_expr("Axes")),
+        replacement: Box::new(bool_expr(true)),
       });
     }
     if !names_ratios {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("BoxRatios".to_string())),
+        pattern: Box::new(id_expr("BoxRatios")),
         replacement: Box::new(Expr::List(
           vec![Expr::Integer(1), Expr::Integer(1), Expr::Real(Z_SCALE)].into(),
         )),
@@ -9804,13 +9803,13 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (names_axes, names_ratios) = (names("Axes"), names("BoxRatios"));
     if !names_axes {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Axes".to_string())),
-        replacement: Box::new(Expr::Identifier("True".to_string())),
+        pattern: Box::new(id_expr("Axes")),
+        replacement: Box::new(bool_expr(true)),
       });
     }
     if !names_ratios {
       structure_args.push(Expr::Rule {
-        pattern: Box::new(Expr::Identifier("BoxRatios".to_string())),
+        pattern: Box::new(id_expr("BoxRatios")),
         replacement: Box::new(Expr::List(
           vec![Expr::Integer(1), Expr::Integer(1), Expr::Real(Z_SCALE)].into(),
         )),

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -2,19 +2,10 @@
 //!
 //! Expand, Factor, Simplify, Coefficient, Exponent, PolynomialQ.
 
-use crate::InterpreterError;
+use super::*;
 use crate::functions::math_ast::{
   gcd_i128, is_sqrt, lcm_i128, make_sqrt, rat_reduce, rat_reduce_bigint,
 };
-use crate::helpers::{
-  bool_expr, call, call0, call1, const_expr, div2, id_expr, minus2, neg1,
-  null_expr, plus2, pow2, times2, unevaluated,
-};
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
-  expr_to_string,
-};
-use num_bigint::BigInt;
 
 mod apart;
 mod cancel;

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -7,6 +7,7 @@ use super::reduce_backend::{
 };
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::try_eval_to_f64;
+use crate::functions::polynomial_ast::helpers::compare_exprs;
 
 // ─── Reduce ──────────────────────────────────────────────────────────
 

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -1560,8 +1560,8 @@ fn split_heads_option(args: &[Expr]) -> (&[Expr], bool) {
 fn head_part(expr: &Expr) -> Option<Expr> {
   match expr {
     Expr::FunctionCall { name, .. } => Some(Expr::Identifier(name.clone())),
-    Expr::List(_) => Some(Expr::Identifier("List".to_string())),
-    Expr::Association(_) => Some(Expr::Identifier("Association".to_string())),
+    Expr::List(_) => Some(id_expr("List")),
+    Expr::Association(_) => Some(id_expr("Association")),
     _ => None,
   }
 }
@@ -1726,7 +1726,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // itself matches the pattern (e.g. _Symbol matches "List" since
         // Head[List] is Symbol).
         if use_pattern {
-          let head_expr = Expr::Identifier("List".to_string());
+          let head_expr = id_expr("List");
           if crate::functions::list_helpers_ast::matches_pattern_ast(
             &head_expr, form,
           ) {
@@ -2222,12 +2222,12 @@ pub fn head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let args = &[crate::evaluator::strip_unevaluated(&args[0])];
   // Check for complex number patterns before the general match
   if is_complex_number(&args[0]) {
-    return Ok(Expr::Identifier("Complex".to_string()));
+    return Ok(id_expr("Complex"));
   }
   // Infinity, -Infinity and ComplexInfinity are DirectedInfinity[…] objects,
   // not symbols/products, so their Head is DirectedInfinity.
   if is_directed_infinity(&args[0]) {
-    return Ok(Expr::Identifier("DirectedInfinity".to_string()));
+    return Ok(id_expr("DirectedInfinity"));
   }
   let head = match &args[0] {
     Expr::Integer(_) | Expr::BigInteger(_) => "Integer",

--- a/src/functions/socket_ast.rs
+++ b/src/functions/socket_ast.rs
@@ -502,7 +502,7 @@ fn socket_open(args: &[Expr]) -> Expr {
       Ok(listener) => listener,
       Err(err) => {
         failed_operation_message(&err);
-        return Expr::Identifier("$Failed".to_string());
+        return fail_expr();
       }
     };
   let local = listener.local_addr().ok();
@@ -731,11 +731,11 @@ fn socket_listen(args: &[Expr]) -> Expr {
   });
   let Some((closed, role, listener, stream)) = listener_state else {
     invalid_socket_message(&uuid);
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   };
   if closed {
     invalid_socket_message(&uuid);
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   }
   // Listening twice on one socket would leave two accept threads fighting
   // over it, so the second call replaces the first.
@@ -1451,7 +1451,7 @@ fn socket_close(uuid: &str) -> Expr {
   let known = with_registry(|reg| reg.entries.contains_key(uuid));
   if !known {
     invalid_socket_message(uuid);
-    return Expr::Identifier("$Failed".to_string());
+    return fail_expr();
   }
   // Closing the socket a listener was set up on ends the listener; closing
   // one connection it accepted only ends that connection, which is what an
@@ -1486,10 +1486,9 @@ fn socket_close(uuid: &str) -> Expr {
   // wolframscript answers with the endpoint that was closed, spelled
   // `"host:port"`, not with the socket object.
   with_registry(|reg| {
-    reg.entries.get(uuid).map_or_else(
-      || Expr::Identifier("$Failed".to_string()),
-      |entry| Expr::String(format!("{}:{}", entry.dest_host, entry.dest_port)),
-    )
+    reg.entries.get(uuid).map_or_else(fail_expr, |entry| {
+      Expr::String(format!("{}:{}", entry.dest_host, entry.dest_port))
+    })
   })
 }
 
@@ -1565,7 +1564,7 @@ fn string_list(items: &[&str]) -> Expr {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn socket_property(uuid: &str, property: &str) -> Option<Expr> {
   if is_closed(uuid) {
-    return Some(Expr::Identifier("$Failed".to_string()));
+    return Some(fail_expr());
   }
   if property == "Properties" {
     return Some(string_list(&SOCKET_PROPERTIES));
@@ -1602,7 +1601,7 @@ pub fn socket_property(uuid: &str, property: &str) -> Option<Expr> {
       // A socket nobody is listening on reports `None`, not the empty list
       // an unknown property gives.
       "SocketListener" => entry.listener_id.map_or_else(
-        || Expr::Identifier("None".to_string()),
+        || id_expr("None"),
         |id| call1("SocketListener", Expr::Integer(id)),
       ),
       "Type" => Expr::String("ZMQ_STREAM".to_string()),
@@ -1662,7 +1661,7 @@ fn byte_array(bytes: &[u8]) -> Expr {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn end_of_file() -> Expr {
-  Expr::Identifier("EndOfFile".to_string())
+  id_expr("EndOfFile")
 }
 
 /// Read one line, waiting for as much of it as the peer still owes.
@@ -1739,7 +1738,7 @@ fn dispatch_native(
     "SocketReadMessage" if args.len() == 1 => {
       let uuid = socket_arg?;
       Some(Ok(match read_available(&uuid) {
-        Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+        Err(SocketUnusable) => fail_expr(),
         Ok(bytes) if bytes.is_empty() => end_of_file(),
         Ok(bytes) => byte_array(&bytes),
       }))
@@ -1753,7 +1752,7 @@ fn dispatch_native(
       if buffered_len(&uuid) == 0
         && let Err(SocketUnusable) = fill_buffer(&uuid, false)
       {
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        return Some(Ok(fail_expr()));
       }
       let bytes = take_buffered(&uuid, Some(limit));
       Some(Ok(if bytes.is_empty() {
@@ -1827,9 +1826,9 @@ fn dispatch_native(
             "The socket listener {} is invalid or not open.",
             expr_to_string(&args[0])
           ));
-          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+          return Some(Ok(fail_expr()));
         }
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+        return Some(Ok(null_expr()));
       }
       // On a socket `DeleteObject` *is* `Close`, down to the endpoint string
       // it answers with.
@@ -1840,7 +1839,7 @@ fn dispatch_native(
     "ReadString" if args.len() == 1 && socket_arg.is_some() => {
       let uuid = socket_arg?;
       Some(Ok(match read_to_close(&uuid) {
-        Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+        Err(SocketUnusable) => fail_expr(),
         Ok(bytes) if bytes.is_empty() => end_of_file(),
         Ok(bytes) => Expr::String(String::from_utf8_lossy(&bytes).into_owned()),
       }))
@@ -1848,7 +1847,7 @@ fn dispatch_native(
     "ReadLine" if args.len() == 1 && socket_arg.is_some() => {
       let uuid = socket_arg?;
       Some(Ok(match read_line(&uuid) {
-        Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+        Err(SocketUnusable) => fail_expr(),
         Ok(None) => end_of_file(),
         Ok(Some(line)) => Expr::String(line),
       }))
@@ -1856,7 +1855,7 @@ fn dispatch_native(
     "BinaryReadList" if args.len() == 1 && socket_arg.is_some() => {
       let uuid = socket_arg?;
       Some(Ok(match read_to_close(&uuid) {
-        Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+        Err(SocketUnusable) => fail_expr(),
         Ok(bytes) => Expr::List(
           bytes
             .iter()
@@ -1877,19 +1876,19 @@ fn dispatch_native(
       };
       Some(Ok(match element.as_str() {
         "Byte" => match read_one_byte(&uuid) {
-          Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+          Err(SocketUnusable) => fail_expr(),
           Ok(None) => end_of_file(),
           Ok(Some(byte)) => Expr::Integer(i128::from(byte)),
         },
         "Character" => match read_one_byte(&uuid) {
-          Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+          Err(SocketUnusable) => fail_expr(),
           Ok(None) => end_of_file(),
           Ok(Some(byte)) => {
             Expr::String(String::from_utf8_lossy(&[byte]).into_owned())
           }
         },
         "String" | "Record" => match read_line(&uuid) {
-          Err(SocketUnusable) => Expr::Identifier("$Failed".to_string()),
+          Err(SocketUnusable) => fail_expr(),
           Ok(None) => end_of_file(),
           Ok(Some(line)) => Expr::String(line),
         },

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5403,10 +5403,8 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // MakeBoxes only fires on `Format[…, TeXForm]` rules. User
         // MakeBoxes patterns use `fmt_` and match any form, so they
         // still apply.
-        let mb_call = call(
-          "MakeBoxes",
-          vec![inner.clone(), Expr::Identifier("TeXForm".to_string())],
-        );
+        let mb_call =
+          call("MakeBoxes", vec![inner.clone(), id_expr("TeXForm")]);
         if let Ok(box_ast) = crate::evaluator::evaluate_expr_to_expr(&mb_call) {
           return Ok(Expr::String(box_ast_to_tex(&box_ast)));
         }
@@ -5556,14 +5554,8 @@ fn to_string_ast_inner(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // box-syntax escape characters (`\!\(\*…\)`). The resulting
         // String displays as `DisplayForm[…]` in OutputForm — matching
         // what wolframscript prints for `ToString[expr, StandardForm]`.
-        let make_boxes_call = Expr::FunctionCall {
-          name: "MakeBoxes".to_string(),
-          args: vec![
-            args[0].clone(),
-            Expr::Identifier("StandardForm".to_string()),
-          ]
-          .into(),
-        };
+        let make_boxes_call =
+          call("MakeBoxes", vec![args[0].clone(), id_expr("StandardForm")]);
         let box_ast = crate::evaluator::evaluate_expr_to_expr(&make_boxes_call)
           .unwrap_or_else(|_| args[0].clone());
         let box_inner_text = linear_syntax_box_text(&box_ast);
@@ -9604,13 +9596,13 @@ pub fn to_expression_ast_as(
   let s = expr_to_str(&args[0]);
   // Empty (or whitespace-only) input is Null, not a value.
   if s.trim().is_empty() {
-    return Ok(Expr::Identifier("Null".to_string()));
+    return Ok(null_expr());
   }
   // Syntactically invalid input yields $Failed with a Wolfram syntax message
   // (sntxi/sntx), rather than leaking the internal parser error.
   if let Some(msg) = to_expression_syntax_error(&s, message_symbol) {
     crate::emit_message(&msg);
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   }
   // Three-argument form ToExpression[str, form, h]: wrap the *parsed but
   // unevaluated* expression with head `h`, then evaluate `h[parsed]`. This
@@ -9666,7 +9658,7 @@ pub(crate) fn parse_program_to_expr(
     // reads a `.wlx` file statement by statement this way and matches on the
     // trailing `Null` to find the names to localise.
     if normalized.trim_end().ends_with(';') && !exprs.is_empty() {
-      exprs.push(Expr::Identifier("Null".to_string()));
+      exprs.push(null_expr());
     }
     match exprs.len() {
       0 => {}
@@ -13350,7 +13342,7 @@ pub fn read_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let read_type = if args.len() >= 2 {
     &args[1]
   } else {
-    &Expr::Identifier("Expression".to_string())
+    &id_expr("Expression")
   };
 
   // Optional max count: must be a non-negative machine integer when
@@ -14400,10 +14392,7 @@ pub fn build_template_object(
     pattern: Box::new(Expr::Identifier(name.to_string())),
     replacement: Box::new(value),
   };
-  object_args.push(option(
-    "CombinerFunction",
-    Expr::Identifier("StringJoin".to_string()),
-  ));
+  object_args.push(option("CombinerFunction", id_expr("StringJoin")));
   // XMLTemplate reports its insertion function as the string "HTMLFragment";
   // plain string templates use the TextString symbol.
   let insertion_value = if insertion_function == "HTMLFragment" {
@@ -16638,7 +16627,7 @@ pub fn snippet_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "Snippet::invcnt: Content should be string, File, URL, or valid \
        ContentObject.",
     );
-    return Ok(Expr::Identifier("$Failed".to_string()));
+    return Ok(fail_expr());
   };
   let lines: Vec<&str> = text.split('\n').collect();
   let count = lines.len() as i128;
@@ -16679,7 +16668,7 @@ pub fn snippet_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "Snippet::invspec: Specification {} should be an integer or Span.",
           expr_to_output(spec)
         ));
-        return Ok(Expr::Identifier("$Failed".to_string()));
+        return Ok(fail_expr());
       }
     }
   };

--- a/src/functions/tree_form.rs
+++ b/src/functions/tree_form.rs
@@ -377,7 +377,7 @@ pub fn tree_form_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Build Graphics[{primitives...}, ImageSize -> width]
   let content = Expr::List(primitives.into());
   let image_size_opt = Expr::Rule {
-    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    pattern: Box::new(id_expr("ImageSize")),
     replacement: Box::new(Expr::Integer(image_width as i128)),
   };
 
@@ -656,7 +656,7 @@ fn tree_to_graphics(tree: &TreeNode) -> Result<Expr, InterpreterError> {
 
   let content = Expr::List(primitives.into());
   let image_size_opt = Expr::Rule {
-    pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
+    pattern: Box::new(id_expr("ImageSize")),
     replacement: Box::new(Expr::Integer(image_width as i128)),
   };
 

--- a/src/functions/wavelet_ast/data.rs
+++ b/src/functions/wavelet_ast/data.rs
@@ -1061,11 +1061,7 @@ pub fn apply_dwd(func: &Expr, args: &[Expr]) -> Result<Expr, InterpreterError> {
           threshold_values: None,
           dims: dwd.dims.clone(),
         };
-        let iargs = vec![
-          sub.to_expr(),
-          Expr::Identifier("Automatic".into()),
-          wind_to_expr(w),
-        ];
+        let iargs = vec![sub.to_expr(), id_expr("Automatic"), wind_to_expr(w)];
         inverse_wavelet_transform_ast(&iargs)?
       }
       _ => coef.clone(),

--- a/src/functions/wavelet_ast/mod.rs
+++ b/src/functions/wavelet_ast/mod.rs
@@ -2,9 +2,7 @@
 //! stationary, packet, lifting, and continuous wavelet transforms, plus
 //! coefficient manipulation and visualization.
 
-use crate::InterpreterError;
-use crate::helpers::{call, call0, call1, unevaluated};
-use crate::syntax::{Expr, expr_to_string};
+use super::*;
 
 pub mod continuous;
 pub mod data;

--- a/src/functions/wavelet_ast/phipsi.rs
+++ b/src/functions/wavelet_ast/phipsi.rs
@@ -31,7 +31,7 @@ fn formula(template: &str, x: &Expr) -> Expr {
   let code = template.replace("#x#", &format!("({})", expr_to_string(x)));
   match crate::syntax::string_to_expr(&code) {
     Ok(e) => eval(e),
-    Err(_) => Expr::Identifier("$Failed".to_string()),
+    Err(_) => fail_expr(),
   }
 }
 

--- a/src/functions/wxf_ast.rs
+++ b/src/functions/wxf_ast.rs
@@ -620,7 +620,7 @@ pub fn binary_deserialize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "BinaryDeserialize::corrupt: Serialized data ByteArray[<{}>] is corrupt and does not represent an expression.",
       bytes.len()
     ));
-    Ok(Expr::Identifier("$Failed".to_string()))
+    Ok(fail_expr())
   };
   if bytes.len() < 2 || bytes[0] != b'8' || bytes[1] != b':' {
     return corrupt();

--- a/src/functions/xlsx_ast.rs
+++ b/src/functions/xlsx_ast.rs
@@ -18,7 +18,7 @@ fn cell_to_expr(cell: &Data) -> Expr {
     Data::DateTime(dt) => Expr::Real(dt.as_f64()),
     Data::DateTimeIso(s) => Expr::String(s.clone()),
     Data::DurationIso(s) => Expr::String(s.clone()),
-    Data::Error(_) => Expr::Identifier("$Failed".to_string()),
+    Data::Error(_) => fail_expr(),
     Data::Empty => Expr::String(String::new()),
   }
 }

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -103,10 +103,7 @@ pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       div2(Expr::Integer(p), z.clone())
     };
-    return Ok(call(
-      "Power",
-      vec![Expr::Identifier("E".to_string()), exponent],
-    ));
+    return Ok(call("Power", vec![id_expr("E"), exponent]));
   }
 
   // Symbolic base: fixed templates for k = 0, 1, 2 (c must be 1)
@@ -1051,7 +1048,7 @@ pub fn fourier_coefficient_ast(
   };
   let times = |fs: Vec<Expr>| call("Times", fs);
   let pow = |b: Expr, e: i128| pow2(b, Expr::Integer(e));
-  let i_unit = || Expr::Identifier("I".to_string());
+  let i_unit = || id_expr("I");
   let pi = || const_expr("Pi");
 
   let (c0, c1, c2, c3) = (coeff(0), coeff(1), coeff(2), coeff(3));


### PR DESCRIPTION
This PR extends the use of id_expr to the remaining src/functions/*.rs files.