### PR TITLE
Let Equal/Unequal decide structural shape mismatches under free symbols

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -3608,6 +3608,15 @@ pub fn evaluate_expr_to_expr_inner(
                 // Same head and arity with every leaf determinably equal,
                 // e.g. `RGBColor[0., 0., 1.] == RGBColor[0, 0, 1]`.
                 true
+              } else if crate::functions::boolean_ast::structurally_unequal(
+                left, right,
+              ) {
+                // A structural shape mismatch (different list lengths, or a
+                // `List` lined up against a `Rule`) decides `Equal` no
+                // matter what free symbol is nested inside — e.g.
+                // `{{x -> 1}} == {{}}` is `False` even though `x` is
+                // unbound.
+                false
               } else if has_free_symbols(left) || has_free_symbols(right) {
                 // Symbolic: return unevaluated
                 return Ok(Expr::Comparison {
@@ -3649,6 +3658,12 @@ pub fn evaluate_expr_to_expr_inner(
             ) {
               // Determinably equal component-wise → `!=` is False.
               false
+            } else if crate::functions::boolean_ast::structurally_unequal(
+              left, right,
+            ) {
+              // A structural shape mismatch decides `!=` regardless of any
+              // free symbol nested inside, mirroring the `Equal` rule above.
+              true
             } else if has_free_symbols(left) || has_free_symbols(right) {
               // Symbolic: return unevaluated
               return Ok(Expr::Comparison {

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -627,6 +627,60 @@ pub fn infinity_equal_verdict(a: &Expr, b: &Expr) -> Option<Option<bool>> {
   }
 }
 
+/// Whether `a` and `b` can be proven to never be equal, no matter what any
+/// bare symbol nested inside either one is later bound to — e.g. comparing
+/// a `List` and a `Rule[…]`, or two `List`s of different lengths, is decided
+/// this way regardless of what values their elements hold: `{{x -> 1}} ==
+/// {{}}` is `False` even though `x` is unbound, since the outer lengths (1
+/// vs. 1) match but the inner ones (1 vs. 0) never can. Returns `false`
+/// whenever it cannot decide, so the caller falls back to leaving the
+/// comparison symbolic rather than concluding `False` outright.
+pub fn structurally_unequal(a: &Expr, b: &Expr) -> bool {
+  // A bare symbol is still an open variable — it could be bound to
+  // anything, so nothing touching it can be decided this way.
+  if matches!(a, Expr::Identifier(_)) || matches!(b, Expr::Identifier(_)) {
+    return false;
+  }
+  fn parts(e: &Expr) -> Option<(&'static str, Vec<&Expr>)> {
+    match e {
+      Expr::List(items) => Some(("List", items.iter().collect())),
+      Expr::Rule {
+        pattern,
+        replacement,
+      } => Some(("Rule", vec![pattern.as_ref(), replacement.as_ref()])),
+      Expr::RuleDelayed {
+        pattern,
+        replacement,
+      } => Some(("RuleDelayed", vec![pattern.as_ref(), replacement.as_ref()])),
+      _ => None,
+    }
+  }
+  match (parts(a), parts(b)) {
+    (Some((h1, a1)), Some((h2, a2))) => {
+      h1 != h2
+        || a1.len() != a2.len()
+        || a1
+          .iter()
+          .zip(a2.iter())
+          .any(|(x, y)| structurally_unequal(x, y))
+    }
+    (None, None) => {
+      use crate::functions::math_ast::try_eval_to_f64;
+      match (try_eval_to_f64(a), try_eval_to_f64(b)) {
+        (Some(x), Some(y)) => x != y,
+        _ => matches!((a, b), (Expr::String(x), Expr::String(y)) if x != y),
+      }
+    }
+    // A bare `List`/`Rule`/`RuleDelayed` lined up against a plain number or
+    // an opaque expression (e.g. a `FunctionCall`) is left undecided: Solve
+    // relies on `{e1, e2, …} == 0` staying unevaluated so it can thread the
+    // scalar across the list itself (see `solve_broadcasts_scalar_across_
+    // list_equation`), and a generic `FunctionCall`'s value could still be
+    // data-dependent.
+    (Some(_), None) | (None, Some(_)) => false,
+  }
+}
+
 pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Equal[] and Equal[x] return True (like wolframscript)
   if args.len() < 2 {
@@ -797,6 +851,14 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(bool_expr(true));
   }
 
+  // A structural shape mismatch (different list lengths, or a `List` lined
+  // up against a `Rule`) decides `Equal` regardless of any free symbol
+  // nested inside — e.g. `{{x -> 1}} == {{}}` is `False` even though `x` is
+  // never bound, because no value of `x` changes the outer shapes involved.
+  if args.windows(2).any(|w| structurally_unequal(&w[0], &w[1])) {
+    return Ok(bool_expr(false));
+  }
+
   // Only stay symbolic if at least one arg has free symbols
   if args.iter().any(crate::evaluator::has_free_symbols) {
     Ok(symbolic_comparison_chain(args, ComparisonOp::Equal))
@@ -898,6 +960,14 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let nums: Vec<Option<f64>> = args.iter().map(try_eval_to_f64).collect();
   if nums.iter().all(std::option::Option::is_some) {
     // All numeric and pairwise different (checked above via strings)
+    return Ok(bool_expr(true));
+  }
+
+  // For the common 2-argument form, a structural shape mismatch (different
+  // list lengths, or a `List` lined up against a `Rule`) decides `Unequal`
+  // regardless of any free symbol nested inside, mirroring the analogous
+  // `Equal` rule above.
+  if args.len() == 2 && structurally_unequal(&args[0], &args[1]) {
     return Ok(bool_expr(true));
   }
 

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -11611,6 +11611,72 @@ mod equal_needs_comparable_operands {
   }
 }
 
+/// `Equal`/`Unequal` can decide a structural shape mismatch — different
+/// list lengths, or a `List` lined up against a `Rule` — without knowing
+/// what any free symbol nested inside is bound to. `Which[sol == {{}} ||
+/// sol == {}, …]` from the "A Geometrical Theorem of Leibniz" Demonstration
+/// relies on this: `sol` is a `Module`-local `NSolve` result like
+/// `{{x$1 -> -0.36}}`, and comparing it against `{{}}`/`{}` must resolve to
+/// `False` even though `x$1` is never bound, so `Which` can pick a branch.
+mod equal_decides_structural_shape_mismatches {
+  use super::*;
+
+  #[test]
+  fn a_list_of_rules_never_equals_a_list_of_empty_lists() {
+    clear_state();
+    assert_eq!(interpret("{{x -> 1}} == {{}}").unwrap(), "False");
+    assert_eq!(interpret("{{x -> 1}} != {{}}").unwrap(), "True");
+    assert_eq!(
+      interpret("sol = {{x -> -0.36}}; sol == {}").unwrap(),
+      "False"
+    );
+    assert_eq!(
+      interpret("sol = {{x -> -0.36}}; sol == {{}} || sol == {}").unwrap(),
+      "False"
+    );
+  }
+
+  #[test]
+  fn different_list_lengths_never_equal_however_deeply_nested() {
+    clear_state();
+    assert_eq!(interpret("{1, 2} == {1, 2, 3}").unwrap(), "False");
+    assert_eq!(interpret("{x, {}} == {x, {1}}").unwrap(), "False");
+    assert_eq!(interpret("{x, {}} != {x, {1}}").unwrap(), "True");
+  }
+
+  #[test]
+  fn a_which_branch_selects_once_the_guard_resolves() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "sol = {{x -> -0.36}}; \
+         Which[sol == {{}} || sol == {}, \"empty\", True, \"full\"]"
+      )
+      .unwrap(),
+      "full"
+    );
+  }
+
+  #[test]
+  fn genuinely_undecidable_comparisons_still_stay_symbolic() {
+    clear_state();
+    // A bare symbol could still be bound to anything, so nothing here is
+    // decided structurally.
+    assert_eq!(interpret("x == y").unwrap(), "x == y");
+    assert_eq!(interpret("{x} == {y}").unwrap(), "{x} == {y}");
+    assert_eq!(interpret("f[x] == g[x]").unwrap(), "f[x] == g[x]");
+    // `Rule[…]` and the `->` operator are the same expression, not a
+    // structural mismatch.
+    assert_eq!(interpret("Rule[1, 2] == (1 -> 2)").unwrap(), "True");
+    // Solve relies on a scalar-vs-list comparison staying unevaluated so it
+    // can thread the scalar across the list itself.
+    assert_eq!(
+      interpret("Solve[{x^2 - 1} == 0, x]").unwrap(),
+      "{{x -> -1}, {x -> 1}}"
+    );
+  }
+}
+
 mod integer_to_a_negative_power_stays_exact {
   use super::*;
 


### PR DESCRIPTION
## Summary

As part of the recurring routine that fetches a random Wolfram Demonstration and checks whether Woxi Studio fully supports it, this run downloaded **"A Geometrical Theorem of Leibniz"** by Jay Warendorff.

Its `Manipulate` computes a triangle's centroid via:

```wolfram
CentroidOfTriangle[{a1_, a2_}, {b1_, b2_}, {c1_, c2_}] := Module[{sol, x},
  sol = NSolve[…, x];
  Which[
    sol == {{}} || sol == {} || ((b1 + c1)/2 == a1 && (b2 + c2)/2 == a2), {},
    (b1 + c1)/2 == a1, ({#, a1} &)[(x /. sol)[[1]]],
    True, ({#, …} &)[(x /. sol)[[1]]]
  ]
]
```

`sol` is a `Module`-local result like `{{x$1 -> -0.36}}`. Comparing it against `{{}}`/`{}` stayed unevaluated in Woxi, purely because `x$1` is an unbound symbol — even though no possible value of `x$1` could ever make a length-1 list of `Rule`s equal a length-0 list. `Which` therefore never picked a branch, so `CentroidOfTriangle` returned the whole unevaluated `Which[…]` expression instead of a point.

## Fix

`Equal`/`Unequal` now recognize when two expressions can be proven never equal based purely on their **shape** — different list lengths, or a `List` lined up against a `Rule`/`RuleDelayed` — regardless of what any nested free symbol is bound to. This decision is made *before* falling back to the "contains a free symbol → stay symbolic" rule, in both the canonical `equal_ast`/`unequal_ast` implementations and the parallel `Equal`/`NotEqual` arms of the operator-syntax comparison-chain evaluator.

The check is intentionally conservative:
- A bare symbol on either side still blocks the decision (`x == y`, `{x} == {y}`, `f[x] == g[x]` all correctly stay symbolic).
- A `List`/`Rule` compared against a bare number, string, or a generic `FunctionCall` is left undecided, since `Solve` relies on `{e1, e2, …} == 0`-shaped equations staying unevaluated so it can thread the scalar across the list itself (`Solve[{x^2 - 1} == 0, x]` still works as before).

## Test plan

- Added `equal_decides_structural_shape_mismatches` in `tests/interpreter_tests/arithmetic.rs`, covering the Demonstration's exact repro, list-length mismatches, the `Which` branch selection, and confirming genuinely undecidable comparisons (bare symbols, `Solve`'s scalar/list broadcast) still stay symbolic.
- `make test` (28,522 unit tests) passes.
- `make format` run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdsaX36pTebQ7MQidD2Lh8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdsaX36pTebQ7MQidD2Lh8)_