### PR TITLE
Draw InfiniteLine/HalfLine in 2D Graphics, not just Graphics3D

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -915,7 +915,7 @@ GraphLayout,,🚫,,8.0,888
 Names,Lists symbol names matching a string pattern whose context part selects the context,✅,pure,1.0,889
 RotateLabel,,🚫,,2.0,890
 TimeZone,,🚫,,2.0,892
-InfiniteLine,Geometric primitive representing an infinite line; drawn in Graphics3D clipped to the plot range,✅,none,10.0,893
+InfiniteLine,Geometric primitive representing an infinite line; drawn in Graphics and Graphics3D clipped to the plot range,✅,none,10.0,893
 GegenbauerC,Gegenbauer (ultraspherical) polynomial C_n^lambda(x); two-arg form GegenbauerC[n;x] is the renormalized (2/n) ChebyshevT[n;x],✅,pure,1.0,894
 SetterBar,Setter bar control (stays symbolic in script mode),✅,unevaluated,6.0,895
 StyleBox,Low-level box construct for styled content display,✅,pure,3.0,896
@@ -2280,7 +2280,7 @@ DateListLogPlot,Plots date-valued data with a logarithmic y-axis,✅,pure,7.0,22
 AbsoluteCurrentValue,dynamic content,🚫,None,6.0,2299
 BatchSize,machine learning option,🚫,None,11.0,2299
 DaubechiesWavelet,Daubechies wavelet family of order n,✅,pure,8.0,2299
-HalfLine,Geometric half-line primitive; drawn in Graphics3D clipped to the plot range,✅,pure,10.0,2299
+HalfLine,Geometric half-line primitive; drawn in Graphics and Graphics3D clipped to the plot range,✅,pure,10.0,2299
 PalindromeQ,Tests if a string or list is a palindrome,✅,pure,10.3,2299
 GraphQ,Test whether an expression is a valid Graph object,✅,1,8.0,2305
 ListStreamPlot,stream visualization,🚫,None,7.0,2305

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -858,6 +858,16 @@ enum Primitive {
     full: bool,
     style: StyleState,
   },
+  /// `InfiniteLine[{p1, p2}]`/`InfiniteLine[p, v]` (the whole line through
+  /// `p` along `v`) or, with `half`, `HalfLine[…]` (only the ray from `p` in
+  /// the `v` direction). Extended past the visible plot range at render
+  /// time, the same way `HalfPlanePrim` is.
+  InfiniteLinePrim {
+    p: (f64, f64),
+    v: (f64, f64),
+    half: bool,
+    style: StyleState,
+  },
   /// A fixed-pixel-size marker (e.g. a `Locator`'s appearance graphic)
   /// centered on a data-space point. The pre-rendered SVG is embedded at
   /// `w`×`h` screen pixels regardless of the plot's coordinate scale.
@@ -886,7 +896,8 @@ impl Primitive {
       | Self::ArrowPrim { style, .. }
       | Self::TextPrim { style, .. }
       | Self::BezierCurvePrim { style, .. }
-      | Self::HalfPlanePrim { style, .. } => Some(style),
+      | Self::HalfPlanePrim { style, .. }
+      | Self::InfiniteLinePrim { style, .. } => Some(style),
       Self::RasterPrim { .. }
       | Self::MarkerPrim { .. }
       | Self::InsetGraphic { .. } => None,
@@ -2062,6 +2073,12 @@ fn collect_primitives(
         "InfinitePlane" => {
           parse_infinite_plane(args, style, prims);
         }
+        "InfiniteLine" if !args.is_empty() => {
+          parse_infinite_line(args, style, prims, false);
+        }
+        "HalfLine" if !args.is_empty() => {
+          parse_infinite_line(args, style, prims, true);
+        }
         // Rotate[g, θ] rotates g by θ radians counterclockwise about the
         // center of its bounding box; Rotate[g, θ, {x, y}] about the point
         // {x, y}. Collect the inner primitives, then rotate their coordinates.
@@ -2825,6 +2842,44 @@ fn parse_infinite_plane(
     v: (1.0, 0.0),
     w: (0.0, 1.0),
     full: true,
+    style: style.clone(),
+  });
+}
+
+/// `InfiniteLine[{p1, p2}]` (the line through two points) or
+/// `InfiniteLine[p, v]` (through `p` along direction `v`); `HalfLine` takes
+/// the same two forms but only draws from `p` onward.
+fn parse_infinite_line(
+  args: &[Expr],
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+  half: bool,
+) {
+  let (p, v) = if args.len() >= 2
+    && let (Some(p), Some(v)) =
+      (expr_to_point(&args[0]), expr_to_point(&args[1]))
+  {
+    (p, v)
+  } else {
+    let Expr::List(pts) = &args[0] else {
+      return;
+    };
+    if pts.len() != 2 {
+      return;
+    }
+    let (Some(p1), Some(p2)) = (expr_to_point(&pts[0]), expr_to_point(&pts[1]))
+    else {
+      return;
+    };
+    (p1, (p2.0 - p1.0, p2.1 - p1.1))
+  };
+  if v.0 == 0.0 && v.1 == 0.0 {
+    return;
+  }
+  prims.push(Primitive::InfiniteLinePrim {
+    p,
+    v,
+    half,
     style: style.clone(),
   });
 }
