### PR TITLE
Fix a panic in NDSolve's PDE initial-condition matcher

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -657,14 +657,15 @@ fn try_pde_initial_condition(
     let Expr::FunctionCall { name, args } = e else {
       return false;
     };
+    if name != u_name || args.len() != 2 {
+      return false;
+    }
     let (t_arg, x_arg) = if swap {
       (&args[1], &args[0])
     } else {
       (&args[0], &args[1])
     };
-    name == u_name
-      && args.len() == 2
-      && matches!(x_arg, Expr::Identifier(n) if n == x_name)
+    matches!(x_arg, Expr::Identifier(n) if n == x_name)
       && nval_to_f64(t_arg)
         .is_some_and(|v| (v - t0).abs() <= 1e-9 * t0.abs().max(1.0))
   };

--- a/tests/cli/comparison/mathematica/conformance_gaps.md
+++ b/tests/cli/comparison/mathematica/conformance_gaps.md
@@ -1205,18 +1205,47 @@ a *particular* solution with `C[1] … C[8]` after `DSolve::lpdeprtclr`. With
 `a == 0` or `c == 0` WL also writes the characteristics unnormalised
 (`C[1][x - y] + C[2][x]`) rather than as `λ x + y`.
 
-### `NDSolve` covers ODEs only
+### `NDSolve`'s PDE branch is 1-D, first-order-in-time only
+
+This entry used to say "`NDSolve` covers ODEs only" — no longer accurate.
+1-D parabolic PDEs (single or coupled reaction-diffusion-convection systems,
+Dirichlet or Neumann boundaries) now solve via the method of lines:
 
 ```wolfram
 NDSolve[{D[u[x,t],t] == D[u[x,t],x,x], u[x,0] == Sin[Pi x],
          u[0,t] == 0, u[1,t] == 0}, u, {x,0,1}, {t,0,1}]
 ```
 
-returns unevaluated. `NeumannValue` is out of scope, `DirichletCondition`
-exists only as a symbol, and `Method -> {"MethodOfLines", …}` has nothing
-behind it. On the symbolic side `DSolve` recognises three first-order
-two-variable PDE shapes; Laplace, which WL solves as
-`C[1][I x + y] + C[2][-I x + y]`, is not among them.
+returns a real `InterpolatingFunction`. What's still missing:
+
+- The evolution equation must be first-order in time (`D[u,t] == …`); a
+  second-order-in-time (hyperbolic/wave) PDE such as
+  `D[u[t,x],t,t] == D[u[t,x],x,x]` is left unevaluated — unlike the ODE
+  branch, it is not order-reduced to a first-order system.
+- The right-hand side may not itself contain a time derivative of the
+  unknown (an implicit/mixed term like `D[u[t,x],x,x,t]`); only the unknown
+  and its pure space derivatives are recognised there.
+- `NeumannValue` and `DirichletCondition` exist only as symbols; boundary
+  conditions must be written as plain equalities.
+
+A concrete example needing both missing pieces: the Wolfram Demonstration
+[*A Passive Cochlear Model*](https://demonstrations.wolfram.com/APassiveCochlearModel/)
+models the cochlea with an equation of the shape
+
+```wolfram
+D[u[t, x], t, t] ==
+  Exp[-2 (x + x0)/c1] (D[u[t, x], x, x] - D[u[t, x], x]/c1) +
+  c2 Exp[-(x + x0)/c1] (D[u[t, x], x, x, t] - D[u[t, x], x, t]/c1) +
+  c3 (D[u[t, x], x, x, t, t] - D[u[t, x], x, t, t]/c1)
+```
+
+— second-order in time, with mixed space/time derivatives on the right —
+so `NDSolve` stays unevaluated in Woxi, and Woxi Studio cannot render this
+Demonstration's `Manipulate` correctly.
+
+On the symbolic side `DSolve` recognises three first-order two-variable PDE
+shapes; Laplace, which WL solves as `C[1][I x + y] + C[2][-I x + y]`, is not
+among them.
 
 `NDSolve`'s DAE support handles an index-1 constraint that solves explicitly
 for one unknown; quadratic, coupled or index ≥ 2 constraints, and constraints

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -8616,6 +8616,27 @@ mod ndsolve {
     );
   }
 
