### PR TITLE
Render AbsoluteDashing as literal-pixel dashes, not solid lines

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1508,7 +1508,7 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
             let dashes: Vec<f64> = items
               .iter()
               .filter_map(|e| {
-                dash_size_to_f64(e).or_else(|| expr_to_f64(e).map(|d| -d))
+                dash_size_to_f64(e).or_else(|| expr_to_f64(e).map(|d| -d.abs()))
               })
               .collect();
             if !dashes.is_empty() {
@@ -1517,7 +1517,7 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
           }
           _ => {
             if let Some(d) = dash_size_to_f64(&args[0])
-              .or_else(|| expr_to_f64(&args[0]).map(|d| -d))
+              .or_else(|| expr_to_f64(&args[0]).map(|d| -d.abs()))
             {
               style.dashing = Some(vec![d, d]);
             }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1495,6 +1495,36 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
         }
         true
       }
+      "AbsoluteDashing" if !args.is_empty() => {
+        // AbsoluteDashing[{d1, d2, ...}] is Dashing's absolute counterpart —
+        // every length is literal pixels (printer's points) rather than a
+        // fraction of the image width, the same relationship
+        // AbsoluteThickness has to Thickness. Stored negative so dash_attr
+        // treats it as literal px.
+        match &args[0] {
+          Expr::Identifier(s) if s == "None" => style.dashing = None,
+          Expr::List(items) if items.is_empty() => style.dashing = None,
+          Expr::List(items) => {
+            let dashes: Vec<f64> = items
+              .iter()
+              .filter_map(|e| {
+                dash_size_to_f64(e).or_else(|| expr_to_f64(e).map(|d| -d))
+              })
+              .collect();
+            if !dashes.is_empty() {
+              style.dashing = Some(dashes);
+            }
+          }
+          _ => {
+            if let Some(d) = dash_size_to_f64(&args[0])
+              .or_else(|| expr_to_f64(&args[0]).map(|d| -d))
+            {
+              style.dashing = Some(vec![d, d]);
+            }
+          }
+        }
+        true
+      }
       "EdgeForm" => {
         if args.is_empty() {
           style.edge_form = Some(EdgeForm {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1185,6 +1185,14 @@ mod graphics {
       // dasharray), matching how the plain `Dashing[{2}]` list branch works.
       assert_eq!(dasharray("AbsoluteDashing[{2}]"), Some("2.0".into()));
       assert_eq!(dasharray("AbsoluteDashing[{}]"), None);
+      // A negative user-supplied length must still land as literal pixels,
+      // not get flipped into dash_attr's "fraction of image width" branch
+      // (a naive `-d` on an already-negative `d` would produce +4.0, read
+      // as 4x the image width instead of ~4 pixels).
+      assert_eq!(
+        dasharray("AbsoluteDashing[{-4, 6}]"),
+        Some("4.0,6.0".into())
+      );
     }
 
     #[test]

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1163,6 +1163,30 @@ mod graphics {
       assert_eq!(width("AbsoluteThickness[1]"), "1.00");
     }
 
+    /// `AbsoluteDashing` is `Dashing`'s absolute counterpart — every length
+    /// is literal pixels, the same relationship `AbsoluteThickness` has to
+    /// `Thickness` — so it must reach the SVG as a `stroke-dasharray` too,
+    /// rather than silently drawing a solid line. `Dashing[{0.05, 0.05}]` on
+    /// the 360px-wide default image is `18,18`; `AbsoluteDashing[{4, 6}]` is
+    /// `4,6` at any image width.
+    #[test]
+    fn absolute_dashing_produces_dasharray() {
+      let dasharray = |directive: &str| {
+        let svg = export_svg(&format!(
+          "Graphics[{{{directive}, Line[{{{{0,0}},{{1,1}}}}]}}]"
+        ));
+        let i = svg.find("stroke-dasharray=\"")?;
+        let rest = &svg[i + "stroke-dasharray=\"".len()..];
+        Some(rest.split('"').next().unwrap().to_string())
+      };
+      assert_eq!(dasharray("Dashing[{0.05, 0.05}]"), Some("18.0,18.0".into()));
+      assert_eq!(dasharray("AbsoluteDashing[{4, 6}]"), Some("4.0,6.0".into()));
+      // A one-element list is left as-is (SVG auto-doubles an odd-length
+      // dasharray), matching how the plain `Dashing[{2}]` list branch works.
+      assert_eq!(dasharray("AbsoluteDashing[{2}]"), Some("2.0".into()));
+      assert_eq!(dasharray("AbsoluteDashing[{}]"), None);
+    }
+
     #[test]
     fn multiple_colors() {
       insta::assert_snapshot!(export_svg(


### PR DESCRIPTION
## Summary

As part of the scheduled "check a random Wolfram Demonstration against Woxi Studio" task, I downloaded a random Demonstration ("Mamikon's Proof of the Pythagorean Theorem") from the Wolfram Demonstrations Project and validated it against Woxi Studio's notebook parsing/rendering pipeline using the project's headless `dump_notebook`/`dump_manipulate` examples.

The notebook parsed and its `Manipulate` reconstructed successfully, but its interactive graphics use `AbsoluteDashing[{1, 3}]` for the dotted tangent-line construction. The SVG graphics renderer's directive parser (`src/functions/graphics.rs`) had no `"AbsoluteDashing"` case, so it silently fell through as unrecognized and the line rendered **solid** instead of dashed — unlike the already-supported `Dashing`/`AbsoluteThickness` directives.

- Added an `"AbsoluteDashing"` case to `apply_directive`, mirroring `Dashing` but treating every length as literal pixels (the same relationship `AbsoluteThickness` has to `Thickness`), reusing the existing negative-value convention `dash_attr` already understands.
- Added a regression test (`absolute_dashing_produces_dasharray`) verifying `AbsoluteDashing` now produces a `stroke-dasharray` in the exported SVG, alongside the equivalent `Dashing` case and edge cases (`{}`, single-element list).

No source code from the downloaded (copyrighted) Demonstration notebook was copied into the repo — only the general bug it exposed was reproduced with original, minimal test code.

## Test plan
- [x] `cargo test --test interpreter_tests absolute_dashing_produces_dasharray` passes
- [x] Full workspace test suite (`cargo test --workspace`) passes, aside from two pre-existing, unrelated failures (`reciprocal_trig_last_bit::*`) confirmed to also fail on `main` without this change
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gBx6NWSWnk829UMBm1YL7

---
_Generated by [Claude Code](https://claude.ai/code/session_015gBx6NWSWnk829UMBm1YL7)_