@@ -4163,6 +4218,12 @@ fn primitive_bbox(prim: &Primitive) -> BBox {
       bb.include_point(p.0 + v.0, p.1 + v.1);
       bb.include_point(p.0 + w.0, p.1 + w.1);
     }
+    // Likewise an unbounded line only anchors the range at its own point
+    // and one step along its direction.
+    Primitive::InfiniteLinePrim { p, v, .. } => {
+      bb.include_point(p.0, p.1);
+      bb.include_point(p.0 + v.0, p.1 + v.1);
+    }
   }
   bb
 }
@@ -4497,6 +4558,14 @@ fn rotate_primitive(
       full: *full,
       style: style.clone(),
     },
+    Primitive::InfiniteLinePrim { p, v, half, style } => {
+      Primitive::InfiniteLinePrim {
+        p: rp(p.0, p.1),
+        v: rv(v.0, v.1),
+        half: *half,
+        style: style.clone(),
+      }
+    }
     // A marker is a screen-space icon anchored on a data point: transforms
     // move the anchor and leave the icon itself untouched.
     Primitive::MarkerPrim { x, y, w, h, svg } => {
@@ -4688,6 +4757,14 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
       full: *full,
       style: style.clone(),
     },
+    Primitive::InfiniteLinePrim { p, v, half, style } => {
+      Primitive::InfiniteLinePrim {
+        p: tp(p.0, p.1),
+        v: *v,
+        half: *half,
+        style: style.clone(),
+      }
+    }
     Primitive::MarkerPrim { x, y, w, h, svg } => Primitive::MarkerPrim {
       x: x + dx,
       y: y + dy,
@@ -4937,6 +5014,15 @@ fn scale_primitive(
       full: *full,
       style: style.clone(),
     },
+    Primitive::InfiniteLinePrim { p, v, half, style } => {
+      let (nx, ny) = sp(p.0, p.1);
+      Primitive::InfiniteLinePrim {
+        p: (nx, ny),
+        v: (v.0 * sx, v.1 * sy),
+        half: *half,
+        style: style.clone(),
+      }
+    }
     Primitive::MarkerPrim { x, y, w, h, svg } => {
       let (nx, ny) = sp(*x, *y);
       Primitive::MarkerPrim {
@@ -6452,6 +6538,32 @@ fn render_primitive(
         fill_opacity,
       ));
     }
+    Primitive::InfiniteLinePrim { p, v, half, style } => {
+      // Extend far past the visible plot range in the drawn direction(s);
+      // the SVG viewport clips it. A `HalfLine` only extends forward.
+      let ext = 10.0 * (bb.width() + bb.height());
+      let len = (v.0 * v.0 + v.1 * v.1).sqrt();
+      let (ux, uy) = (v.0 / len * ext, v.1 / len * ext);
+      let (sx, sy) = if *half {
+        (p.0, p.1)
+      } else {
+        (p.0 - ux, p.1 - uy)
+      };
+      let (ex, ey) = (p.0 + ux, p.1 + uy);
+      let color = style.effective_color();
+      let sw = thickness_px(style.thickness, bb, svg_w).max(0.5);
+      let dash = dash_attr(style.dashing.as_ref(), bb, svg_w);
+      let cap = stroke_linecap_attr(style.cap_form);
+      out.push_str(&format!(
+        "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"{sw:.2}\" stroke-linecap=\"{cap}\"{dash}{}/>\n",
+        coord_x(sx, bb, svg_w),
+        coord_y(sy, bb, svg_h),
+        coord_x(ex, bb, svg_w),
+        coord_y(ey, bb, svg_h),
+        color.to_svg_rgb(),
+        color.opacity_attr(),
+      ));
+    }
     Primitive::ArrowPrim {
       points,
       setback,
@@ -7204,6 +7316,9 @@ fn primitives_to_box_elements(primitives: &[Primitive]) -> Vec<String> {
       }
       Primitive::HalfPlanePrim { .. } => {
         // Unbounded fills have no fixed-coordinate box form; skip
+      }
+      Primitive::InfiniteLinePrim { .. } => {
+        // Unbounded lines have no fixed-coordinate box form; skip
       }
       Primitive::MarkerPrim { .. } => {
         // Screen-space marker icons have no box form; skip

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -4662,6 +4662,64 @@ mod plot3d {
     }
   }
 
+  mod unbounded_primitives_2d {
+    use super::*;
+
+    /// `InfiniteLine`/`HalfLine` used to draw nothing at all in a 2D
+    /// `Graphics` (only the `Graphics3D` case was handled), which left a
+    /// scene built around one of Wolfram's own `TriangleLine`-style helpers
+    /// (three infinite lines through a triangle's edges — independently
+    /// written here, not copied from any specific Demonstration) with its
+    /// extended edge lines entirely missing.
+    #[test]
+    fn infinite_line_and_half_line_draw_in_2d_graphics() {
+      for code in [
+        "Graphics[{Gray, InfiniteLine[{{0, 0}, {1, 1}}]}, \
+         PlotRange -> {{-5, 5}, {-5, 5}}]",
+        "Graphics[{Gray, InfiniteLine[{0, 0}, {1, 1}]}, \
+         PlotRange -> {{-5, 5}, {-5, 5}}]",
+        "Graphics[{Red, HalfLine[{0, 0}, {1, 1}]}, \
+         PlotRange -> {{-5, 5}, {-5, 5}}]",
+        "Graphics[{Red, HalfLine[{{2, 0}, {3, 0}}]}, \
+         PlotRange -> {{-5, 5}, {-5, 5}}]",
+      ] {
+        let svg = export_svg(code);
+        assert!(svg.contains("<line "), "{code} drew nothing: {svg}");
+      }
+    }
+
+    /// A `HalfLine` only extends forward from its starting point, so it
+    /// covers half the area a full `InfiniteLine` through the same points
+    /// does — checked by clipping each to a box that only the full line
+    /// reaches on both sides.
+    #[test]
+    fn half_line_only_extends_forward() {
+      let full = export_svg(
+        "Graphics[{InfiniteLine[{{0, 0}, {1, 0}}]}, \
+         PlotRange -> {{-5, 5}, {-1, 1}}]",
+      );
+      let half = export_svg(
+        "Graphics[{HalfLine[{{0, 0}, {1, 0}}]}, \
+         PlotRange -> {{-5, 5}, {-1, 1}}]",
+      );
+      assert_ne!(
+        full, half,
+        "a HalfLine must not draw the same as the InfiniteLine through the \
+         same two points"
+      );
+    }
+
+    /// A degenerate `InfiniteLine`/`HalfLine` (both defining points equal,
+    /// so no direction exists) draws nothing rather than erroring out.
+    #[test]
+    fn degenerate_infinite_line_draws_nothing() {
+      assert_eq!(
+        export_svg("Graphics[{InfiniteLine[{{1, 1}, {1, 1}}]}]"),
+        export_svg("Graphics[{}]")
+      );
+    }
+  }
+
   mod view_angle {
     use super::*;
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7211,6 +7211,53 @@ mod tests {
     );
   }
 
+  /// A triangle-center Manipulate with three `Locator`-draggable vertices
+  /// and a small helper drawing the (extended) edge lines through each pair
+  /// of vertices with `InfiniteLine`, alongside the filled triangle and its
+  /// centroid — the general shape a triangle-geometry Wolfram Demonstrations
+  /// Project notebook uses to show a center against the extended sides
+  /// (independently written here, not copied from any specific one).
+  /// Regression: `InfiniteLine`/`HalfLine` were only drawn inside
+  /// `Graphics3D`; ordinary 2D `Graphics` silently dropped them, so a
+  /// Manipulate like this rendered its triangle and centroid but left the
+  /// extended edge lines entirely missing from the widget's picture.
+  #[test]
+  fn manipulate_locator_triangle_with_infinite_edge_lines() {
+    let code = r#"Manipulate[
+      Graphics[{
+        {Gray, InfiniteLine[{pA, pB}], InfiniteLine[{pB, pC}], InfiniteLine[{pC, pA}]},
+        {LightBlue, EdgeForm[Blue], Polygon[{pA, pB, pC}]},
+        {Red, PointSize[0.02], Point[Mean[{pA, pB, pC}]]}
+      }, PlotRange -> {{-5, 5}, {-5, 5}}],
+      {{pA, {0, 3}}, {-5, -5}, {5, 5}, Locator},
+      {{pB, {-3, -2}}, {-5, -5}, {5, 5}, Locator},
+      {{pC, {3, -2}}, {-5, -5}, {5, 5}, Locator}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a Locator triangle with InfiniteLine edges should build a ManipulateState");
+    assert_eq!(state.error, None, "the body must evaluate cleanly");
+    assert!(state.graphics_handle.is_some(), "the triangle must render");
+
+    let bindings: Vec<(String, String)> = state
+      .controls
+      .iter()
+      .filter(|c| c.binds_variable())
+      .map(|c| (c.name().to_string(), c.current_code()))
+      .collect();
+    let svg = woxi::with_scoped_globals(&bindings, || {
+      woxi::interpret_with_stdout(&state.body)
+    })
+    .expect("the body must evaluate")
+    .graphics
+    .expect("the body must render a graphic");
+    assert!(
+      svg.matches("<line ").count() >= 3,
+      "the three extended edge lines must be drawn: {svg}"
+    );
+  }
+
   /// A dissection Manipulate assembling colored polygon pieces with
   /// `Translate`/`Rotate`, a boolean checkbox control (`{False, True}`
   /// domain) toggling a hint overlay, and several `Tiny` step sliders with


### PR DESCRIPTION
## Summary
- A random Wolfram Demonstrations Project notebook (fetched via the Wolfram Cloud resource system's random-page API) used a small helper building three `InfiniteLine` primitives through a triangle's edges inside an ordinary 2D `Graphics[...]`.
- Woxi Studio evaluated the notebook's `Manipulate` without error, but silently dropped those lines from the rendered picture: 2D `Graphics` only handled `InfiniteLine`/`HalfLine` for the `Graphics3D` case (confirmed via `src/functions/plot3d.rs`, with no equivalent path in `src/functions/graphics.rs`).
- Added a `Primitive::InfiniteLinePrim` variant and rendering path for both primitives in 2D `Graphics`, mirroring the existing `HalfPlane`/`InfinitePlane` handling — the line is extended far past the plot range so the SVG viewport clips it, with support for both `InfiniteLine[{p1, p2}]` and `InfiniteLine[p, v]` argument forms (and the `HalfLine` ray variants).
- Updated `functions.csv` descriptions for `InfiniteLine` and `HalfLine` to reflect that they now render in both `Graphics` and `Graphics3D`.

## Test plan
- Added unit tests in `tests/interpreter_tests/graphics.rs` (`unbounded_primitives_2d` module) covering: both primitives drawing in 2D, `HalfLine` only extending forward (not both directions like `InfiniteLine`), and degenerate zero-direction input drawing nothing.
- Added a regression test in `woxi-studio/src/main.rs` (`manipulate_locator_triangle_with_infinite_edge_lines`) reproducing the Manipulate shape that surfaced the bug (three `Locator`-draggable triangle vertices with `InfiniteLine`-drawn extended edges), independently written and not copied from the notebook.
- `make format` and `make test` (28,538 tests) pass; `make test-studio` (232 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3KESyHszg1CKdt8MWT2V3


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3KESyHszg1CKdt8MWT2V3)_