### PR TITLE
Fix Dynamic value not showing in Style-wrapped Manipulate caption

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -24016,11 +24016,52 @@ fn spacer_width(arg: &Expr) -> f64 {
 /// value. Falls back to the generic leaf when the fragment does not
 /// evaluate (e.g. it is really a graphic).
 fn styled_text_node(expr: &Expr, bindings: &[(String, String)]) -> DisplayNode {
-  match eval_display_in_scope(expr, bindings) {
+  // `Dynamic` is `HoldFirst`, so evaluating `Style[Dynamic[t], Bold]` as a
+  // whole never reduces the `Dynamic[t]` argument — Style itself isn't
+  // held, but that just evaluates each argument in place, and evaluating
+  // `Dynamic[t]` leaves `t` unevaluated by design. Resolve any `Dynamic[…]`
+  // wrapped inside this caption fragment against the live bindings first,
+  // mirroring what the Wolfram front end does when it redraws a `Dynamic`,
+  // so `Style[Dynamic[t]]` shows t's current value rather than the literal
+  // symbol name.
+  let resolved = resolve_display_dynamics(expr, bindings);
+  match eval_display_in_scope(&resolved, bindings) {
     Some(evaluated) => DisplayNode::Text {
       runs: manipulate_label_runs(&evaluated, false),
     },
     None => static_leaf_node(expr, bindings),
+  }
+}
+
+/// Replace every `Dynamic[inner]` found anywhere inside `expr` with `inner`
+/// evaluated against `bindings` (falling back to the untouched `Dynamic[…]`
+/// wrapper when that fails), leaving everything else — style directives,
+/// wrapper structure — untouched. Used to release captions like
+/// `Style[Dynamic[t], Bold]` before formatting them for display.
+fn resolve_display_dynamics(
+  expr: &Expr,
+  bindings: &[(String, String)],
+) -> Expr {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if name == "Dynamic" && !args.is_empty() =>
+    {
+      eval_display_in_scope(&args[0], bindings).unwrap_or_else(|| expr.clone())
+    }
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args
+        .iter()
+        .map(|a| resolve_display_dynamics(a, bindings))
+        .collect(),
+    },
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|i| resolve_display_dynamics(i, bindings))
+        .collect(),
+    ),
+    other => other.clone(),
   }
 }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -12953,6 +12953,51 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
     );
   }
 
+  /// A Demonstration built the way the Wolfram Demonstrations Project
+  /// writes a slider-with-live-readout row: `Row[{Control[…], " ",
+  /// Style[Dynamic[var]]}]` puts the current value of the slider's own
+  /// variable right next to it, and a separate `Style[Dynamic[msg], Bold,
+  /// Red]` caption reports a status message computed from the body.
+  /// Independently written (a made-up "reach the target" puzzle with its
+  /// own variable names) — not the notebook's own code or wording, which
+  /// is copyrighted.
+  ///
+  /// Regression: `Style[Dynamic[var]]` nests the `Dynamic` *inside* the
+  /// `Style` wrapper (unlike a caption where `Dynamic` is the outermost
+  /// call, already handled elsewhere). Evaluating the whole `Style[…]`
+  /// fragment at once never releases that inner `Dynamic` — `Dynamic` is
+  /// `HoldFirst`, so `Dynamic[var]` evaluates to itself regardless of what
+  /// wraps it — so the caption fell back to the literal formatting of the
+  /// held expression and displayed the bare symbol name (`"target"`,
+  /// `"status"`) instead of the variable's current value on every render.
+  #[test]
+  fn manipulate_style_wrapped_dynamic_caption_shows_the_live_value() {
+    let code = r#"Manipulate[
+      status = If[target >= 8, "reached", "not yet"];
+      target,
+      Row[{Control[{{target, 1, "target"}, 0, 10, ImageSize -> Small}],
+        Style[" "], Style[Dynamic[target]]}],
+      Style[Dynamic[status], Bold, Red],
+      {{status, "", ""}, ControlType -> None}
+    ]"#;
+    let expr = woxi::interpret_to_expr(code).expect("must parse");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the Manipulate must build a widget");
+    assert!(state.error.is_none(), "render failed: {:?}", state.error);
+
+    let caption = display_text(&state.display_trees);
+    assert!(
+      caption.contains('1') && !caption.contains("target"),
+      "Style[Dynamic[target]] must show target's current value (1), not \
+       the literal symbol name: {caption:?}"
+    );
+    assert!(
+      caption.contains("not yet") && !caption.contains("status"),
+      "Style[Dynamic[status], Bold, Red] must show status's current value \
+       (\"not yet\"), not the literal symbol name: {caption:?}"
+    );
+  }
+
   /// Collect `(mutation, selected)` of every Toggler in a display tree.
   fn collect_togglers(
     trees: &[woxi::functions::graphics::DisplayNode],


### PR DESCRIPTION
## Summary

- Checked Woxi Studio against a randomly downloaded Wolfram Demonstrations Project notebook (via the scheduled "check a random Demonstration" routine).
- Found that a Manipulate display caption written as `Style[Dynamic[var]]` — the common Demonstrations idiom for showing a slider's live value right next to it — rendered the bare variable name instead of its current value.
- Root cause: `Dynamic` is `HoldFirst`, so evaluating the whole `Style[Dynamic[var], …]` fragment at once never releases the held `Dynamic[var]` argument, regardless of what wraps it. The existing top-level `Dynamic[…]` handling only covered the case where `Dynamic` is the *outermost* call in a caption, not nested one level down inside `Style`.
- Fix: recursively resolve any `Dynamic[…]` found inside a caption fragment against the live bindings before formatting it, mirroring what the Wolfram front end does when it redraws a `Dynamic`.

## Test plan

- [x] Added a regression test (`manipulate_style_wrapped_dynamic_caption_shows_the_live_value`) with an independently-authored Manipulate exercising both `Style[Dynamic[var]]` and `Style[Dynamic[var], Bold, Red]` captions; verified it fails without the fix and passes with it.
- [x] `cargo test -p woxi-studio` — 231 passed, 0 failed.
- [x] `make test` — 28527 passed, 0 failed.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LDgojpbbjr9uSfwZ7v8qw

---
_Generated by [Claude Code](https://claude.ai/code/session_011LDgojpbbjr9uSfwZ7v8qw)_