+  /// The domain declared as `{x, ...}, {t, ...}` (space before time) forces
+  /// the solver to retry the space/time roles swapped. Before matching the
+  /// swapped roles, it first tries the unswapped ones and calls the initial
+  /// condition matcher on `Sin[Pi x]` — a one-argument call — as a candidate
+  /// `u[t0, x]` shape. The matcher used to index that call's second argument
+  /// before checking its arity, panicking instead of rejecting the shape and
+  /// falling through to the swapped attempt that actually matches.
+  #[test]
+  fn pde_initial_condition_matcher_rejects_a_one_argument_call_without_panicking()
+   {
+    let result = interpret(
+      "NDSolve[{D[u[x, t], t] == D[u[x, t], {x, 2}], u[x, 0] == Sin[Pi x], \
+       u[0, t] == 0, u[1, t] == 0}, u, {x, 0, 1}, {t, 0, 1}]",
+    )
+    .unwrap();
+    assert!(
+      result.starts_with("{{u -> InterpolatingFunction["),
+      "Got: {result}"
+    );
+  }
+
   /// The PDE branch's `InterpolatingFunction` must be usable exactly like
   /// any other two-argument one — in particular as the function
   /// `ContourPlot` samples over its `{t, x}` grid, the shape a


### PR DESCRIPTION
## Summary

- While checking whether Woxi Studio can fully open a random Wolfram Demonstrations Project notebook ("A Passive Cochlear Model"), I found that `NDSolve`'s PDE method-of-lines branch panics on some inputs instead of failing gracefully.
- `try_pde_initial_condition` (in `src/functions/ode_ast.rs`) indexed a candidate call's second argument before checking that it actually had two arguments. When the solver tries the "unswapped" `u[t, x]` role against an equation like `u[x, 0] == Sin[Pi x]`, it ends up testing `Sin[Pi x]` — a one-argument call — and panics with an index-out-of-bounds instead of rejecting the shape and falling through to the swapped `u[x, t]` attempt that actually matches.
- Fixed by checking `name` and `args.len()` before indexing.
- The cochlear model's own `cochleaSolve[]` doesn't hit this specific panic (its domain order avoids it), but its underlying PDE (second-order in time, with mixed space/time derivatives on the right-hand side) is a separate, larger gap that `NDSolve`'s PDE branch doesn't support at all yet — it stays unevaluated rather than crashing, so this Demonstration's `Manipulate` still won't render correctly in Woxi Studio.
- Updated the stale `conformance_gaps.md` entry ("`NDSolve` covers ODEs only") which no longer reflected reality — 1-D parabolic PDEs via method of lines already work — and replaced it with an accurate description of what's still missing (second-order-in-time / RHS-mixed-derivative PDEs), using the cochlear model as a concrete real-world example.

## Test plan

- [x] Added a regression test (`pde_initial_condition_matcher_rejects_a_one_argument_call_without_panicking`) reproducing the exact panic on the pre-fix code and passing after the fix.
- [x] `cargo test --test interpreter_tests pde_` — 17/17 passed.
- [x] `cargo test --test interpreter_tests` (full suite) — 26217/26219 passed; the 2 failures (`reciprocal_trig_last_bit::*`) are pre-existing and unrelated (confirmed via `git stash` on a clean checkout of the base commit).
- [x] `cargo test --lib` — 312/312 passed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gL7RzkN8Y4oXM2mMrDc6b

---
_Generated by [Claude Code](https://claude.ai/code/session_011gL7RzkN8Y4oXM2mMrDc6b)_