### PR TITLE
Rotate a Text label's offset along with its direction vector

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -6621,23 +6621,41 @@ fn render_primitive(
       let text_w = longest as f64 * fs * 0.6;
       let text_h = text.split('\n').count() as f64 * fs;
       let (ax, ay) = resolve_anchor(*x, *y, *scaled, bb);
-      let sx = coord_x(ax, bb, svg_w) - offset.0 * text_w / 2.0;
-      let sy = coord_y(ay, bb, svg_h) + offset.1 * text_h / 2.0;
+      let anchor_x = coord_x(ax, bb, svg_w);
+      let anchor_y = coord_y(ay, bb, svg_h);
       // A fourth `direction` argument tilts the label's baseline to match
       // that vector — carried in data coordinates, so it has to go through
       // the same x/y pixel-per-unit scaling `coord_x`/`coord_y` apply (and
-      // the same y-flip) before it becomes a screen-space angle for SVG's
-      // `rotate()`.
-      let rotate_attr = match direction {
-        Some((dx, dy)) if *dx != 0.0 || *dy != 0.0 => {
-          let px = dx * svg_w / bb.width();
-          let py = -dy * svg_h / bb.height();
-          format!(
-            " transform=\"rotate({:.3} {sx:.2} {sy:.2})\"",
-            py.atan2(px).to_degrees()
-          )
-        }
-        _ => String::new(),
+      // the same y-flip) before it becomes a screen-space angle. The offset
+      // is measured along that same tilted baseline (its local x-axis) and
+      // perpendicular to it (its local y-axis), not along the fixed screen
+      // axes — so a label offset "backward" along a rotated direction is
+      // pushed out along the direction it points, which is what fans the
+      // labels in `Table[Text[…, dir], {dir, …}]` out radially instead of
+      // stacking them all at the same offset.
+      let has_direction =
+        matches!(direction, Some((dx, dy)) if *dx != 0.0 || *dy != 0.0);
+      let angle = if has_direction {
+        let (dx, dy) = direction.unwrap();
+        let px = dx * svg_w / bb.width();
+        let py = -dy * svg_h / bb.height();
+        py.atan2(px)
+      } else {
+        0.0
+      };
+      let (ux, uy) = (angle.cos(), angle.sin());
+      let (vx, vy) = (-angle.sin(), angle.cos());
+      let sx =
+        anchor_x - offset.0 * text_w / 2.0 * ux + offset.1 * text_h / 2.0 * vx;
+      let sy =
+        anchor_y - offset.0 * text_w / 2.0 * uy + offset.1 * text_h / 2.0 * vy;
+      let rotate_attr = if has_direction {
+        format!(
+          " transform=\"rotate({:.3} {sx:.2} {sy:.2})\"",
+          angle.to_degrees()
+        )
+      } else {
+        String::new()
       };
       // `Background -> colour` paints a panel behind the label, which is
       // what keeps a value readable over whatever it is placed on; a

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2141,6 +2141,39 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_text_offset_follows_rotated_direction() {
+    // `Text[expr, coords, offset, direction]` measures `offset` along the
+    // label's own (rotated) baseline, not along the fixed screen axes:
+    // Wolfram's docs describe the offset as relative to that rotated
+    // baseline, and demonstrations that fan labels out radially (e.g.
+    // `Table[Text[…, {Cos[a], Sin[a]}], {a, 0, 2 Pi, …}]`) rely on this to
+    // push each label outward along its own direction rather than by a
+    // fixed amount in x. Regression: the offset used to be applied purely
+    // along the unrotated x/y screen axes, so every label in such a table
+    // landed at the exact same on-screen position regardless of direction.
+    clear_state();
+    let svg = interpret(
+      "ExportString[Graphics[{Text[\"Q\", {0, 0}, {-1, 0}, {1, 0}], Text[\"Q\", {0, 0}, {-1, 0}, {0, 1}]}, ImageSize -> {100, 100}, PlotRange -> {{-1, 1}, {-1, 1}}], \"SVG\"]",
+    )
+    .unwrap();
+    // Direction {1, 0} (pointing right, unrotated baseline): offset -1
+    // shifts the label along x only, landing right of the anchor.
+    assert!(
+      svg.contains("<text x=\"54.20\" y=\"50.00\""),
+      "unrotated offset in the wrong place: {svg}"
+    );
+    // Direction {0, 1} (baseline rotated 90 degrees to point up): the same
+    // offset -1 now shifts the label along the rotated baseline, i.e.
+    // vertically, landing above the anchor instead of to its right.
+    assert!(
+      svg.contains(
+        "<text x=\"50.00\" y=\"45.80\" fill=\"rgb(0,0,0)\" font-size=\"14\" font-weight=\"normal\" font-style=\"normal\" text-anchor=\"middle\" dominant-baseline=\"central\" transform=\"rotate(-90.000 50.00 45.80)\""
+      ),
+      "offset was not rotated along with direction: {svg}"
+    );
+  }
+
+  #[test]
   fn test_invisible_text_label_paints_nothing() {
     // `Text[Invisible[Style["e", …]], pos]` — a Demonstration hides one
     // item's label (e.g. an edge whose name shouldn't show) by wrapping it


### PR DESCRIPTION
## Summary

This was found while checking whether Woxi Studio fully supports a random Wolfram Demonstration ("Rotated and Scaled Text in Graphics"), which arranges rotated `Sqrt[Mathematica]` labels radially around a point using:

```
Text[Style[Sqrt[Mathematica], fontsize, Italic], {0, 0}, {-1.5, 0}, {Cos[a + rotation], Sin[a + rotation]}]
```

`Text[expr, coords, offset, direction]` measures `offset` along the label's own (rotated) baseline, not along the fixed screen x/y axes — per Wolfram's docs, the offset is relative to that rotated baseline. The SVG renderer instead applied `offset` purely along the unrotated screen axes and only rotated the glyph afterward in place, so every label in a `Table[Text[…, dir], {dir, …}]` loop landed at the *same* on-screen position regardless of `direction`. This broke any Demonstration that fans labels out radially by combining a non-zero offset with a varying direction vector (exactly what this notebook, and Woxi Studio's rendering of it, needs).

- Compute the screen-space rotation angle once, and rotate the offset vector by that same angle before applying it — so the label's local x/y offset axes track its baseline direction.
- Left the exact original "when does a `rotate(...)` attribute get emitted" condition alone (still tied to whether `direction` is a non-zero vector, not to the resulting angle), so a `{1, 0}` direction still emits an explicit `~0deg` rotation as before.

Verified visually: with the offset+direction fix, `Table[Text[Style[Sqrt[Mathematica], 20, Italic], {0,0}, {-1.5,0}, {Cos[a],Sin[a]}], {a, 0, 2Pi-0.01, Pi/4}]` now renders as 8 labels fanned out radially (matching the Demonstration), instead of 8 labels stacked on top of each other at the same spot.

## Test plan
- Added `test_text_offset_follows_rotated_direction` (regression test) verifying a `{-1, 0}` offset lands to the right of the anchor for direction `{1, 0}` and above the anchor for direction `{0, 1}`.
- `make test` — all 28,514 tests pass.
- `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138dfgLue9Q8iAiKxDt35EY

---
_Generated by [Claude Code](https://claude.ai/code/session_0138dfgLue9Q8iAiKxDt35EY)_