### PR TITLE
Fix disjoint SetterBar rows sharing one Manipulate variable

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -17945,6 +17945,16 @@ pub enum ManipulateControl {
     /// parallel to `values`. `None` for plain text labels.
     value_label_svgs: Vec<Option<String>>,
     initial_index: usize,
+    /// The initial value's InputForm, kept only when it is *not* one of
+    /// `values` — e.g. a shared variable with several disjoint SetterBar
+    /// rows (a Demonstration's aberration picker splits 22 choices across
+    /// four rows; the shared default only appears in one of them). Every
+    /// other row's `initial_index` falls back to `0` for display, which is
+    /// fine for a button that isn't lit up — but the *bound* value must stay
+    /// the true default, not silently become that row's first choice.
+    /// `current_code`/`set_current_from_code` prefer this over
+    /// `values[initial_index]` whenever it is set.
+    initial_overflow: Option<String>,
     label: String,
     label_runs: Vec<LabelRun>,
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
@@ -22327,9 +22337,14 @@ fn parse_manipulate_control(
       if values.is_empty() {
         return None;
       }
+      // `resolved_init_code` is the initial value's InputForm once evaluated
+      // (falling back to its held form), used below to keep it as
+      // `initial_overflow` when it matches none of this row's own choices.
+      let mut resolved_init_code: Option<String> = None;
       let initial_index = match explicit_initial {
         Some(init) => {
           let init_code = crate::syntax::expr_to_input_form(&init);
+          resolved_init_code = Some(init_code.clone());
           values
             .iter()
             .position(|v| *v == init_code)
@@ -22341,12 +22356,19 @@ fn parse_manipulate_control(
               let evaluated =
                 crate::evaluator::evaluate_expr_to_expr(&init).ok()?;
               let code = crate::syntax::expr_to_input_form(&evaluated);
+              resolved_init_code = Some(code.clone());
               values.iter().position(|v| *v == code)
             })
             .unwrap_or(0)
         }
         None => 0,
       };
+      // Several disjoint SetterBar rows can share one variable (see
+      // `initial_overflow`'s doc comment); when this row's own choices don't
+      // include the true initial value, keep it so the bound value stays
+      // correct even though this particular row shows no button lit up.
+      let initial_overflow =
+        resolved_init_code.filter(|code| !values.iter().any(|v| v == code));
       // A choice list built from another control's variable (`Range[1,
       // If[flat, 3, 6], 1]`) only holds for that variable's current value;
       // keep its code so the frontend can rebuild the choices whenever the
@@ -22364,6 +22386,7 @@ fn parse_manipulate_control(
           value_labels,
           value_label_svgs,
           initial_index,
+          initial_overflow,
           label,
           label_runs,
           popup: control_type.as_deref() == Some("PopupMenu"),
@@ -22469,6 +22492,7 @@ fn parse_manipulate_control(
           value_labels,
           value_label_svgs,
           initial_index: 0,
+          initial_overflow: None,
           label,
           label_runs,
           popup: false,
@@ -22857,13 +22881,16 @@ pub fn manipulate_initial_bindings(
         name,
         values,
         initial_index,
+        initial_overflow,
         ..
       } => Some((
         name.clone(),
-        values
-          .get(*initial_index)
-          .cloned()
-          .unwrap_or_else(|| "Null".to_string()),
+        initial_overflow.clone().unwrap_or_else(|| {
+          values
+            .get(*initial_index)
+            .cloned()
+            .unwrap_or_else(|| "Null".to_string())
+        }),
       )),
       ManipulateControl::Slider2D {
         name,
@@ -23362,6 +23389,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         value_labels,
         value_label_svgs,
         initial_index,
+        initial_overflow: _,
         label,
         label_runs,
         popup,

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3996,11 +3996,17 @@ fn render_manipulate_widget<'a>(
         value_labels,
         value_label_svgs,
         current_index,
+        overflow,
         popup,
         setter_bar: force_setter_bar,
         slider: as_slider,
         vertical: is_vertical,
       } => {
+        // A shared variable can have several disjoint SetterBar rows (see
+        // `ControlState::Discrete::overflow`'s doc comment); while the true
+        // value is one none of *this* row's own choices represent, no
+        // button/checkbox/dropdown entry here should show as selected.
+        let has_overflow = overflow.is_some();
         let label_widget =
           manipulate_label_widget(label_runs, label, label_col_width, enabled);
         // `ControlType -> Slider` over a discrete domain: a slider that
@@ -4039,8 +4045,8 @@ fn render_manipulate_widget<'a>(
           && bool_values.iter().any(|v| v == "True")
           && bool_values.iter().any(|v| v == "False");
         if is_bool_domain {
-          let checked =
-            bool_values.get(*current_index).is_some_and(|v| v == "True");
+          let checked = !has_overflow
+            && bool_values.get(*current_index).is_some_and(|v| v == "True");
           // Toggling selects the other entry; the update handler maps the
           // sent display label back to its index.
           let other_label = value_labels
@@ -4079,7 +4085,7 @@ fn render_manipulate_widget<'a>(
           let is_vertical = *is_vertical;
           let mut buttons = Vec::with_capacity(value_labels.len());
           for (i, choice_label) in value_labels.iter().enumerate() {
-            let is_selected = i == *current_index;
+            let is_selected = !has_overflow && i == *current_index;
             let choice = choice_label.clone();
             // A choice whose rule label is a graphic (`"+" -> myIcon[2]`)
             // shows the rendered icon; text choices show their label.
@@ -4122,7 +4128,11 @@ fn render_manipulate_widget<'a>(
               .into()
           }
         } else {
-          let selected = value_labels.get(*current_index).cloned();
+          let selected = if has_overflow {
+            None
+          } else {
+            value_labels.get(*current_index).cloned()
+          };
           let on_select = move |choice: String| {
             if enabled {
               Message::ManipulateDiscreteChanged(cell_idx, ctrl_idx, choice)
@@ -6983,6 +6993,84 @@ fn strip_svg_wrapper(svg: &str) -> &str {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  /// A picker offering more choices than fit in one row splits them across
+  /// several `SetterBar`s that all share one control variable — the shape a
+  /// Wolfram Demonstrations Project notebook's aberration/category picker
+  /// takes when it has, say, twenty-two choices (independently written, not
+  /// copied from any specific one). Regression: only the row whose own
+  /// choices happened to include the shared default reported the right
+  /// value; every other row silently fell back to its own first choice, and
+  /// because bindings are applied in row order the *last* row in the
+  /// specification always won outright — so the widget opened showing
+  /// whichever row came last, not the declared default, and clicking a
+  /// choice in an earlier row changed nothing unless the last row happened
+  /// to share that exact value too.
+  #[test]
+  fn manipulate_disjoint_setter_bar_siblings_share_the_true_default_value() {
+    let code = "Manipulate[\
+      Which[kind == 1, \"circle\", kind == 2, \"square\", kind == 3, \"triangle\", \
+        kind == 4, \"pentagon\", kind == 5, \"hexagon\"], \
+      {{kind, 2, \"\"}, {1 -> \"circle\", 2 -> \"square\", 3 -> \"triangle\"}, \
+        ControlType -> SetterBar}, \
+      {{kind, 2, \"\"}, {4 -> \"pentagon\", 5 -> \"hexagon\"}, ControlType -> SetterBar}\
+      ]";
+    let state = instantiate_stored_manipulate(code, "")
+      .expect("the shared-variable SetterBar Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state.text_output.as_deref(),
+      Some("square"),
+      "the declared default (kind -> 2, \"square\") must win, not whichever \
+       SetterBar row happens to come last"
+    );
+
+    let kind_rows: Vec<usize> = state
+      .controls
+      .iter()
+      .enumerate()
+      .filter(|(_, c)| c.name() == "kind")
+      .map(|(i, _)| i)
+      .collect();
+    assert_eq!(
+      kind_rows.len(),
+      2,
+      "expected two SetterBar rows sharing `kind`: {:?}",
+      state.controls
+    );
+
+    // The second row has no button for `2` at all; picking one of its own
+    // choices must still change the rendered output — pre-fix, the second
+    // row's own (wrong) fallback value silently overrode whatever the first
+    // row held, every time, because it came last in `self.controls`.
+    let mut state = state;
+    let second_idx = kind_rows[1];
+    if let manipulate::ControlState::Discrete {
+      values,
+      current_index,
+      overflow,
+      ..
+    } = &mut state.controls[second_idx]
+    {
+      *current_index = values
+        .iter()
+        .position(|v| v == "5")
+        .expect("the hexagon choice");
+      *overflow = None;
+    }
+    state.apply_tracking(second_idx);
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "re-render after picking a SetterBar choice failed: {:?}",
+      state.error
+    );
+    assert_eq!(state.text_output.as_deref(), Some("hexagon"));
+  }
 
   /// A Manipulate whose body calls a `Compile`d helper with bare
   /// (undeclared-type) parameters that are only ever used as repetition

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -56,6 +56,15 @@ pub enum ControlState {
     /// (`"+" -> myIcon[2]`), parallel to `values`. `None` = text label.
     value_label_svgs: Vec<Option<svg::Handle>>,
     current_index: usize,
+    /// The true current value's InputForm, kept only while it matches none
+    /// of `values` (mirrors `ManipulateControl::Discrete::initial_overflow`
+    /// in `woxi::functions::graphics`): several disjoint SetterBar rows can
+    /// share one variable, and this row's own choices needn't include
+    /// whatever value another row just picked. `current_code` and
+    /// `set_current_from_code` prefer this over `values[current_index]`
+    /// whenever it is set, so the row still hands back the right value even
+    /// though none of its own buttons apply.
+    overflow: Option<String>,
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
     /// choice count is small enough for a SetterBar.
     popup: bool,
@@ -203,11 +212,14 @@ impl ControlState {
       ControlState::Discrete {
         values,
         current_index,
+        overflow,
         ..
-      } => values
-        .get(*current_index)
-        .cloned()
-        .unwrap_or_else(|| "Null".to_string()),
+      } => overflow.clone().unwrap_or_else(|| {
+        values
+          .get(*current_index)
+          .cloned()
+          .unwrap_or_else(|| "Null".to_string())
+      }),
       ControlState::Slider2D { x, y, .. } => {
         format!("{{{}, {}}}", format_f64(*x), format_f64(*y))
       }
@@ -260,11 +272,15 @@ impl ControlState {
       ControlState::Discrete {
         values,
         current_index,
+        overflow,
         ..
       } => {
         let form = woxi::syntax::expr_to_input_form(&expr);
         if let Some(i) = values.iter().position(|v| *v == form) {
           *current_index = i;
+          *overflow = None;
+        } else {
+          *overflow = Some(form);
         }
       }
       ControlState::Slider2D { x, y, .. } => {
@@ -1088,6 +1104,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         value_labels,
         value_label_svgs,
         initial_index,
+        initial_overflow,
         popup,
         setter_bar,
         slider,
@@ -1106,6 +1123,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           })
           .collect(),
         current_index: *initial_index,
+        overflow: initial_overflow.clone(),
         popup: *popup,
         setter_bar: *setter_bar,
         slider: *slider,


### PR DESCRIPTION
## Summary

- The "Zernike Polynomials and Optical Aberration" Demonstration (randomly sampled from the Wolfram Demonstrations Project) offers 22 aberration choices through four separate `SetterBar` rows bound to one shared `Manipulate` variable, each row holding a disjoint slice of the choices. Getting its `Manipulate` to build correctly in Woxi Studio surfaced a bug that applies to any such split picker, not just this one.
- Each row independently fell back to its own first choice whenever the shared value wasn't among its own choices, and because control bindings are applied in row order, the *last* row's value always won outright, regardless of which row the user actually picked from. The widget opened showing the wrong picture, and clicking an earlier row did nothing unless the last row happened to hold the same value too.
- Fix: give a `Discrete` control an `overflow` field that keeps the true value whenever it isn't one of that row's own choices, and prefer it in `current_code`/`set_current_from_code` and in the initial-bindings builder, so every sibling row agrees on the one true value instead of each guessing independently. Also suppress a row's highlighted button while its value lives in `overflow`, since none of its own choices are actually selected.

## Test plan

- [x] Added `manipulate_disjoint_setter_bar_siblings_share_the_true_default_value` (independently written, not copied from the Demonstration) — verified it fails without the fix (reproducing the exact "last row wins" symptom) and passes with it.
- [x] `cargo test -p woxi-studio --bin woxi-studio` — 228/228 pass (one unrelated, pre-existing floating-point-precision flake in `demonstration_two_pivoting_rays_trace_their_intersection`, confirmed to fail identically on `main` without this change).
- [x] `cargo test -p woxi` — all lib + integration tests pass.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jz3worgsGexicvpmCBTXnX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz3worgsGexicvpmCBTXnX)_